### PR TITLE
feat: add usage pace display mode

### DIFF
--- a/Sources/App/Views/QuotaCardView.swift
+++ b/Sources/App/Views/QuotaCardView.swift
@@ -12,6 +12,14 @@ struct QuotaCardView: View {
         settings.usageDisplayMode
     }
 
+    /// Effective display mode: falls back to .used when pace is unknown
+    private var effectiveDisplayMode: UsageDisplayMode {
+        if displayMode == .pace && quota.pace == .unknown {
+            return .used
+        }
+        return displayMode
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             // Label
@@ -20,14 +28,14 @@ struct QuotaCardView: View {
                 .foregroundStyle(.secondary)
 
             // Percentage
-            Text("\(Int(quota.displayPercent(mode: displayMode)))%")
+            Text("\(Int(quota.displayPercent(mode: effectiveDisplayMode)))%")
                 .font(.title2)
                 .fontWeight(.semibold)
-                .foregroundStyle(quota.status.displayColor)
+                .foregroundStyle(effectiveDisplayMode == .pace ? quota.pace.displayColor : quota.status.displayColor)
 
             // Progress bar
             GeometryReader { geometry in
-                let progressPercent = quota.displayProgressPercent(mode: displayMode)
+                let progressPercent = quota.displayProgressPercent(mode: effectiveDisplayMode)
                 ZStack(alignment: .leading) {
                     // Track
                     RoundedRectangle(cornerRadius: 2)

--- a/Sources/App/Views/SettingsView.swift
+++ b/Sources/App/Views/SettingsView.swift
@@ -2286,7 +2286,11 @@ struct DisplayModeButton: View {
     @State private var isHovering = false
 
     private var iconName: String {
-        mode == .remaining ? "arrow.down.right" : "arrow.up.right"
+        switch mode {
+        case .remaining: "arrow.down.right"
+        case .used: "arrow.up.right"
+        case .pace: "gauge.with.needle.fill"
+        }
     }
 
     var body: some View {

--- a/Sources/App/Views/Theme.swift
+++ b/Sources/App/Views/Theme.swift
@@ -770,6 +770,30 @@ extension QuotaStatus {
     }
 }
 
+// MARK: - UsagePace Theme Extension
+
+extension UsagePace {
+    /// Display color for pace indicators
+    var displayColor: Color {
+        switch self {
+        case .onPace: .green
+        case .ahead: .orange
+        case .behind: AppTheme.tealBright
+        case .unknown: .secondary
+        }
+    }
+
+    /// Adaptive display color for pace indicators
+    func themeColor(for scheme: ColorScheme) -> Color {
+        switch self {
+        case .onPace: AppTheme.statusHealthy(for: scheme)
+        case .ahead: AppTheme.statusWarning(for: scheme)
+        case .behind: AppTheme.tealBright(for: scheme)
+        case .unknown: AppTheme.textSecondary(for: scheme)
+        }
+    }
+}
+
 // MARK: - BudgetStatus Theme Extension
 
 extension BudgetStatus {

--- a/Sources/Domain/Provider/UsageDisplayMode.swift
+++ b/Sources/Domain/Provider/UsageDisplayMode.swift
@@ -1,18 +1,21 @@
 import Foundation
 
-/// Controls whether quota percentages are displayed as "remaining" or "used".
+/// Controls whether quota percentages are displayed as "remaining", "used", or "pace".
 ///
 /// - `.remaining`: Shows how much quota is left (e.g., "25% Remaining")
 /// - `.used`: Shows how much quota has been consumed (e.g., "75% Used")
+/// - `.pace`: Shows how far ahead/behind expected usage pace (e.g., "20% Ahead")
 public enum UsageDisplayMode: String, Sendable, Equatable, CaseIterable {
     case remaining
     case used
+    case pace
 
     /// The label shown alongside the percentage in quota cards.
     public var displayLabel: String {
         switch self {
         case .remaining: "Remaining"
         case .used: "Used"
+        case .pace: "Remaining"
         }
     }
 }

--- a/Sources/Domain/Provider/UsagePace.swift
+++ b/Sources/Domain/Provider/UsagePace.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Represents the pace of quota consumption relative to expected usage over time.
+///
+/// - `.onPace`: Usage is roughly matching expected pace (within 5% threshold)
+/// - `.ahead`: Consuming faster than expected (warning: may run out early)
+/// - `.behind`: Consuming slower than expected (room to spare)
+/// - `.unknown`: Cannot determine pace (no reset time available)
+public enum UsagePace: Sendable, Equatable {
+    case onPace
+    case ahead
+    case behind
+    case unknown
+
+    /// The threshold (in percentage points) within which usage is considered "on pace".
+    private static let onPaceThreshold: Double = 5.0
+
+    // MARK: - Factory Methods
+
+    /// Creates a pace from the difference between actual usage and expected usage.
+    /// - Parameters:
+    ///   - percentUsed: How much quota has been consumed (0-100+)
+    ///   - percentTimeElapsed: How much of the reset period has elapsed (0-100)
+    /// - Returns: The pace classification
+    public static func from(percentUsed: Double, percentTimeElapsed: Double) -> UsagePace {
+        let difference = percentUsed - percentTimeElapsed
+        if abs(difference) <= onPaceThreshold {
+            return .onPace
+        } else if difference > 0 {
+            return .ahead
+        } else {
+            return .behind
+        }
+    }
+
+    // MARK: - Display
+
+    /// Human-readable name for this pace
+    public var displayName: String {
+        switch self {
+        case .onPace: "On track"
+        case .ahead: "Running hot"
+        case .behind: "Room to spare"
+        case .unknown: "Unknown"
+        }
+    }
+
+    /// SF Symbol name representing this pace
+    public var symbolName: String {
+        switch self {
+        case .onPace: "equal.circle.fill"
+        case .ahead: "hare.fill"
+        case .behind: "tortoise.fill"
+        case .unknown: "questionmark.circle.fill"
+        }
+    }
+}

--- a/Tests/DomainTests/Provider/UsagePaceTests.swift
+++ b/Tests/DomainTests/Provider/UsagePaceTests.swift
@@ -1,0 +1,332 @@
+import Testing
+import Foundation
+@testable import Domain
+
+@Suite
+struct UsagePaceTests {
+
+    // MARK: - Factory Method
+
+    @Test
+    func `on pace when usage matches time elapsed within threshold`() {
+        // Given: 50% time elapsed, 52% used (within 5% threshold)
+        let pace = UsagePace.from(percentUsed: 52, percentTimeElapsed: 50)
+
+        // Then
+        #expect(pace == .onPace)
+    }
+
+    @Test
+    func `on pace when usage exactly matches time elapsed`() {
+        let pace = UsagePace.from(percentUsed: 50, percentTimeElapsed: 50)
+        #expect(pace == .onPace)
+    }
+
+    @Test
+    func `on pace at threshold boundary`() {
+        // Exactly 5% difference should still be on pace
+        let pace = UsagePace.from(percentUsed: 55, percentTimeElapsed: 50)
+        #expect(pace == .onPace)
+    }
+
+    @Test
+    func `ahead when consuming faster than expected`() {
+        // Given: 30% time elapsed, 50% used
+        let pace = UsagePace.from(percentUsed: 50, percentTimeElapsed: 30)
+
+        // Then
+        #expect(pace == .ahead)
+    }
+
+    @Test
+    func `behind when consuming slower than expected`() {
+        // Given: 50% time elapsed, 30% used
+        let pace = UsagePace.from(percentUsed: 30, percentTimeElapsed: 50)
+
+        // Then
+        #expect(pace == .behind)
+    }
+
+    @Test
+    func `ahead just beyond threshold`() {
+        // 5.1% difference (just beyond 5% threshold)
+        let pace = UsagePace.from(percentUsed: 55.1, percentTimeElapsed: 50)
+        #expect(pace == .ahead)
+    }
+
+    @Test
+    func `behind just beyond threshold`() {
+        // -5.1% difference (just beyond 5% threshold)
+        let pace = UsagePace.from(percentUsed: 44.9, percentTimeElapsed: 50)
+        #expect(pace == .behind)
+    }
+
+    @Test
+    func `ahead when fully used early in period`() {
+        // Given: 10% time elapsed, 100% used
+        let pace = UsagePace.from(percentUsed: 100, percentTimeElapsed: 10)
+        #expect(pace == .ahead)
+    }
+
+    @Test
+    func `behind when nothing used late in period`() {
+        // Given: 90% time elapsed, 0% used
+        let pace = UsagePace.from(percentUsed: 0, percentTimeElapsed: 90)
+        #expect(pace == .behind)
+    }
+
+    // MARK: - Display Properties
+
+    @Test
+    func `display names are correct`() {
+        #expect(UsagePace.onPace.displayName == "On track")
+        #expect(UsagePace.ahead.displayName == "Running hot")
+        #expect(UsagePace.behind.displayName == "Room to spare")
+        #expect(UsagePace.unknown.displayName == "Unknown")
+    }
+
+    @Test
+    func `symbol names are valid SF Symbols`() {
+        #expect(UsagePace.onPace.symbolName == "equal.circle.fill")
+        #expect(UsagePace.ahead.symbolName == "hare.fill")
+        #expect(UsagePace.behind.symbolName == "tortoise.fill")
+        #expect(UsagePace.unknown.symbolName == "questionmark.circle.fill")
+    }
+
+    // MARK: - UsageQuota Pace Integration
+
+    @Test
+    func `quota percentTimeElapsed is nil without resetsAt`() {
+        let quota = UsageQuota(
+            percentRemaining: 50,
+            quotaType: .session,
+            providerId: "claude"
+        )
+        #expect(quota.percentTimeElapsed == nil)
+    }
+
+    @Test
+    func `quota percentTimeElapsed calculates correctly for session halfway through`() {
+        // Session = 5 hours. If resets in 2.5 hours, we're 50% through.
+        let resetsAt = Date().addingTimeInterval(2.5 * 3600) // 2.5 hours from now
+        let quota = UsageQuota(
+            percentRemaining: 50,
+            quotaType: .session,
+            providerId: "claude",
+            resetsAt: resetsAt
+        )
+
+        let elapsed = quota.percentTimeElapsed!
+        #expect(elapsed > 49 && elapsed < 51) // ~50%, allow for test execution time
+    }
+
+    @Test
+    func `quota percentTimeElapsed is clamped to 0 when just reset`() {
+        // Reset time is the full duration away (just started)
+        let resetsAt = Date().addingTimeInterval(5 * 3600) // 5 hours from now (full session)
+        let quota = UsageQuota(
+            percentRemaining: 100,
+            quotaType: .session,
+            providerId: "claude",
+            resetsAt: resetsAt
+        )
+
+        let elapsed = quota.percentTimeElapsed!
+        #expect(elapsed >= 0 && elapsed < 1) // ~0%
+    }
+
+    @Test
+    func `quota percentTimeElapsed is clamped to 100 when past reset time`() {
+        // Reset time is in the past (timeUntilReset will be 0)
+        let resetsAt = Date().addingTimeInterval(-60) // 1 minute ago
+        let quota = UsageQuota(
+            percentRemaining: 0,
+            quotaType: .session,
+            providerId: "claude",
+            resetsAt: resetsAt
+        )
+
+        #expect(quota.percentTimeElapsed == 100)
+    }
+
+    @Test
+    func `quota pacePercent is nil without resetsAt`() {
+        let quota = UsageQuota(
+            percentRemaining: 50,
+            quotaType: .session,
+            providerId: "claude"
+        )
+        #expect(quota.pacePercent == nil)
+    }
+
+    @Test
+    func `quota pacePercent is positive when ahead`() {
+        // 50% used, ~25% time elapsed → pacePercent ≈ +25
+        let resetsAt = Date().addingTimeInterval(3.75 * 3600) // 75% remaining of 5h session
+        let quota = UsageQuota(
+            percentRemaining: 50,
+            quotaType: .session,
+            providerId: "claude",
+            resetsAt: resetsAt
+        )
+
+        let pace = quota.pacePercent!
+        #expect(pace > 20 && pace < 30) // ~25%, allow for test execution time
+    }
+
+    @Test
+    func `quota pacePercent is negative when behind`() {
+        // 25% used, ~50% time elapsed → pacePercent ≈ -25
+        let resetsAt = Date().addingTimeInterval(2.5 * 3600) // 50% remaining of 5h session
+        let quota = UsageQuota(
+            percentRemaining: 75,
+            quotaType: .session,
+            providerId: "claude",
+            resetsAt: resetsAt
+        )
+
+        let pace = quota.pacePercent!
+        #expect(pace < -20 && pace > -30) // ~-25%
+    }
+
+    @Test
+    func `quota pace is unknown without resetsAt`() {
+        let quota = UsageQuota(
+            percentRemaining: 50,
+            quotaType: .session,
+            providerId: "claude"
+        )
+        #expect(quota.pace == .unknown)
+    }
+
+    @Test
+    func `quota pace is ahead when consuming fast`() {
+        // 70% used, ~25% time elapsed
+        let resetsAt = Date().addingTimeInterval(3.75 * 3600)
+        let quota = UsageQuota(
+            percentRemaining: 30,
+            quotaType: .session,
+            providerId: "claude",
+            resetsAt: resetsAt
+        )
+        #expect(quota.pace == .ahead)
+    }
+
+    @Test
+    func `quota pace is behind when consuming slow`() {
+        // 10% used, ~75% time elapsed
+        let resetsAt = Date().addingTimeInterval(1.25 * 3600)
+        let quota = UsageQuota(
+            percentRemaining: 90,
+            quotaType: .session,
+            providerId: "claude",
+            resetsAt: resetsAt
+        )
+        #expect(quota.pace == .behind)
+    }
+
+    // MARK: - Display Percent in Pace Mode
+
+    @Test
+    func `displayPercent in pace mode returns percentRemaining`() {
+        let resetsAt = Date().addingTimeInterval(3.75 * 3600)
+        let quota = UsageQuota(
+            percentRemaining: 30,
+            quotaType: .session,
+            providerId: "claude",
+            resetsAt: resetsAt
+        )
+
+        #expect(quota.displayPercent(mode: .pace) == 30)
+    }
+
+    @Test
+    func `displayPercent in pace mode returns percentRemaining when no resetsAt`() {
+        let quota = UsageQuota(
+            percentRemaining: 50,
+            quotaType: .session,
+            providerId: "claude"
+        )
+        #expect(quota.displayPercent(mode: .pace) == 50)
+    }
+
+    @Test
+    func `displayProgressPercent in pace mode returns percentRemaining`() {
+        let quota = UsageQuota(
+            percentRemaining: 30,
+            quotaType: .session,
+            providerId: "claude"
+        )
+        #expect(quota.displayProgressPercent(mode: .pace) == 30)
+    }
+
+    // MARK: - Weekly Quota Pace
+
+    @Test
+    func `weekly quota percentTimeElapsed calculates correctly`() {
+        // Weekly = 7 days. If resets in 3.5 days, we're 50% through.
+        let resetsAt = Date().addingTimeInterval(3.5 * 24 * 3600)
+        let quota = UsageQuota(
+            percentRemaining: 50,
+            quotaType: .weekly,
+            providerId: "claude",
+            resetsAt: resetsAt
+        )
+
+        let elapsed = quota.percentTimeElapsed!
+        #expect(elapsed > 49 && elapsed < 51)
+    }
+
+    // MARK: - Pace Insight
+
+    @Test
+    func `paceInsight returns nil without resetsAt`() {
+        let quota = UsageQuota(
+            percentRemaining: 50,
+            quotaType: .session,
+            providerId: "claude"
+        )
+        #expect(quota.paceInsight == nil)
+    }
+
+    @Test
+    func `paceInsight returns below expected when behind`() {
+        // 10% used, ~75% time elapsed → behind, pacePercent ≈ -65
+        let resetsAt = Date().addingTimeInterval(1.25 * 3600)
+        let quota = UsageQuota(
+            percentRemaining: 90,
+            quotaType: .session,
+            providerId: "claude",
+            resetsAt: resetsAt
+        )
+        let insight = quota.paceInsight!
+        #expect(insight.hasSuffix("below expected usage"))
+    }
+
+    @Test
+    func `paceInsight returns above expected when ahead`() {
+        // 70% used, ~25% time elapsed → ahead, pacePercent ≈ +45
+        let resetsAt = Date().addingTimeInterval(3.75 * 3600)
+        let quota = UsageQuota(
+            percentRemaining: 30,
+            quotaType: .session,
+            providerId: "claude",
+            resetsAt: resetsAt
+        )
+        let insight = quota.paceInsight!
+        #expect(insight.hasSuffix("above expected usage"))
+    }
+
+    @Test
+    func `paceInsight returns right on track when on pace`() {
+        // 50% used, ~50% time elapsed → on pace
+        let resetsAt = Date().addingTimeInterval(2.5 * 3600)
+        let quota = UsageQuota(
+            percentRemaining: 50,
+            quotaType: .session,
+            providerId: "claude",
+            resetsAt: resetsAt
+        )
+        #expect(quota.paceInsight == "Right on track")
+    }
+}

--- a/Tests/DomainTests/Provider/UsageQuotaTests.swift
+++ b/Tests/DomainTests/Provider/UsageQuotaTests.swift
@@ -202,4 +202,24 @@ struct UsageQuotaTests {
         // When & Then
         #expect(quota.displayProgressPercent(mode: .used) == 25)
     }
+
+    // MARK: - Display Percent (Pace Mode)
+
+    @Test
+    func `displayPercent returns percentRemaining in pace mode`() {
+        // Given - pace mode shows familiar remaining number
+        let quota = UsageQuota(percentRemaining: 75, quotaType: .session, providerId: "claude")
+
+        // When & Then
+        #expect(quota.displayPercent(mode: .pace) == 75)
+    }
+
+    @Test
+    func `displayProgressPercent returns percentRemaining in pace mode`() {
+        // Given
+        let quota = UsageQuota(percentRemaining: 75, quotaType: .session, providerId: "claude")
+
+        // When & Then - pace mode progress bar shows remaining (same as remaining mode)
+        #expect(quota.displayProgressPercent(mode: .pace) == 75)
+    }
 }

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -9,7 +9,11 @@ let packageSettings = PackageSettings(
     // Customize the product types for specific package product
     // Default is .staticFramework
     // productTypes: ["Alamofire": .framework,]
-    productTypes: [:]
+    productTypes: [:],
+    targetSettings: [
+        "IssueReporting": ["SWIFT_PACKAGE_NAME": "xctest-dynamic-overlay"],
+        "IssueReportingPackageSupport": ["SWIFT_PACKAGE_NAME": "xctest-dynamic-overlay"],
+    ]
 )
 #endif
 


### PR DESCRIPTION
## Summary

This adds a **"Pace" display mode** — a third option alongside "Remaining" and "Used" — that shows how quota consumption compares to expected usage over the reset period. This helps users understand whether they're on track, consuming too fast, or have room to spare.

> **Note:** I understand this may not align with your vision for ClaudeBar — feel free to close this if it doesn't fit. Just thought it might be a useful addition!

## Screenshot

<img width="403" height="414" alt="image" src="https://github.com/user-attachments/assets/9ca82a8d-6772-48e4-a9e7-ad259d403405" />

## What's included

- **`UsagePace` domain model** — rich enum with `onPace`, `ahead`, `behind`, `unknown` states, following existing domain patterns (factory method, `displayName`, `symbolName`)
- **Pace calculations on `UsageQuota`** — `percentTimeElapsed`, `pacePercent`, `paceInsight` computed properties using `QuotaType.duration` and reset time
- **"Pace" option in display mode picker** — with themed colors (green/orange/teal) and contextual insight labels (e.g., "59% below expected usage")
- **Graceful fallback** — when pace can't be determined (no reset time), automatically falls back to "Used" mode
- **Shell escape sequence stripping** — fixes `which` output parsing when terminal emulators (iTerm2) inject ANSI/OSC sequences
- **Tuist `Package.swift` fix** — `SWIFT_PACKAGE_NAME` target settings to resolve `xctest-dynamic-overlay` build issue
- **Comprehensive tests** — `UsagePaceTests` (17 tests) + additional `UsageQuotaTests` for pace mode

## Test plan

- [ ] `tuist test` passes for Domain scheme
- [ ] Pace mode displays correctly for session and weekly quotas
- [ ] Falls back to "Used" when no reset time available
- [ ] Shell probe output handled correctly with escape sequences

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pace monitoring to track usage progress relative to time elapsed—see whether you're on pace, ahead, or behind schedule with new visual indicators.
  * Introduced new pace display mode option in settings, complementing existing remaining and used views.
  * Pace-specific colors and insights display your usage status relative to the quota timeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->