### PR TITLE
fix(updater): bring update window to front when checking for updates

### DIFF
--- a/Sources/App/SparkleUpdater.swift
+++ b/Sources/App/SparkleUpdater.swift
@@ -147,6 +147,8 @@ final class SparkleUpdater {
         guard let controller = controller, controller.updater.canCheckForUpdates else {
             return
         }
+        // Bring app to front so update window appears above other windows
+        NSApp.activate(ignoringOtherApps: true)
         controller.checkForUpdates(nil)
     }
 


### PR DESCRIPTION
Add NSApp.activate(ignoringOtherApps: true) before triggering Sparkle update check so the update window appears above all other windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update notification visibility by ensuring the update window appears on top of other windows when checking for updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->