### PR TITLE
fix: parse reset time when percentage shares same line

### DIFF
--- a/Sources/Infrastructure/Claude/ClaudeUsageProbe.swift
+++ b/Sources/Infrastructure/Claude/ClaudeUsageProbe.swift
@@ -704,6 +704,12 @@ public final class ClaudeUsageProbe: UsageProbe, @unchecked Sendable {
         // Using the *last* occurrence handles both start-of-line "Resets Jan 1, 2026"
         // and mid-line "$5.41 ... · Resets Jan 1, 2026 (America/New_York)".
         var cleaned = text
+
+        // Strip trailing "NN% used" or "NN% left" — in newer CLI formats the reset text
+        // and percentage share the same line (e.g., "Resets 3pm (Europe/Amsterdam)  27% used")
+        cleaned = cleaned
+            .replacingOccurrences(of: #"\s+\d{1,3}%\s*(?:used|left)\s*$"#, with: "", options: .regularExpression)
+
         if let lastResets = cleaned.range(of: "resets", options: [.caseInsensitive, .backwards]) {
             cleaned = String(cleaned[lastResets.upperBound...])
         }

--- a/Tests/InfrastructureTests/Claude/ClaudeUsageProbeParsingTests.swift
+++ b/Tests/InfrastructureTests/Claude/ClaudeUsageProbeParsingTests.swift
@@ -294,6 +294,47 @@ struct ClaudeUsageProbeParsingTests {
         #expect(snapshot.weeklyQuota?.resetsAt != nil, "Weekly resetsAt should be populated for 'Resets Feb 12 at 4pm (TZ)' format")
     }
 
+    // MARK: - Reset on Same Line as Percentage (CLI v2.1.109+ format)
+
+    // Real output from Claude CLI where reset text and percentage share the same line
+    // (no separate progress bar line, no separate reset line)
+    static let resetOnSameLineOutput = """
+    Current session
+      Resets 3pm (Europe/Amsterdam)                      27% used
+
+
+      Current week (all models)
+      Resets Apr 16 at 4:59pm (Europe/Amsterdam)         40% used
+
+      Current week (Sonnet only)
+      Resets Apr 17 at 11:59am (Europe/Amsterdam)        0% used
+    """
+
+    @Test
+    func `parses percentages when reset and percent share same line`() throws {
+        // When
+        let snapshot = try simulateParse(text: Self.resetOnSameLineOutput)
+
+        // Then
+        #expect(snapshot.sessionQuota?.percentRemaining == 73) // 27% used = 73% remaining
+        #expect(snapshot.weeklyQuota?.percentRemaining == 60)  // 40% used = 60% remaining
+        #expect(snapshot.quota(for: .modelSpecific("sonnet"))?.percentRemaining == 100) // 0% used
+    }
+
+    @Test
+    func `parses resetsAt when reset and percent share same line`() throws {
+        // When
+        let snapshot = try ClaudeUsageProbe.parse(Self.resetOnSameLineOutput)
+
+        // Then — all quotas should have resetsAt populated (enables pace triangle)
+        #expect(snapshot.sessionQuota?.resetsAt != nil,
+                "Session resetsAt should be populated for 'Resets 3pm (TZ) ... 27% used' format")
+        #expect(snapshot.weeklyQuota?.resetsAt != nil,
+                "Weekly resetsAt should be populated for 'Resets Apr 16 at 4:59pm (TZ) ... 40% used' format")
+        #expect(snapshot.quota(for: .modelSpecific("sonnet"))?.resetsAt != nil,
+                "Sonnet resetsAt should be populated for 'Resets Apr 17 at 11:59am (TZ) ... 0% used' format")
+    }
+
     // MARK: - ANSI Code Handling
 
     static let ansiColoredOutput = """


### PR DESCRIPTION
## Summary
- Newer Claude CLI versions (v2.1.109+) render the reset text and percentage on the **same line** instead of separate lines:
  ```
  Resets 3pm (Europe/Amsterdam)                      27% used
  ```
- The trailing `NN% used/left` suffix prevented timezone stripping and date parsing in `parseAbsoluteDate`, causing `resetsAt` to be `nil` — which made the pace triangle marker disappear from the progress bar.
- Fix: strip the `% used`/`% left` suffix before date parsing begins.

## Changes
- `ClaudeUsageProbe.swift`: Strip `\d{1,3}% (used|left)` suffix at the start of `parseAbsoluteDate`
- `ClaudeUsageProbeParsingTests.swift`: Two new tests with real CLI output from v2.1.109

## Test Plan
- [x] `parses percentages when reset and percent share same line` — verifies 27%, 40%, 0% are parsed correctly
- [x] `parses resetsAt when reset and percent share same line` — verifies `resetsAt` is populated (enables pace triangle)
- [ ] Existing tests (blocked locally by pre-existing SwiftTerm Metal duplicate tasks build issue, should pass in CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of Claude usage data to correctly handle newer CLI output formats where reset information and usage percentage appear on the same line, ensuring accurate quota tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->