### PR TITLE
Improve Claude setup-token OAuth usage and API fallback

### DIFF
--- a/Sources/Infrastructure/Claude/ClaudeAPIUsageProbe.swift
+++ b/Sources/Infrastructure/Claude/ClaudeAPIUsageProbe.swift
@@ -199,7 +199,7 @@ public struct ClaudeAPIUsageProbe: UsageProbe, @unchecked Sendable {
     private func fetchUsage(accessToken: String) async throws -> UsageResponse {
         var request = URLRequest(url: Self.usageURL)
         request.httpMethod = "GET"
-        request.setValue("Bearer \(accessToken.trimmingCharacters(in: .whitespaces))", forHTTPHeaderField: "Authorization")
+        request.setValue("Bearer \(accessToken.trimmingCharacters(in: .whitespacesAndNewlines))", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")

--- a/Sources/Infrastructure/Claude/ClaudeCredentialLoader.swift
+++ b/Sources/Infrastructure/Claude/ClaudeCredentialLoader.swift
@@ -147,8 +147,12 @@ public struct ClaudeCredentialLoader: Sendable {
     // MARK: - Private: Environment Operations
 
     private func loadFromEnvironment() -> ClaudeCredentialResult? {
-        guard let token = environment["CLAUDE_CODE_OAUTH_TOKEN"],
-              !token.isEmpty else {
+        guard let rawToken = environment["CLAUDE_CODE_OAUTH_TOKEN"] else {
+            return nil
+        }
+
+        let token = rawToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !token.isEmpty else {
             return nil
         }
 
@@ -173,10 +177,12 @@ public struct ClaudeCredentialLoader: Sendable {
             let data = try Data(contentsOf: URL(fileURLWithPath: path))
             guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
                   let oauthDict = json["claudeAiOauth"] as? [String: Any],
-                  let accessToken = oauthDict["accessToken"] as? String,
-                  !accessToken.isEmpty else {
+                  let rawAccessToken = oauthDict["accessToken"] as? String else {
                 return nil
             }
+
+            let accessToken = rawAccessToken.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !accessToken.isEmpty else { return nil }
 
             let oauth = ClaudeOAuthCredentials(
                 accessToken: accessToken,
@@ -227,10 +233,12 @@ public struct ClaudeCredentialLoader: Sendable {
             guard let jsonData = jsonString.data(using: .utf8),
                   let json = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
                   let oauthDict = json["claudeAiOauth"] as? [String: Any],
-                  let accessToken = oauthDict["accessToken"] as? String,
-                  !accessToken.isEmpty else {
+                  let rawAccessToken = oauthDict["accessToken"] as? String else {
                 return nil
             }
+
+            let accessToken = rawAccessToken.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !accessToken.isEmpty else { return nil }
 
             let oauth = ClaudeOAuthCredentials(
                 accessToken: accessToken,

--- a/Tests/InfrastructureTests/Claude/ClaudeCredentialLoaderTests.swift
+++ b/Tests/InfrastructureTests/Claude/ClaudeCredentialLoaderTests.swift
@@ -260,6 +260,21 @@ struct ClaudeCredentialLoaderTests {
     }
 
     @Test
+    func `loadCredentials trims whitespace and newlines from env token`() throws {
+        let tempDir = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let loader = ClaudeCredentialLoader(
+            homeDirectory: tempDir.path,
+            useKeychain: false,
+            environment: ["CLAUDE_CODE_OAUTH_TOKEN": "  my-setup-token\n"]
+        )
+        let result = loader.loadCredentials()
+
+        #expect(result?.oauth.accessToken == "my-setup-token")
+    }
+
+    @Test
     func `loadCredentials prefers file credentials over env var`() throws {
         let tempDir = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: tempDir) }


### PR DESCRIPTION
## Summary
- add robust support for `CLAUDE_CODE_OAUTH_TOKEN` setup tokens (including whitespace/newline normalization) so long-lived local OAuth tokens are accepted reliably
- improve Claude refresh behavior by falling back between CLI and API probes, allowing sub-limit quotas to load from OAuth API when `/usage` parsing fails
- add acceptance and infrastructure regression tests for setup-token auth headers, credential loading, and probe-mode fallback behavior

## Verification
- tuist test Infrastructure -- -only-testing:InfrastructureTests/ClaudeCredentialLoaderTests
- tuist test AcceptanceTests -- -only-testing:AcceptanceTests/ClaudeConfigSpec
- tuist test Domain -- -only-testing:DomainTests/AIProviderProtocolTests
- tuist build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed credential handling by trimming whitespace from tokens to prevent authentication failures
  * Improved whitespace normalization in authentication headers for better token processing

* **New Features**
  * Added fallback support between authentication modes for improved resilience when the primary method becomes unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->