### PR TITLE
fix(claude): clear credential cache on auth failure to prevent session lock-out

### DIFF
--- a/Sources/Infrastructure/Claude/ClaudeAPIUsageProbe.swift
+++ b/Sources/Infrastructure/Claude/ClaudeAPIUsageProbe.swift
@@ -1,15 +1,28 @@
 import Foundation
 import Domain
 
-/// Thread-safe in-memory cache for Claude OAuth credentials.
-/// Avoids repeated Keychain/CLI lookups on every probe cycle.
+/// Thread-safe in-memory cache for Claude OAuth credentials with TTL.
+/// Avoids repeated Keychain/CLI lookups on every probe cycle while ensuring
+/// external credential changes (e.g. CLI re-login) are picked up.
 private final class CredentialCache: @unchecked Sendable {
     private var cached: ClaudeCredentialResult?
+    private var cachedAt: Date?
     private let lock = NSLock()
+
+    /// Cache TTL: 5 minutes. Forces reload from file to detect external changes.
+    /// 缓存生存时间：5分钟，确保能感知 CLI 等外部凭证变更
+    static let ttl: TimeInterval = 5 * 60
 
     func get() -> ClaudeCredentialResult? {
         lock.lock()
         defer { lock.unlock() }
+        // Invalidate if TTL expired
+        // TTL 过期时自动失效，下次从文件重新加载
+        if let cachedAt, Date().timeIntervalSince(cachedAt) > Self.ttl {
+            cached = nil
+            self.cachedAt = nil
+            return nil
+        }
         return cached
     }
 
@@ -17,12 +30,14 @@ private final class CredentialCache: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         cached = credentials
+        cachedAt = Date()
     }
 
     func clear() {
         lock.lock()
         defer { lock.unlock() }
         cached = nil
+        cachedAt = nil
     }
 }
 
