### PR TITLE
feat: add pace tick mark below consumption bar

### DIFF
--- a/Sources/App/Views/MenuContentView.swift
+++ b/Sources/App/Views/MenuContentView.swift
@@ -773,22 +773,41 @@ struct WrappedStatCard: View {
                 .lineLimit(1)
             }
 
-            // Progress bar with gradient
-            GeometryReader { geo in
-                let progressPercent = quota.displayProgressPercent(mode: effectiveDisplayMode)
-                ZStack(alignment: .leading) {
-                    // Track
-                    RoundedRectangle(cornerRadius: 3)
-                        .fill(theme.progressTrack)
+            // Progress bar with gradient and pace tick
+            VStack(spacing: 1) {
+                GeometryReader { geo in
+                    let progressPercent = quota.displayProgressPercent(mode: effectiveDisplayMode)
+                    ZStack(alignment: .leading) {
+                        // Track
+                        RoundedRectangle(cornerRadius: 3)
+                            .fill(theme.progressTrack)
 
-                    // Fill (clamp width to 0-100%)
-                    RoundedRectangle(cornerRadius: 3)
-                        .fill(theme.progressGradient(for: quota.percentRemaining))
-                        .frame(width: animateProgress ? geo.size.width * max(0, min(100, progressPercent)) / 100 : 0)
-                        .animation(.spring(response: 0.8, dampingFraction: 0.7).delay(delay + 0.2), value: animateProgress)
+                        // Fill (clamp width to 0-100%)
+                        RoundedRectangle(cornerRadius: 3)
+                            .fill(theme.progressGradient(for: quota.percentRemaining))
+                            .frame(width: animateProgress ? geo.size.width * max(0, min(100, progressPercent)) / 100 : 0)
+                            .animation(.spring(response: 0.8, dampingFraction: 0.7).delay(delay + 0.2), value: animateProgress)
+                    }
+                }
+                .frame(height: 5)
+
+                // Expected pace tick mark
+                if let expectedPercent = quota.expectedProgressPercent(mode: effectiveDisplayMode) {
+                    GeometryReader { geo in
+                        let tickX = geo.size.width * max(0, min(100, expectedPercent)) / 100
+                        Path { path in
+                            path.move(to: CGPoint(x: tickX - 3, y: 4))
+                            path.addLine(to: CGPoint(x: tickX + 3, y: 4))
+                            path.addLine(to: CGPoint(x: tickX, y: 0))
+                            path.closeSubpath()
+                        }
+                        .fill(theme.textTertiary)
+                        .opacity(animateProgress ? 1 : 0)
+                        .animation(.easeIn(duration: 0.3).delay(delay + 0.5), value: animateProgress)
+                    }
+                    .frame(height: 5)
                 }
             }
-            .frame(height: 5)
 
             // Reset info
             if let resetText = quota.resetText ?? quota.resetDescription {

--- a/Sources/App/Views/QuotaCardView.swift
+++ b/Sources/App/Views/QuotaCardView.swift
@@ -33,22 +33,39 @@ struct QuotaCardView: View {
                 .fontWeight(.semibold)
                 .foregroundStyle(effectiveDisplayMode == .pace ? quota.pace.displayColor : quota.status.displayColor)
 
-            // Progress bar
-            GeometryReader { geometry in
-                let progressPercent = quota.displayProgressPercent(mode: effectiveDisplayMode)
-                ZStack(alignment: .leading) {
-                    // Track
-                    RoundedRectangle(cornerRadius: 2)
-                        .fill(Color.primary.opacity(0.1))
-                        .frame(height: 4)
+            // Progress bar with pace tick
+            VStack(spacing: 1) {
+                GeometryReader { geometry in
+                    let progressPercent = quota.displayProgressPercent(mode: effectiveDisplayMode)
+                    ZStack(alignment: .leading) {
+                        // Track
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(Color.primary.opacity(0.1))
+                            .frame(height: 4)
 
-                    // Fill (clamp width to 0-100%)
-                    RoundedRectangle(cornerRadius: 2)
-                        .fill(quota.status.displayColor)
-                        .frame(width: geometry.size.width * max(0, min(100, progressPercent)) / 100, height: 4)
+                        // Fill (clamp width to 0-100%)
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(quota.status.displayColor)
+                            .frame(width: geometry.size.width * max(0, min(100, progressPercent)) / 100, height: 4)
+                    }
+                }
+                .frame(height: 4)
+
+                // Expected pace tick mark
+                if let expectedPercent = quota.expectedProgressPercent(mode: effectiveDisplayMode) {
+                    GeometryReader { geometry in
+                        let tickX = geometry.size.width * max(0, min(100, expectedPercent)) / 100
+                        Path { path in
+                            path.move(to: CGPoint(x: tickX - 3, y: 4))
+                            path.addLine(to: CGPoint(x: tickX + 3, y: 4))
+                            path.addLine(to: CGPoint(x: tickX, y: 0))
+                            path.closeSubpath()
+                        }
+                        .fill(Color.secondary.opacity(0.6))
+                    }
+                    .frame(height: 5)
                 }
             }
-            .frame(height: 4)
         }
         .padding(12)
         .background(Color.primary.opacity(0.05))

--- a/Sources/Domain/Provider/UsageQuota.swift
+++ b/Sources/Domain/Provider/UsageQuota.swift
@@ -81,6 +81,17 @@ public struct UsageQuota: Sendable, Equatable, Hashable, Comparable {
         }
     }
 
+    /// Returns the expected progress bar position based on time elapsed and display mode.
+    /// This represents where the bar "should be" if usage were perfectly on pace.
+    /// Returns nil when reset time is unknown.
+    public func expectedProgressPercent(mode: UsageDisplayMode) -> Double? {
+        guard let percentTimeElapsed else { return nil }
+        switch mode {
+        case .remaining, .pace: return 100 - percentTimeElapsed
+        case .used: return percentTimeElapsed
+        }
+    }
+
     // MARK: - Pace
 
     /// The percentage of the reset period that has elapsed (0-100), or nil if no reset time is known.


### PR DESCRIPTION
## Summary
- Add a small triangle marker (▲) below the progress bar showing where usage "should be" based on time elapsed in the quota period
- Helps users see at a glance whether they're ahead or behind pace
- Works in all display modes (remaining, used, pace) and only appears when reset time is known

## Test plan
- [x] Build succeeds
- [x] All Domain tests pass
- [ ] Visual verification: tick appears below consumption bars at the expected pace position
- [ ] Tick correctly positions for remaining mode (100 - percentTimeElapsed)
- [ ] Tick correctly positions for used mode (percentTimeElapsed)
- [ ] Tick hidden when no reset time is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual pace tick indicator to progress bars, showing the expected progress position based on elapsed time and the selected display mode. This helps users see how current usage aligns with the expected pace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->