### PR TITLE
Add ~/.claude/local to binary search paths

### DIFF
--- a/Sources/Infrastructure/Adapters/BinaryLocator.swift
+++ b/Sources/Infrastructure/Adapters/BinaryLocator.swift
@@ -53,6 +53,7 @@ public struct BinaryLocator: Sendable {
     static func searchPaths() -> String {
         let home = NSHomeDirectory()
         let commonLocations = [
+            "\(home)/.claude/local",
             "/usr/local/bin",
             "/opt/homebrew/bin",
             "\(home)/.local/bin",


### PR DESCRIPTION
## Summary
- Add `~/.claude/local` to `BinaryLocator.searchPaths()` so the Claude CLI installed via the official installer is found

## Problem
The Claude CLI installed via the official installer is located at `~/.claude/local/claude`, causing "CLI 'claude' not found" errors because this path wasn't being searched.

## Test plan
- [x] Verified Claude CLI is found after this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded the search paths for CLI tools to now include the ~/.claude/local directory, enabling automatic discovery of tools installed in this location.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->