### PR TITLE
fix: add standard nvm path to BinaryLocator commonPaths

### DIFF
--- a/Sources/Infrastructure/Shared/BinaryLocator.swift
+++ b/Sources/Infrastructure/Shared/BinaryLocator.swift
@@ -40,7 +40,9 @@ public struct BinaryLocator: Sendable {
             "/usr/local/lib/node_modules/.bin",
             // pnpm
             "\(home)/Library/pnpm",
-            // Herd/nvm (for node-based CLIs like codex)
+            // nvm (for node-based CLIs like codex)
+            "\(home)/.nvm/versions",
+            // Herd/nvm
             "\(home)/Library/Application Support/Herd/config/nvm/versions",
         ]
     }


### PR DESCRIPTION
## Summary

- Add `~/.nvm/versions` to `BinaryLocator.commonPaths` for fallback binary detection
- The standard nvm path was missing, causing Codex CLI detection to fail in menu bar app context (launchd) where shell PATH from `.zshrc` is not available
- Herd's nvm path was already included, but standard nvm (`~/.nvm`) — the most common nvm installation — was not

## Context

When ClaudeBar runs as a menu bar app, `whichViaShell()` can fail because launchd doesn't load `.zshrc` (where nvm is initialized). The `findInCommonPaths()` fallback then searches `commonPaths`, but `~/.nvm/versions` was missing from that list.

The existing `searchNvmVersions()` method already handles the `nvm/versions` directory structure correctly — this change just adds the missing path entry so it gets called for standard nvm installations.

## Test plan

- [x] Verified `searchNvmVersions()` already handles `~/.nvm/versions/node/vX.Y.Z/bin/` structure
- [ ] Existing `BinaryLocatorTests` should continue to pass
- [ ] ClaudeBar should detect Codex CLI installed via nvm without requiring a symlink

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced executable discovery to search additional installation paths, improving compatibility with various development environments and tool management configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->