### PR TITLE
feat: support `claude setup-token` for quota monitoring

### DIFF
--- a/Sources/Infrastructure/Shared/DefaultCLIExecutor.swift
+++ b/Sources/Infrastructure/Shared/DefaultCLIExecutor.swift
@@ -3,7 +3,14 @@ import Foundation
 /// Default CLIExecutor that uses BinaryLocator and InteractiveRunner.
 /// This is an adapter that wraps system APIs for CLI execution.
 public struct DefaultCLIExecutor: CLIExecutor {
-    public init() {}
+    /// Environment variable keys to exclude from the subprocess environment.
+    /// When set, these keys are removed before the subprocess launches,
+    /// preventing tokens like `CLAUDE_CODE_OAUTH_TOKEN` from being inherited.
+    private let environmentExclusions: [String]
+
+    public init(environmentExclusions: [String] = []) {
+        self.environmentExclusions = environmentExclusions
+    }
 
     public func locate(_ binary: String) -> String? {
         BinaryLocator.which(binary)
@@ -22,7 +29,8 @@ public struct DefaultCLIExecutor: CLIExecutor {
             timeout: timeout,
             workingDirectory: workingDirectory,
             arguments: args,
-            autoResponses: autoResponses
+            autoResponses: autoResponses,
+            environmentExclusions: environmentExclusions
         )
 
         let result = try runner.run(binary: binary, input: input ?? "", options: options)

--- a/Tests/InfrastructureTests/Claude/ClaudeUsageProbeTests.swift
+++ b/Tests/InfrastructureTests/Claude/ClaudeUsageProbeTests.swift
@@ -202,4 +202,22 @@ struct ClaudeUsageProbeTests {
         #expect(snapshot.costUsage?.budget == Decimal(string: "20.00"))
         #expect(snapshot.quotas.count >= 1)
     }
+
+    // MARK: - Setup Token Environment Exclusion Tests
+
+    @Test
+    func `envExclusions includes CLAUDE_CODE_OAUTH_TOKEN`() {
+        // The CLI probe must strip the setup-token env var so that
+        // `claude /usage` falls back to stored credentials with full scope.
+        #expect(ClaudeUsageProbe.envExclusions.contains("CLAUDE_CODE_OAUTH_TOKEN"))
+    }
+
+    @Test
+    func `default init creates executor that excludes setup token env var`() {
+        // When ClaudeUsageProbe is created without an explicit CLIExecutor,
+        // the default executor should be configured to exclude CLAUDE_CODE_OAUTH_TOKEN.
+        // We verify this indirectly by checking the static envExclusions constant.
+        let exclusions = ClaudeUsageProbe.envExclusions
+        #expect(exclusions == ["CLAUDE_CODE_OAUTH_TOKEN"])
+    }
 }


### PR DESCRIPTION
## Summary

Adds support for users who authenticate via `claude setup-token`, which produces a long-lived, inference-only OAuth token exported as `CLAUDE_CODE_OAUTH_TOKEN`. This is a common setup for CI/automated environments and developers who prefer token-based auth.

## Problem

The `claude setup-token` command produces a token with only the `user:inference` scope. However, both ClaudeBar's API probe (`/api/oauth/usage`) and CLI probe (`claude /usage`) require the `user:profile` scope to fetch quota data. When `CLAUDE_CODE_OAUTH_TOKEN` is set in the environment:

- **API probe**: Loads the inference-only token, attempts to call the usage endpoint, gets a `permission_error` (missing `user:profile` scope), then enters a retry/refresh loop that never succeeds because setup-tokens have no refresh token.
- **CLI probe**: The `claude /usage` subprocess inherits `CLAUDE_CODE_OAUTH_TOKEN` from the parent process, causing the Claude CLI to use the inference-only token instead of stored credentials from `claude login`.

**Net effect**: ClaudeBar fails to display quota data for any user with `CLAUDE_CODE_OAUTH_TOKEN` exported, even if they also have full-scope credentials from `claude login`.

## Solution

Three complementary fixes that work together:

### 1. Credential priority reordering (ClaudeCredentialLoader)
- Added `.environment` credential source to load tokens from `CLAUDE_CODE_OAUTH_TOKEN`
- **Reordered priority**: file → keychain → env (was: env → file → keychain)
- Full-scope stored credentials from `claude login` are now preferred over the inference-only setup-token
- Environment source has no-op `saveCredentials` (env tokens are read-only)

### 2. Graceful handling of missing refresh token (ClaudeAPIUsageProbe)
- When `needsRefresh()` returns true but `refreshToken` is nil, skip refresh and proceed with the existing token
- On 401/403 retry, if no refresh token is available, re-throw immediately instead of attempting a doomed refresh
- Prevents infinite retry loops when using setup-tokens

### 3. CLI subprocess env var stripping (ClaudeUsageProbe + InteractiveRunner)
- `ClaudeUsageProbe` now creates its `DefaultCLIExecutor` with `environmentExclusions: ["CLAUDE_CODE_OAUTH_TOKEN"]`
- `InteractiveRunner.Options` gained an `environmentExclusions: [String]` field (defaults to `[]`, backward-compatible)
- `InteractiveRunner.terminalEnvironment(excluding:)` removes specified keys before building the subprocess environment
- This ensures `claude /usage` falls back to stored credentials with the full `user:profile` scope

## Files Changed

| File | Change |
|------|--------|
| `ClaudeCredentialLoader.swift` | `.environment` source, env loading, priority reorder |
| `ClaudeAPIUsageProbe.swift` | Skip refresh when no refresh token, graceful 401/403 |
| `ClaudeUsageProbe.swift` | Pass env exclusions to default CLI executor |
| `DefaultCLIExecutor.swift` | Accept and forward `environmentExclusions` |
| `InteractiveRunner.swift` | `environmentExclusions` in Options, strip in `terminalEnvironment()` |

## Tests

16 new tests added across 4 test files, all passing with zero regressions:

- **ClaudeCredentialLoaderTests** (7): Environment source loading, priority ordering, no-op save
- **ClaudeAPIUsageProbeTests** (3): Skip refresh without token, 401 handling, setup-token suite
- **ClaudeUsageProbeTests** (2): Env exclusion constant verification
- **InteractiveRunnerTests** (4): Options storage, integration tests proving env vars are actually stripped/preserved in subprocesses

## User Impact

Users who have `CLAUDE_CODE_OAUTH_TOKEN` set (from `claude setup-token`) and also have stored credentials (from `claude login`) will now see their quota data in ClaudeBar. The setup-token continues to handle inference in the terminal, while stored credentials handle quota monitoring — no workflow changes required.

## Note

Users still need to run `claude login` once to create full-scope credentials. The setup-token alone cannot fetch quota data due to Anthropic's scope restrictions (`user:inference` only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for setup tokens, allowing credentials without automatic refresh capability
  * Enabled authentication via environment variables as an alternative to file-based credentials

* **Improvements**
  * Enhanced token refresh logic with improved handling of different credential types and scenarios
  * Strengthened security by refining environment variable isolation in subprocess execution contexts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->