### PR TITLE
fix(ui): prevent layout constraint crash in background views

### DIFF
--- a/Sources/App/Views/MenuContentView.swift
+++ b/Sources/App/Views/MenuContentView.swift
@@ -165,6 +165,7 @@ struct MenuContentView: View {
                     .blur(radius: 30)
             }
         }
+        .frame(width: 380, height: 600)
     }
 
     // MARK: - Header

--- a/Sources/App/Views/Theme.swift
+++ b/Sources/App/Views/Theme.swift
@@ -1229,5 +1229,6 @@ struct ChristmasBackgroundOrbs: View {
                     .blur(radius: 18)
             }
         }
+        .frame(width: 380, height: 600)
     }
 }


### PR DESCRIPTION
Add explicit frame to GeometryReader-based background views (backgroundOrbs and ChristmasBackgroundOrbs) to prevent NSHostingView from triggering constraint updates during layout passes, which causes a SIGABRT crash.

Resolves crash in NSHostingView.invalidateSafeAreaInsets() during window layout on macOS 26+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized layout frame dimensions for menu content and background visual elements to ensure consistent display and proper alignment across the interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->