@@ -66,11 +81,16 @@ public struct ClaudeAPIUsageProbe: UsageProbe, @unchecked Sendable {
 
     public func probe() async throws -> UsageSnapshot {
         // Check cache first, fall back to loading from file/keychain
-        guard var credentials = cache.get() ?? credentialLoader.loadCredentials() else {
+        // Only update cache when loading from file (not from cache hit) to preserve TTL
+        // 仅在从文件加载时更新缓存，避免滑动续期导致 TTL 永不过期
+        let fromCache = cache.get()
+        guard var credentials = fromCache ?? credentialLoader.loadCredentials() else {
             AppLog.probes.error("Claude API: No credentials found")
             throw ProbeError.authenticationRequired
         }
-        cache.set(credentials)
+        if fromCache == nil {
+            cache.set(credentials)
+        }
 
         // Check if token needs refresh
         if credentialLoader.needsRefresh(credentials.oauth) {
@@ -78,9 +98,33 @@ public struct ClaudeAPIUsageProbe: UsageProbe, @unchecked Sendable {
                 AppLog.probes.info("Claude API: Token expired or expiring soon, refreshing...")
                 do {
                     credentials = try await refreshToken(credentials)
-                } catch {
-                    AppLog.probes.error("Claude API: Token refresh failed: \(error.localizedDescription)")
-                    throw error
+                } catch let refreshError {
+                    // Clear cache so next probe reloads from file (CLI may have re-authenticated)
+                    // 清除缓存，下次 probe 会从文件重新加载（CLI 可能已重新登录）
+                    cache.clear()
+
+                    // Try reloading from file — CLI may have updated credentials externally
+                    // 尝试从文件重新加载——CLI 可能已在外部更新了凭证
+                    if let freshCredentials = credentialLoader.loadCredentials(),
+                       freshCredentials.oauth != credentials.oauth {
+                        AppLog.probes.info("Claude API: Found updated credentials from file, retrying...")
+                        credentials = freshCredentials
+                        cache.set(credentials)
+                        // Re-check if the fresh credentials also need refresh
+                        if credentialLoader.needsRefresh(credentials.oauth) {
+                            do {
+                                credentials = try await refreshToken(credentials)
+                            } catch {
+                                AppLog.probes.error("Claude API: Retry with fresh credentials also failed: \(error.localizedDescription)")
+                                cache.clear()
+                                throw error
+                            }
+                        }
+                        // Fresh credentials are valid, continue to fetch usage
+                    } else {
+                        AppLog.probes.error("Claude API: Token refresh failed: \(refreshError.localizedDescription)")
+                        throw refreshError
+                    }
                 }
             } else {
                 // Long-lived token (e.g. from `claude setup-token`) — no refresh mechanism.
@@ -95,18 +139,23 @@ public struct ClaudeAPIUsageProbe: UsageProbe, @unchecked Sendable {
             usageData = try await fetchUsage(accessToken: credentials.oauth.accessToken)
         } catch let error as ProbeError where error == .authenticationRequired {
             // Token might have been invalidated, try refreshing once
+            // Token 可能已被外部失效，尝试刷新一次
             if credentials.oauth.refreshToken != nil {
                 AppLog.probes.info("Claude API: Got 401/403, attempting token refresh...")
                 do {
                     credentials = try await refreshToken(credentials)
                     usageData = try await fetchUsage(accessToken: credentials.oauth.accessToken)
                 } catch {
+                    // Clear cache on auth failure so next probe reloads from file
+                    // 认证失败时清除缓存，下次 probe 从文件重新加载
+                    cache.clear()
                     AppLog.probes.error("Claude API: Retry after refresh failed: \(error.localizedDescription)")
                     throw error
                 }
             } else {
                 // No refresh token (setup-token) — can't recover from 401/403
                 AppLog.probes.error("Claude API: Got 401/403 with no refresh token available")
+                cache.clear()
                 throw error
             }
         }
@@ -156,10 +205,12 @@ public struct ClaudeAPIUsageProbe: UsageProbe, @unchecked Sendable {
 
                 if errorResponse.error == "invalid_grant" {
                     AppLog.probes.error("Claude API: Session expired (invalid_grant) - run `claude` to re-authenticate")
+                    cache.clear()
                     throw ProbeError.sessionExpired
                 }
             }
             AppLog.probes.error("Claude API: Token expired or invalid (HTTP \(httpResponse.statusCode))")
+            cache.clear()
             throw ProbeError.sessionExpired
         }
 

--- a/Tests/InfrastructureTests/Claude/ClaudeAPIUsageProbeTests.swift
+++ b/Tests/InfrastructureTests/Claude/ClaudeAPIUsageProbeTests.swift
@@ -616,6 +616,131 @@ struct ClaudeAPIUsageProbeTokenRefreshTests {
         }
     }
 
+    @Test
+    func `probe recovers after session expiry when file has updated credentials`() async throws {
+        // Scenario: cached refresh token is invalid, but CLI has re-authenticated
+        // and written new credentials to the file
+        let tempDir = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        // Start with expired token
+        let pastExpiry = Date().addingTimeInterval(-3600).timeIntervalSince1970 * 1000
+        try createCredentialsFile(at: tempDir, accessToken: "old-token", expiresAt: pastExpiry)
+
+        let mockNetwork = MockNetworkClient()
+        var callCount = 0
+
+        given(mockNetwork).request(.any).willProduce { request in
+            callCount += 1
+            let url = request.url?.absoluteString ?? ""
+
+            if url.contains("oauth/token") {
+                if callCount == 1 {
+                    // First refresh attempt: old token is invalid
+                    let errorResponse = """
+                    { "error": "invalid_grant", "error_description": "Refresh token has been revoked" }
+                    """.data(using: .utf8)!
+                    return (errorResponse, HTTPURLResponse(
+                        url: URL(string: "https://platform.claude.com")!,
+                        statusCode: 400, httpVersion: nil, headerFields: nil)!)
+                } else {
+                    // Second refresh attempt (with fresh file credentials): success
+                    let refreshResponse = """
+                    { "access_token": "brand-new-token", "refresh_token": "brand-new-refresh", "expires_in": 3600 }
+                    """.data(using: .utf8)!
+                    return (refreshResponse, HTTPURLResponse(
+                        url: URL(string: "https://platform.claude.com")!,
+                        statusCode: 200, httpVersion: nil, headerFields: nil)!)
+                }
+            } else {
+                // Usage request succeeds
+                let usageResponse = """
+                { "five_hour": { "utilization": 15.0 } }
+                """.data(using: .utf8)!
+                return (usageResponse, HTTPURLResponse(
+                    url: URL(string: "https://api.anthropic.com")!,
+                    statusCode: 200, httpVersion: nil, headerFields: nil)!)
+            }
+        }
+
+        let loader = ClaudeCredentialLoader(homeDirectory: tempDir.path, useKeychain: false)
+        let probe = ClaudeAPIUsageProbe(credentialLoader: loader, networkClient: mockNetwork)
+
+        // First probe: old token fails refresh → sessionExpired (file still has old creds)
+        await #expect(throws: ProbeError.sessionExpired) {
+            try await probe.probe()
+        }
+
+        // Simulate CLI re-authentication: write new credentials to file
+        let newExpiry = Date().addingTimeInterval(-60).timeIntervalSince1970 * 1000
+        try createCredentialsFile(at: tempDir, accessToken: "cli-refreshed-token",
+                                  refreshToken: "cli-refreshed-refresh", expiresAt: newExpiry)
+
+        // Second probe: cache was cleared, reloads from file → gets new creds → succeeds
+        let snapshot = try await probe.probe()
+        #expect(snapshot.providerId == "claude")
+        #expect(snapshot.quotas.first?.percentRemaining == 85.0)
+    }
+
+    @Test
+    func `probe falls back to file credentials when refresh fails with invalid_grant and file has new token`() async throws {
+        // Scenario: during a single probe() call, refresh fails but file has been
+        // updated by CLI in the meantime with a different access token
+        let tempDir = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        // Expired token in file
+        let pastExpiry = Date().addingTimeInterval(-3600).timeIntervalSince1970 * 1000
+        try createCredentialsFile(at: tempDir, accessToken: "stale-token", expiresAt: pastExpiry)
+
+        let loader = ClaudeCredentialLoader(homeDirectory: tempDir.path, useKeychain: false)
+        let mockNetwork = MockNetworkClient()
+        var refreshCallCount = 0
+
+        given(mockNetwork).request(.any).willProduce { request in
+            let url = request.url?.absoluteString ?? ""
+
+            if url.contains("oauth/token") {
+                refreshCallCount += 1
+                if refreshCallCount == 1 {
+                    // First refresh attempt with stale token fails
+                    // Simulate CLI updating the file concurrently
+                    let futureExpiry = Date().addingTimeInterval(3600).timeIntervalSince1970 * 1000
+                    try! self.createCredentialsFile(at: tempDir, accessToken: "brand-new-token",
+                                                    refreshToken: "brand-new-refresh", expiresAt: futureExpiry)
+
+                    let errorResponse = """
+                    { "error": "invalid_grant", "error_description": "Token revoked" }
+                    """.data(using: .utf8)!
+                    return (errorResponse, HTTPURLResponse(
+                        url: URL(string: "https://platform.claude.com")!,
+                        statusCode: 400, httpVersion: nil, headerFields: nil)!)
+                } else {
+                    // Should not reach here — brand-new token from file is not expired
+                    fatalError("Should not refresh a valid non-expired token")
+                }
+            } else {
+                // Usage request succeeds
+                let usageResponse = """
+                { "five_hour": { "utilization": 20.0 } }
+                """.data(using: .utf8)!
+                return (usageResponse, HTTPURLResponse(
+                    url: URL(string: "https://api.anthropic.com")!,
+                    statusCode: 200, httpVersion: nil, headerFields: nil)!)
+            }
+        }
+
+        let probe = ClaudeAPIUsageProbe(credentialLoader: loader, networkClient: mockNetwork)
+
+        // Probe should recover: refresh fails → clears cache → reloads from file
+        // → finds brand-new non-expired token → fetches usage successfully
+        let snapshot = try await probe.probe()
+        #expect(snapshot.providerId == "claude")
+        #expect(snapshot.quotas.first?.percentRemaining == 80.0) // 100 - 20
+        #expect(refreshCallCount == 1) // Only one refresh attempt (stale token)
+    }
+}
+
 // MARK: - Setup-Token (Environment) Tests
 
 @Suite("ClaudeAPIUsageProbe Setup-Token Tests")
@@ -754,5 +879,4 @@ struct ClaudeAPIUsageProbeSetupTokenTests {
 
         #expect(await probe.isAvailable() == true)
     }
-}
 }


