### PR TITLE
fix(docs): correct release build command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ tuist test DomainTests
 tuist test --result-bundle-path TestResults.xcresult -- -enableCodeCoverage YES
 
 # Build release configuration
-tuist build -- -configuration Release
+tuist build ClaudeBar -C Release
 ```
 
 **Key files:**

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ brew install tuist
 
 # Install dependencies and build
 tuist install
-tuist build -- -configuration Release
+tuist build ClaudeBar -C Release
 ```
 
 ## Usage
@@ -144,7 +144,7 @@ tuist test
 tuist test --result-bundle-path TestResults.xcresult -- -enableCodeCoverage YES
 
 # Build release configuration
-tuist build -- -configuration Release
+tuist build ClaudeBar -C Release
 ```
 
 ### SwiftUI Previews


### PR DESCRIPTION
## Summary

- Fix incorrect release build command in CLAUDE.md and README.md
- Replace `tuist build -- -configuration Release` with `tuist build ClaudeBar -C Release`

Fixes #111

## Test plan

- [x] `tuist build ClaudeBar -C Release` builds successfully
- [x] Verified old command fails with `@testable import` error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build instructions across documentation files to standardize the build process for consistency and clarity. The documentation now uses a more explicit approach to specify the target project and release configuration in build commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->