### PR TITLE
feat(settings): add support to enable/disable AI providers

### DIFF
--- a/Sources/App/Settings/AppSettings.swift
+++ b/Sources/App/Settings/AppSettings.swift
@@ -36,6 +36,16 @@ public final class AppSettings {
 
     // MARK: - Provider Settings
 
+    /// Set of enabled provider IDs
+    public var enabledProviderIds: Set<String> {
+        get {
+            Set(UserDefaults.standard.stringArray(forKey: Keys.enabledProviderIds) ?? [])
+        }
+        set {
+            UserDefaults.standard.set(Array(newValue), forKey: Keys.enabledProviderIds)
+        }
+    }
+
     /// Whether GitHub Copilot provider is enabled
     public var copilotEnabled: Bool {
         didSet {
@@ -76,6 +86,26 @@ public final class AppSettings {
         }
     }
 
+    // MARK: - Provider Management
+
+    /// All available provider IDs in the app
+    public static let allProviderIds: Set<String> = ["claude", "codex", "gemini", "antigravity", "zai", "copilot"]
+
+    /// Check if a provider is enabled
+    public func isProviderEnabled(id: String) -> Bool {
+        enabledProviderIds.contains(id)
+    }
+
+    /// Set whether a provider is enabled
+    public func setProviderEnabled(id: String, enabled: Bool) {
+        if enabled {
+            enabledProviderIds.insert(id)
+        } else {
+            enabledProviderIds.remove(id)
+        }
+        AppLog.providers.info("Provider '\(id)' \(enabled ? "enabled" : "disabled")")
+    }
+
     // MARK: - Token Management
 
     /// Whether a GitHub Copilot token is configured
@@ -113,6 +143,8 @@ public final class AppSettings {
         self.claudeApiBudgetEnabled = UserDefaults.standard.bool(forKey: Keys.claudeApiBudgetEnabled)
         self.claudeApiBudget = Decimal(UserDefaults.standard.double(forKey: Keys.claudeApiBudget))
         self.receiveBetaUpdates = UserDefaults.standard.bool(forKey: Keys.receiveBetaUpdates)
+
+        // Load enabled provider IDs (computed property handles this automatically)
 
         // Auto-enable Christmas theme during Dec 24-26 if user hasn't explicitly chosen
         applySeasonalTheme()
@@ -154,6 +186,7 @@ private extension AppSettings {
     enum Keys {
         static let themeMode = "themeMode"
         static let userHasChosenTheme = "userHasChosenTheme"
+        static let enabledProviderIds = "enabledProviderIds"
         static let copilotEnabled = "copilotEnabled"
         static let claudeApiBudgetEnabled = "claudeApiBudgetEnabled"
         static let claudeApiBudget = "claudeApiBudget"


### PR DESCRIPTION
Address https://github.com/tddworks/ClaudeBar/issues/11:

- Add `enabledProviderIds` persistence to `AppSettings`
- Implement "AI Providers" management card in Settings UI
- Filter visible provider pills in the menu based on enabled status
- Add fallback logic to switch providers if the active one is disabled
- Ensure initial app state respects stored enabled provider settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider toggles in Settings—enable or disable specific providers based on your preferences
  * Provider selections now persist across app sessions
  * App intelligently selects the first enabled provider on startup if your previous choice is disabled

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->