### PR TITLE
fix(gemini): fall back to any GCP project for accurate quota data

### DIFF
--- a/Sources/Infrastructure/CLI/GeminiProject.swift
+++ b/Sources/Infrastructure/CLI/GeminiProject.swift
@@ -17,11 +17,16 @@ internal struct GeminiProjects: Decodable, Sendable {
     let projects: [GeminiProject]
     
     var bestProjectForQuota: GeminiProject? {
-        // Prefer CLI-created projects
+        // Prefer CLI-created projects (gen-lang-client-*)
         if let cliProject = projects.first(where: { $0.isCLIProject }) {
             return cliProject
         }
         // Fallback to any project with the generative-language label
-        return projects.first(where: { $0.hasGenerativeLanguageLabel })
+        if let labeledProject = projects.first(where: { $0.hasGenerativeLanguageLabel }) {
+            return labeledProject
+        }
+        // Final fallback: use any available project
+        // This handles users who don't have a CLI-created project but have other GCP projects
+        return projects.first
     }
 }

--- a/Tests/InfrastructureTests/CLI/GeminiProjectTests.swift
+++ b/Tests/InfrastructureTests/CLI/GeminiProjectTests.swift
@@ -140,7 +140,7 @@ struct GeminiProjectsTests {
     }
 
     @Test
-    func `bestProjectForQuota returns nil when no suitable project`() {
+    func `bestProjectForQuota falls back to any project when no CLI or labeled project`() {
         // Given
         let regularProject = GeminiProject(projectId: "regular-project", labels: nil)
         let projects = GeminiProjects(projects: [regularProject])
@@ -148,8 +148,8 @@ struct GeminiProjectsTests {
         // When
         let best = projects.bestProjectForQuota
 
-        // Then
-        #expect(best == nil)
+        // Then - should return the regular project as a fallback
+        #expect(best?.projectId == "regular-project")
     }
 
     @Test


### PR DESCRIPTION
## Problem

The Gemini quota API (`retrieveUserQuota`) requires a project ID to return accurate data. Without it:
- All models show **100% remaining** instead of actual usage
- **Gemini 3 models are not returned** by the API

The current `bestProjectForQuota` logic only matches:
- Projects with `gen-lang-client-*` prefix (CLI-created)
- Projects with `generative-language` label

Users with other GCP projects get `nil`, causing an empty request body and broken quota display.

## Solution

Add a final fallback to use any available GCP project. The priority order is now:
1. CLI-created projects (`gen-lang-client-*`)
2. Projects with `generative-language` label
3. **Any available project** ← new fallback

## Result

With a valid project ID in the request:
- ✅ Accurate quota percentages for all models
- ✅ Gemini 3 models (gemini-3-flash-preview, gemini-3-pro-preview) now appear

## Testing

Verified with a GCP account that only has regular projects. Both issues are resolved.