### PR TITLE
fix(probe): handle new Claude CLI trust prompt format

### DIFF
--- a/Sources/Infrastructure/CLI/ClaudeUsageProbe.swift
+++ b/Sources/Infrastructure/CLI/ClaudeUsageProbe.swift
@@ -56,6 +56,7 @@ public final class ClaudeUsageProbe: UsageProbe, @unchecked Sendable {
                     "Ready to code here?": "\r",
                     "Press Enter to continue": "\r",
                     "ctrl+t to disable": "\r",  // Onboarding complete
+                    "Yes, I trust this folder": "\r",  // New trust prompt format
                 ]
             )
         } catch {
@@ -112,6 +113,7 @@ public final class ClaudeUsageProbe: UsageProbe, @unchecked Sendable {
                     "Ready to code here?": "\r",
                     "Press Enter to continue": "\r",
                     "ctrl+t to disable": "\r",
+                    "Yes, I trust this folder": "\r",  // New trust prompt format
                 ]
             )
         } catch {
@@ -633,7 +635,9 @@ public final class ClaudeUsageProbe: UsageProbe, @unchecked Sendable {
     internal func extractUsageError(_ text: String) -> ProbeError? {
         let lower = text.lowercased()
 
-        if lower.contains("do you trust the files in this folder?"), !lower.contains("current session") {
+        if (lower.contains("do you trust the files in this folder?") ||
+            lower.contains("is this a project you created or one you trust")),
+           !lower.contains("current session") {
             AppLog.probes.error("Claude probe blocked: folder trust required")
             return .folderTrustRequired
         }

--- a/Tests/InfrastructureTests/CLI/ClaudeUsageProbeParsingTests.swift
+++ b/Tests/InfrastructureTests/CLI/ClaudeUsageProbeParsingTests.swift
@@ -165,6 +165,20 @@ struct ClaudeUsageProbeParsingTests {
     No, cancel (n)
     """
 
+    // New trust prompt format introduced in later Claude CLI versions
+    static let newTrustPromptOutput = """
+    Accessing workspace:
+
+    /Users/testuser/Library/Application Support/ClaudeBar/Probe
+
+    Quick safety check: Is this a project you created or one you trust? (Like your own code, a well-known open source project, or work from your team). If not, take a moment to review what's in this folder first.
+
+    Claude Code'll be able to read, edit, and execute files here.
+
+    ❯ 1. Yes, I trust this folder
+      2. No, exit
+    """
+
     static let authErrorOutput = """
     authentication_error: Your session has expired.
     Please run `claude login` to authenticate.
@@ -174,6 +188,17 @@ struct ClaudeUsageProbeParsingTests {
     func `detects folder trust prompt and throws error`() throws {
         // Given
         let output = Self.trustPromptOutput
+
+        // When & Then
+        #expect(throws: ProbeError.self) {
+            try simulateParse(text: output)
+        }
+    }
+
+    @Test
+    func `detects new folder trust prompt format and throws error`() throws {
+        // Given - New trust prompt format with "Is this a project you created or one you trust"
+        let output = Self.newTrustPromptOutput
 
         // When & Then
         #expect(throws: ProbeError.self) {


### PR DESCRIPTION
## Summary

- Fix Claude probe hanging on new interactive trust prompt
- Add auto-response for the new Yes I trust this folder selection menu
- Update error detection to recognize both old and new prompt formats

## Problem

The Claude CLI introduced a new trust prompt format that was blocking the probe.

## Solution

1. Added new auto-response pattern to automatically select the first option
2. Updated extractUsageError to detect both old and new trust prompt formats
3. Added test coverage for the new prompt format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced folder trust prompt detection to recognize additional prompt format variations.

* **Tests**
  * Added tests to validate handling of updated trust prompt formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->