### PR DESCRIPTION
## Summary
- Add 5-minute TTL to `CredentialCache` to detect external credential changes (e.g. CLI re-login)
- Clear cache on `sessionExpired` / `authenticationRequired` errors to break the stale-credential loop
- Fall back to file credentials when token refresh fails — recovers seamlessly if CLI has re-authenticated
- Compare full `ClaudeOAuthCredentials` struct (not just `accessToken`) for file fallback detection
- Preserve upstream setup-token (no refresh token) behavior with cache clear on 401/403

## Root Cause
When the app is left idle, the OAuth access token expires. If Claude CLI refreshes the token externally (making the old single-use refresh token invalid), ClaudeBar's in-memory cache keeps serving the stale credentials. Every subsequent probe attempt fails with `invalid_grant`, creating a permanent authentication loop — even after the user re-authenticates via CLI.

## Test plan
- [x] Existing 17 tests pass (no regressions)
- [x] New: `probe recovers after session expiry when file has updated credentials` — verifies cross-probe recovery
- [x] New: `probe falls back to file credentials when refresh fails with invalid_grant and file has new token` — verifies intra-probe file fallback
- [x] Upstream 4 setup-token tests pass (conflict resolved, both features coexist)
- [x] Total: 23 tests in 3 suites pass

Closes #143

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential cache handling with automatic expiration to enhance resilience during token refresh failures.
  * Enhanced error recovery when credentials are updated externally or authentication attempts fail.
  * Better safeguards to ensure credentials remain synchronized across probe operations.

* **Tests**
  * Added test coverage for credential recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->