### PR TITLE
fix(minimax): add region selector for international and China API endpoints

### DIFF
--- a/Sources/Domain/Provider/MiniMax/MiniMaxProvider.swift
+++ b/Sources/Domain/Provider/MiniMax/MiniMaxProvider.swift
@@ -13,7 +13,7 @@ public final class MiniMaxProvider: AIProvider, @unchecked Sendable {
     public let cliCommand: String = "" // API-only provider, no CLI (纯 API 提供者，无 CLI)
 
     public var dashboardURL: URL? {
-        URL(string: "https://platform.minimaxi.com/user-center/payment/coding-plan")
+        settingsRepository.minimaxRegion().dashboardURL
     }
 
     public var statusPageURL: URL? {

--- a/Sources/Domain/Provider/MiniMax/MiniMaxRegion.swift
+++ b/Sources/Domain/Provider/MiniMax/MiniMaxRegion.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Represents the MiniMax API region. (MiniMax API 区域设置)
+/// - international: api.minimax.io / platform.minimax.io (For International Users)
+/// - china: api.minimaxi.com / platform.minimaxi.com (For Users in China)
+public enum MiniMaxRegion: String, Sendable, Equatable, CaseIterable {
+    case international
+    case china
+
+    /// Display name for the region picker (区域显示名称)
+    public var displayName: String {
+        switch self {
+        case .international: return "International (minimax.io)"
+        case .china: return "China (minimaxi.com)"
+        }
+    }
+
+    /// API base URL for coding plan remains endpoint (Coding Plan API 基础 URL)
+    public var apiBaseURL: String {
+        switch self {
+        case .international: return "https://api.minimax.io"
+        case .china: return "https://api.minimaxi.com"
+        }
+    }
+
+    /// Platform URL for dashboard (平台仪表盘 URL)
+    public var platformURL: String {
+        switch self {
+        case .international: return "https://platform.minimax.io"
+        case .china: return "https://platform.minimaxi.com"
+        }
+    }
+
+    /// URL to get API keys from the platform (获取 API Key 的页面 URL)
+    public var apiKeysURL: URL {
+        switch self {
+        case .international:
+            return URL(string: "https://platform.minimax.io/user-center/basic-information/interface-key")!
+        case .china:
+            return URL(string: "https://platform.minimaxi.com/user-center/basic-information/interface-key")!
+        }
+    }
+
+    /// Dashboard URL for coding plan payment page (Coding Plan 付费页面 URL)
+    public var dashboardURL: URL {
+        switch self {
+        case .international:
+            return URL(string: "https://platform.minimax.io/user-center/payment/coding-plan")!
+        case .china:
+            return URL(string: "https://platform.minimaxi.com/user-center/payment/coding-plan")!
+        }
+    }
+
+    /// Full API URL for the coding plan remains endpoint (Coding Plan 剩余额度 API URL)
+    public var codingPlanRemainsURL: String {
+        "\(apiBaseURL)/v1/api/openplatform/coding_plan/remains"
+    }
+}

--- a/Sources/Domain/Provider/ProviderSettingsRepository.swift
+++ b/Sources/Domain/Provider/ProviderSettingsRepository.swift
@@ -191,27 +191,34 @@ public protocol KimiSettingsRepository: ProviderSettingsRepository {
 }
 
 /// MiniMax-specific settings repository, extending base ProviderSettingsRepository.
-/// Stores API key configuration for MiniMax Coding Plan quota monitoring.
+/// Stores API key and region configuration for MiniMax Coding Plan quota monitoring.
 /// Tests can use UserDefaultsProviderSettingsRepository with test UserDefaults.
 /// App uses UserDefaultsProviderSettingsRepository.
 public protocol MiniMaxSettingsRepository: ProviderSettingsRepository {
+    /// Gets the API region (international or china, default: china for legacy compatibility)
+    /// (获取 API 区域设置，默认中国区以兼容旧版用户)
+    func minimaxRegion() -> MiniMaxRegion
+
+    /// Sets the API region (设置 API 区域)
+    func setMinimaxRegion(_ region: MiniMaxRegion)
+
     /// Gets the environment variable name for MiniMax API key (empty = use default MINIMAX_API_KEY)
-    func minimaxiAuthEnvVar() -> String
+    func minimaxAuthEnvVar() -> String
 
     /// Sets the environment variable name for MiniMax API key
-    func setMinimaxiAuthEnvVar(_ envVar: String)
+    func setMinimaxAuthEnvVar(_ envVar: String)
 
     /// Saves the MiniMax API key (for Settings UI input)
-    func saveMinimaxiApiKey(_ key: String)
+    func saveMinimaxApiKey(_ key: String)
 
     /// Retrieves the MiniMax API key
-    func getMinimaxiApiKey() -> String?
+    func getMinimaxApiKey() -> String?
 
     /// Deletes the MiniMax API key
-    func deleteMinimaxiApiKey()
+    func deleteMinimaxApiKey()
 
     /// Checks if a MiniMax API key is saved
-    func hasMinimaxiApiKey() -> Bool
+    func hasMinimaxApiKey() -> Bool
 }
 
 // MARK: - Default Implementation

--- a/Sources/Infrastructure/Storage/UserDefaultsProviderSettingsRepository.swift
+++ b/Sources/Infrastructure/Storage/UserDefaultsProviderSettingsRepository.swift
@@ -251,27 +251,40 @@ public final class UserDefaultsProviderSettingsRepository: ZaiSettingsRepository
 
     // MARK: - MiniMaxSettingsRepository
 
-    public func minimaxiAuthEnvVar() -> String {
+    public func minimaxRegion() -> MiniMaxRegion {
+        // Legacy compatibility: key absent means user upgraded from pre-region version,
+        // which only supported china (minimaxi.com). (兼容旧版：无 key 则默认中国区)
+        guard let rawValue = userDefaults.string(forKey: Keys.minimaxRegion) else {
+            return .china
+        }
+        return MiniMaxRegion(rawValue: rawValue) ?? .china
+    }
+
+    public func setMinimaxRegion(_ region: MiniMaxRegion) {
+        userDefaults.set(region.rawValue, forKey: Keys.minimaxRegion)
+    }
+
+    public func minimaxAuthEnvVar() -> String {
         userDefaults.string(forKey: Keys.minimaxiAuthEnvVar) ?? ""
     }
 
-    public func setMinimaxiAuthEnvVar(_ envVar: String) {
+    public func setMinimaxAuthEnvVar(_ envVar: String) {
         userDefaults.set(envVar, forKey: Keys.minimaxiAuthEnvVar)
     }
 
-    public func saveMinimaxiApiKey(_ key: String) {
+    public func saveMinimaxApiKey(_ key: String) {
         userDefaults.set(key, forKey: Keys.minimaxiApiKey)
     }
 
-    public func getMinimaxiApiKey() -> String? {
+    public func getMinimaxApiKey() -> String? {
         userDefaults.string(forKey: Keys.minimaxiApiKey)
     }
 
-    public func deleteMinimaxiApiKey() {
+    public func deleteMinimaxApiKey() {
         userDefaults.removeObject(forKey: Keys.minimaxiApiKey)
     }
 
-    public func hasMinimaxiApiKey() -> Bool {
+    public func hasMinimaxApiKey() -> Bool {
         userDefaults.object(forKey: Keys.minimaxiApiKey) != nil
     }
 
@@ -325,6 +338,7 @@ public final class UserDefaultsProviderSettingsRepository: ZaiSettingsRepository
         static let bedrockRegions = "providerConfig.bedrockRegions"
         static let bedrockDailyBudget = "providerConfig.bedrockDailyBudget"
         // MiniMax settings (key strings kept for backward compatibility 保持向后兼容)
+        static let minimaxRegion = "providerConfig.minimaxRegion"
         static let minimaxiAuthEnvVar = "providerConfig.minimaxiAuthEnvVar"
         static let minimaxiApiKey = "com.claudebar.credentials.minimaxi-api-key"
         // Credentials (kept compatible with old UserDefaultsCredentialRepository keys)

--- a/Tests/DomainTests/Provider/MiniMax/MiniMaxRegionTests.swift
+++ b/Tests/DomainTests/Provider/MiniMax/MiniMaxRegionTests.swift
@@ -1,0 +1,105 @@
+import Testing
+@testable import Domain
+
+@Suite
+struct MiniMaxRegionTests {
+
+    // MARK: - displayName
+
+    @Test
+    func `international displayName`() {
+        #expect(MiniMaxRegion.international.displayName == "International (minimax.io)")
+    }
+
+    @Test
+    func `china displayName`() {
+        #expect(MiniMaxRegion.china.displayName == "China (minimaxi.com)")
+    }
+
+    // MARK: - apiBaseURL
+
+    @Test
+    func `international apiBaseURL`() {
+        #expect(MiniMaxRegion.international.apiBaseURL == "https://api.minimax.io")
+    }
+
+    @Test
+    func `china apiBaseURL`() {
+        #expect(MiniMaxRegion.china.apiBaseURL == "https://api.minimaxi.com")
+    }
+
+    // MARK: - platformURL
+
+    @Test
+    func `international platformURL`() {
+        #expect(MiniMaxRegion.international.platformURL == "https://platform.minimax.io")
+    }
+
+    @Test
+    func `china platformURL`() {
+        #expect(MiniMaxRegion.china.platformURL == "https://platform.minimaxi.com")
+    }
+
+    // MARK: - apiKeysURL
+
+    @Test
+    func `international apiKeysURL`() {
+        #expect(MiniMaxRegion.international.apiKeysURL.absoluteString ==
+            "https://platform.minimax.io/user-center/basic-information/interface-key")
+    }
+
+    @Test
+    func `china apiKeysURL`() {
+        #expect(MiniMaxRegion.china.apiKeysURL.absoluteString ==
+            "https://platform.minimaxi.com/user-center/basic-information/interface-key")
+    }
+
+    // MARK: - dashboardURL
+
+    @Test
+    func `international dashboardURL`() {
+        #expect(MiniMaxRegion.international.dashboardURL.absoluteString ==
+            "https://platform.minimax.io/user-center/payment/coding-plan")
+    }
+
+    @Test
+    func `china dashboardURL`() {
+        #expect(MiniMaxRegion.china.dashboardURL.absoluteString ==
+            "https://platform.minimaxi.com/user-center/payment/coding-plan")
+    }
+
+    // MARK: - codingPlanRemainsURL
+
+    @Test
+    func `international codingPlanRemainsURL`() {
+        #expect(MiniMaxRegion.international.codingPlanRemainsURL ==
+            "https://api.minimax.io/v1/api/openplatform/coding_plan/remains")
+    }
+
+    @Test
+    func `china codingPlanRemainsURL`() {
+        #expect(MiniMaxRegion.china.codingPlanRemainsURL ==
+            "https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains")
+    }
+
+    // MARK: - rawValue & allCases
+
+    @Test
+    func `rawValue round-trip`() {
+        for region in MiniMaxRegion.allCases {
+            #expect(MiniMaxRegion(rawValue: region.rawValue) == region)
+        }
+    }
+
+    @Test
+    func `allCases contains both regions`() {
+        #expect(MiniMaxRegion.allCases.count == 2)
+        #expect(MiniMaxRegion.allCases.contains(.international))
+        #expect(MiniMaxRegion.allCases.contains(.china))
+    }
+
+    @Test
+    func `invalid rawValue returns nil`() {
+        #expect(MiniMaxRegion(rawValue: "invalid") == nil)
+    }
+}

--- a/Tests/InfrastructureTests/MiniMax/MiniMaxUsageProbeTests.swift
+++ b/Tests/InfrastructureTests/MiniMax/MiniMaxUsageProbeTests.swift
@@ -27,16 +27,21 @@ struct MiniMaxUsageProbeTests {
     // MARK: - Helper
 
     /// Creates a probe with test UserDefaults and mock network client
+    /// Pass nil for region to test the "not configured" fallback path (传 nil 测试未配置 region 的回退路径)
     private func makeProbe(
         apiKey: String? = nil,
         envVar: String = "",
+        region: MiniMaxRegion? = .china,
         networkClient: any NetworkClient = MockNetworkClient()
     ) -> MiniMaxUsageProbe {
         let defaults = UserDefaults(suiteName: "MiniMaxProbeTests.\(UUID().uuidString)")!
         let settingsRepository = UserDefaultsProviderSettingsRepository(userDefaults: defaults)
-        settingsRepository.setMinimaxiAuthEnvVar(envVar)
+        if let region {
+            settingsRepository.setMinimaxRegion(region)
+        }
+        settingsRepository.setMinimaxAuthEnvVar(envVar)
         if let apiKey {
-            settingsRepository.saveMinimaxiApiKey(apiKey)
+            settingsRepository.saveMinimaxApiKey(apiKey)
         }
         return MiniMaxUsageProbe(
             networkClient: networkClient,
@@ -72,7 +77,7 @@ struct MiniMaxUsageProbeTests {
         let mockNetwork = MockNetworkClient()
         let responseData = Data(Self.sampleApiResponse.utf8)
         let httpResponse = HTTPURLResponse(
-            url: URL(string: "https://www.minimaxi.com/v1/api/openplatform/coding_plan/remains")!,
+            url: URL(string: "https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains")!,
             statusCode: 200,
             httpVersion: nil,
             headerFields: nil
@@ -108,7 +113,7 @@ struct MiniMaxUsageProbeTests {
         // Given
         let mockNetwork = MockNetworkClient()
         let httpResponse = HTTPURLResponse(
-            url: URL(string: "https://www.minimaxi.com/v1/api/openplatform/coding_plan/remains")!,
+            url: URL(string: "https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains")!,
             statusCode: 401,
             httpVersion: nil,
             headerFields: nil
@@ -130,7 +135,7 @@ struct MiniMaxUsageProbeTests {
         // Given
         let mockNetwork = MockNetworkClient()
         let httpResponse = HTTPURLResponse(
-            url: URL(string: "https://www.minimaxi.com/v1/api/openplatform/coding_plan/remains")!,
+            url: URL(string: "https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains")!,
             statusCode: 500,
             httpVersion: nil,
             headerFields: nil
@@ -145,5 +150,66 @@ struct MiniMaxUsageProbeTests {
         await #expect(throws: ProbeError.self) {
             try await probe.probe()
         }
+    }
+
+    // MARK: - Region Tests
+
+    @Test
+    func `apiURL defaults to china when region not configured`() {
+        // Given: no region set, simulating legacy user upgrade (模拟旧版用户升级，未配置 region)
+        let probe = makeProbe(apiKey: "test-key", region: nil)
+
+        // Then: falls back to china for backward compatibility (兼容旧版默认中国区)
+        #expect(probe.apiURL == "https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains")
+    }
+
+    @Test
+    func `apiURL uses china region when explicitly configured`() {
+        // Given
+        let probe = makeProbe(apiKey: "test-key", region: .china)
+
+        // Then
+        #expect(probe.apiURL == "https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains")
+    }
+
+    @Test
+    func `apiURL uses international region when configured`() {
+        // Given
+        let probe = makeProbe(apiKey: "test-key", region: .international)
+
+        // Then
+        #expect(probe.apiURL == "https://api.minimax.io/v1/api/openplatform/coding_plan/remains")
+    }
+
+    @Test
+    func `probe uses international API URL when region is international`() async throws {
+        // Given
+        let mockNetwork = MockNetworkClient()
+        let responseData = Data(Self.sampleApiResponse.utf8)
+        let httpResponse = HTTPURLResponse(
+            url: URL(string: "https://api.minimax.io/v1/api/openplatform/coding_plan/remains")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        // Capture the request to verify URL (捕获请求以验证 URL)
+        var capturedRequest: URLRequest?
+        given(mockNetwork)
+            .request(.any)
+            .willProduce { request in
+                capturedRequest = request
+                return (responseData, httpResponse)
+            }
+
+        let probe = makeProbe(apiKey: "test-key", region: .international, networkClient: mockNetwork)
+
+        // When
+        let snapshot = try await probe.probe()
+
+        // Then: verify response parsing
+        #expect(snapshot.quotas.count == 1)
+        #expect(snapshot.providerId == "minimax")
+        // Verify the request was sent to international endpoint (验证请求发送到国际版端点)
+        #expect(capturedRequest?.url?.absoluteString == "https://api.minimax.io/v1/api/openplatform/coding_plan/remains")
     }
 }


### PR DESCRIPTION
## Summary
- Add `MiniMaxRegion` enum supporting international (`minimax.io`) and China (`minimaxi.com`) API endpoints
- Add region selector (segmented picker) in MiniMax settings UI so users can choose their region
- Update `MiniMaxUsageProbe` and `MiniMaxProvider` to dynamically resolve URLs based on configured region
- Rename `minimaxiXxx` methods to `minimaxXxx` for consistent naming convention

## Context
MiniMax provider previously hardcoded `minimaxi.com` URLs, which only works for China region users. International users at `minimax.io` could not configure the provider properly. See [MiniMax docs](https://platform.minimax.io/docs/coding-plan/claude-code#configure-minimax-api) for the two region endpoints.

Closes #125

## Test plan
- [x] Build passes (`tuist build`)
- [x] All tests pass (`tuist test`), including new region-specific tests
- [ ] Verify international region resolves to `api.minimax.io`
- [ ] Verify China region resolves to `api.minimaxi.com`
- [ ] Verify region picker persists selection across app restarts
- [ ] Verify "Open MiniMax API Keys" link opens correct region URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MiniMax region selection in Settings (International / China) and region-aware links (API, dashboard, API keys).
  * Region-aware usage checking and persistence for selected region.

* **Bug Fixes / UX**
  * Save & Test now persists auth env var before testing.
  * Minor UI text updates for consistent MiniMax terminology.

* **Tests**
  * Added region-focused tests for MiniMax region values and usage probe behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->