### PR TITLE
feat: migrate minimum deployment target to macOS 12 (Monterey)

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -9,7 +9,7 @@ let project = Project(
     settings: .settings(
         base: [
             "SWIFT_VERSION": "6.0",
-            "MACOSX_DEPLOYMENT_TARGET": "15.0",
+            "MACOSX_DEPLOYMENT_TARGET": "12.0",
             "ENABLE_DEBUG_DYLIB": "YES",
         ],
         debug: [
@@ -27,7 +27,7 @@ let project = Project(
             destinations: .macOS,
             product: .staticFramework,
             bundleId: "com.tddworks.claudebar.domain",
-            deploymentTargets: .macOS("15.0"),
+            deploymentTargets: .macOS("12.0"),
             sources: ["Sources/Domain/**"],
             dependencies: [
                 .external(name: "Mockable"),
@@ -45,19 +45,19 @@ let project = Project(
             destinations: .macOS,
             product: .staticFramework,
             bundleId: "com.tddworks.claudebar.infrastructure",
-            deploymentTargets: .macOS("15.0"),
+            deploymentTargets: .macOS("12.0"),
             sources: ["Sources/Infrastructure/**"],
             dependencies: [
                 .target(name: "Domain"),
-                .external(name: "Mockable"),
                 .external(name: "SwiftTerm"),
+                .external(name: "SweetCookieKit"),
+                .external(name: "Mockable"),
                 .external(name: "AWSCloudWatch"),
                 .external(name: "AWSSTS"),
                 .external(name: "AWSPricing"),
                 .external(name: "AWSSDKIdentity"),
                 .external(name: "AWSSSO"),
                 .external(name: "AWSSSOOIDC"),
-                .external(name: "SweetCookieKit"),
             ],
             settings: .settings(
                 base: [
@@ -72,7 +72,7 @@ let project = Project(
             destinations: .macOS,
             product: .app,
             bundleId: "com.tddworks.claudebar",
-            deploymentTargets: .macOS("15.0"),
+            deploymentTargets: .macOS("12.0"),
             infoPlist: .file(path: "Sources/App/Info.plist"),
             sources: ["Sources/App/**"],
             resources: [
@@ -107,7 +107,7 @@ let project = Project(
             destinations: .macOS,
             product: .unitTests,
             bundleId: "com.tddworks.claudebar.domain-tests",
-            deploymentTargets: .macOS("15.0"),
+            deploymentTargets: .macOS("12.0"),
             sources: ["Tests/DomainTests/**"],
             dependencies: [
                 .target(name: "Domain"),
@@ -133,7 +133,7 @@ let project = Project(
             destinations: .macOS,
             product: .unitTests,
             bundleId: "com.tddworks.claudebar.infrastructure-tests",
-            deploymentTargets: .macOS("15.0"),
+            deploymentTargets: .macOS("12.0"),
             sources: ["Tests/InfrastructureTests/**"],
             dependencies: [
                 .target(name: "Infrastructure"),
@@ -159,7 +159,7 @@ let project = Project(
             destinations: .macOS,
             product: .unitTests,
             bundleId: "com.tddworks.claudebar.acceptance-tests",
-            deploymentTargets: .macOS("15.0"),
+            deploymentTargets: .macOS("12.0"),
             sources: ["Tests/AcceptanceTests/**"],
             dependencies: [
                 .target(name: "Domain"),

--- a/Sources/App/ClaudeBarApp.swift
+++ b/Sources/App/ClaudeBarApp.swift
@@ -223,6 +223,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 vc.rootView = rootView
             }
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+            constrainPopoverToScreen()
+        }
+    }
+
+    /// Clamp popover position so it stays within visible screen bounds (macOS 12 fix).
+    private func constrainPopoverToScreen() {
+        guard let popover = popover,
+              let window = popover.contentViewController?.view.window,
+              let screen = window.screen ?? NSScreen.main else { return }
+
+        let screenFrame = screen.visibleFrame
+        let windowFrame = window.frame
+
+        if windowFrame.maxX > screenFrame.maxX {
+            let shift = windowFrame.maxX - screenFrame.maxX
+            window.setFrameOrigin(NSPoint(x: windowFrame.origin.x - shift, y: windowFrame.origin.y))
+        }
+        if windowFrame.maxY > screenFrame.maxY {
+            let shift = windowFrame.maxY - screenFrame.maxY
+            window.setFrameOrigin(NSPoint(x: windowFrame.origin.x, y: windowFrame.origin.y - shift))
         }
     }
 

--- a/Sources/App/ClaudeBarApp.swift
+++ b/Sources/App/ClaudeBarApp.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 import Domain
 import Infrastructure
+import Combine
+import UserNotifications
 #if ENABLE_SPARKLE
 import Sparkle
 #endif
@@ -9,20 +11,37 @@ extension Notification.Name {
     static let hookSettingsChanged = Notification.Name("com.tddworks.claudebar.hookSettingsChanged")
 }
 
+// MARK: - App Entry Point
+
 @main
 struct ClaudeBarApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
+    var body: some Scene {
+        Settings {
+            EmptyView()
+        }
+    }
+}
+
+// MARK: - AppDelegate
+
+@MainActor
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    private var statusItem: NSStatusItem?
+    private var popover: NSPopover?
+
     /// The main domain service - monitors all AI providers
-    /// This is the single source of truth for providers and their state
-    @State private var monitor: QuotaMonitor
+    private(set) var monitor: QuotaMonitor!
 
     /// Monitors Claude Code sessions via hook events
-    @State private var sessionMonitor = SessionMonitor()
+    private(set) var sessionMonitor: SessionMonitor!
 
     /// The hook HTTP server that receives events from Claude Code
     private let hookServer = HookHTTPServer()
 
-    /// Task for the hook server event loop (allows cancellation on toggle off)
-    @State private var hookServerTask: Task<Void, Never>?
+    /// Task for the hook server event loop
+    private var hookServerTask: Task<Void, Never>?
 
     /// Alerts users when quota status degrades
     private let quotaAlerter = NotificationAlerter()
@@ -32,24 +51,21 @@ struct ClaudeBarApp: App {
 
     #if ENABLE_SPARKLE
     /// Sparkle updater for auto-updates
-    @State private var sparkleUpdater = SparkleUpdater()
+    private(set) var sparkleUpdater: SparkleUpdater?
     #endif
 
-    init() {
+    /// Combine subscriptions for observing model changes
+    private var cancellables: Set<AnyCancellable> = []
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
         let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
         AppLog.ui.info("ClaudeBar v\(version) (\(build)) initializing...")
 
         // Create the shared settings repository (JSON-backed: ~/.claudebar/settings.json)
-        // JSONSettingsRepository implements all sub-protocols:
-        // - AppSettingsRepository (app-level display/sync settings)
-        // - ProviderSettingsRepository + all provider sub-protocols
-        // - HookSettingsRepository
         let settingsRepository = JSONSettingsRepository.shared
 
         // Create all providers with their probes (rich domain models)
-        // Each provider manages its own isEnabled state (persisted via ProviderSettingsRepository)
-        // Each probe checks isAvailable() for credentials/prerequisites
         let repository = AIProviders(providers: [
             ClaudeProvider(
                 cliProbe: ClaudeUsageProbe(),
@@ -102,12 +118,19 @@ struct ClaudeBarApp: App {
         AppLog.providers.info("Created \(repository.all.count) providers")
 
         // Initialize the domain service with quota alerter
-        // QuotaMonitor automatically validates selected provider on init
         monitor = QuotaMonitor(
             providers: repository,
-            alerter: quotaAlerter
+            alerter: quotaAlerter,
+            clock: SystemClock()
         )
         AppLog.monitor.info("QuotaMonitor initialized")
+
+        // Initialize session monitor
+        sessionMonitor = SessionMonitor()
+
+        #if ENABLE_SPARKLE
+        sparkleUpdater = SparkleUpdater()
+        #endif
 
         // Load user extensions from ~/.claudebar/extensions/
         let extensionRegistry = ExtensionRegistry(
@@ -124,31 +147,186 @@ struct ClaudeBarApp: App {
             startHookServer()
         }
 
-        // Note: Notification permission is requested in onAppear, not here
-        // Menu bar apps need the run loop to be active before requesting permissions
+        // Set up status bar
+        setupStatusBar()
+
+        // Observe model changes to update status bar icon
+        observeModelChanges()
+
+        // Request notification permission
+        requestNotificationPermission()
 
         AppLog.ui.info("ClaudeBar initialization complete")
     }
 
-    /// App settings for theme
-    @State private var settings = AppSettings.shared
+    // MARK: - Status Bar Setup
 
-    /// Status of selected provider, considering burn rate setting
-    private var effectiveSelectedProviderStatus: QuotaStatus {
-        guard let snapshot = monitor.selectedProvider?.snapshot else { return .healthy }
-        if settings.burnRateWarningEnabled {
-            return snapshot.paceAwareOverallStatus(burnRateThreshold: settings.burnRateThreshold)
+    private func setupStatusBar() {
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+
+        if let button = statusItem?.button {
+            button.image = statusBarImage(for: .healthy)
+            button.action = #selector(togglePopover)
+            button.target = self
+            button.sendAction(on: [.leftMouseUp, .rightMouseUp])
         }
-        return snapshot.overallStatus
+
+        popover = NSPopover()
+        popover?.behavior = .transient
+
+        var contentView: AnyView = AnyView(MenuContentView(
+            monitor: monitor,
+            sessionMonitor: sessionMonitor,
+            quotaAlerter: quotaAlerter
+        ) { [weak self] enabled in
+            if enabled { self?.startHookServer() } else { self?.stopHookServer() }
+        }
+        .environmentObject(AppSettings.shared)
+        .appThemeProvider(themeModeId: AppSettings.shared.themeMode))
+
+        #if ENABLE_SPARKLE
+        if let sparkleUpdater = sparkleUpdater {
+            contentView = AnyView(contentView.environment(\.sparkleUpdater, sparkleUpdater))
+        }
+        #endif
+
+        popover?.contentViewController = NSHostingController(rootView: contentView)
     }
 
-    /// Current theme mode from settings
-    private var currentThemeMode: ThemeMode {
-        ThemeMode(rawValue: settings.themeMode) ?? .system
+    // MARK: - Popover Toggle
+
+    @objc private func togglePopover() {
+        guard let popover = popover, let button = statusItem?.button else { return }
+
+        if popover.isShown {
+            popover.performClose(nil)
+        } else {
+            // Update theme when opening
+            if let vc = popover.contentViewController as? NSHostingController<AnyView> {
+                let settings = AppSettings.shared
+                var rootView: AnyView = AnyView(MenuContentView(
+                    monitor: monitor,
+                    sessionMonitor: sessionMonitor,
+                    quotaAlerter: quotaAlerter
+                ) { [weak self] enabled in
+                    if enabled { self?.startHookServer() } else { self?.stopHookServer() }
+                }
+                .environmentObject(settings)
+                .appThemeProvider(themeModeId: settings.themeMode))
+
+                #if ENABLE_SPARKLE
+                if let sparkleUpdater = sparkleUpdater {
+                    rootView = AnyView(rootView.environment(\.sparkleUpdater, sparkleUpdater))
+                }
+                #endif
+
+                vc.rootView = rootView
+            }
+            popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+        }
     }
+
+    // MARK: - Model Change Observation
+
+    private func observeModelChanges() {
+        // Update status bar icon when provider state changes
+        monitor.objectWillChange
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.updateStatusBarIcon()
+            }
+            .store(in: &cancellables)
+
+        sessionMonitor.objectWillChange
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.updateStatusBarIcon()
+            }
+            .store(in: &cancellables)
+
+        AppSettings.shared.objectWillChange
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.updateStatusBarIcon()
+            }
+            .store(in: &cancellables)
+    }
+
+    private func updateStatusBarIcon() {
+        guard let snapshot = monitor?.selectedProvider?.snapshot else {
+            statusItem?.button?.image = statusBarImage(for: .healthy)
+            return
+        }
+
+        let settings = AppSettings.shared
+        let status: QuotaStatus
+        if settings.burnRateWarningEnabled {
+            status = snapshot.paceAwareOverallStatus(burnRateThreshold: settings.burnRateThreshold)
+        } else {
+            status = snapshot.overallStatus
+        }
+
+        if let session = sessionMonitor?.activeSession {
+            statusItem?.button?.image = sessionStatusBarImage(sessionPhase: session.phase, status: status)
+        } else {
+            statusItem?.button?.image = statusBarImage(for: status)
+        }
+    }
+
+    // MARK: - Status Bar Images
+
+    private func statusBarImage(for status: QuotaStatus) -> NSImage? {
+        guard let theme = ThemeRegistry.shared.theme(for: AppSettings.shared.themeMode) else {
+            return NSImage(systemSymbolName: "chart.bar.fill", accessibilityDescription: String(describing: status))
+        }
+
+        let iconName: String
+        if let themeIcon = theme.statusBarIconName {
+            iconName = themeIcon
+        } else {
+            switch status {
+            case .depleted: iconName = "chart.bar.xaxis"
+            case .critical: iconName = "exclamationmark.triangle.fill"
+            case .warning, .healthy: iconName = "chart.bar.fill"
+            }
+        }
+
+        let color = NSColor(theme.statusColor(for: status))
+        return NSImage(systemSymbolName: iconName, accessibilityDescription: String(describing: status))?
+            .withSymbolConfiguration(.init(paletteColors: [color]))
+    }
+
+    private func sessionStatusBarImage(sessionPhase: ClaudeSession.Phase, status: QuotaStatus) -> NSImage? {
+        let phaseColor = NSColor(sessionPhase.color)
+        guard let theme = ThemeRegistry.shared.theme(for: AppSettings.shared.themeMode) else {
+            return NSImage(systemSymbolName: "terminal.fill", accessibilityDescription: "session")?
+                .withSymbolConfiguration(.init(paletteColors: [phaseColor]))
+        }
+        let statusColor = NSColor(theme.statusColor(for: status))
+
+        let terminalImage = NSImage(systemSymbolName: "terminal.fill", accessibilityDescription: "session")?
+            .withSymbolConfiguration(.init(paletteColors: [phaseColor]))
+
+        let statusIconName: String
+        if let themeIcon = theme.statusBarIconName {
+            statusIconName = themeIcon
+        } else {
+            switch status {
+            case .depleted: statusIconName = "chart.bar.xaxis"
+            case .critical: statusIconName = "exclamationmark.triangle.fill"
+            case .warning, .healthy: statusIconName = "chart.bar.fill"
+            }
+        }
+
+        let statusImage = NSImage(systemSymbolName: statusIconName, accessibilityDescription: String(describing: status))?
+            .withSymbolConfiguration(.init(paletteColors: [statusColor]))
+
+        return terminalImage ?? statusImage
+    }
+
+    // MARK: - Hook Server
 
     private func startHookServer() {
-        // Cancel any existing server task
         hookServerTask?.cancel()
         hookServer.stop()
 
@@ -202,125 +380,52 @@ struct ClaudeBarApp: App {
         }
     }
 
-    var body: some Scene {
-        MenuBarExtra {
-            #if ENABLE_SPARKLE
-            MenuContentView(monitor: monitor, sessionMonitor: sessionMonitor, quotaAlerter: quotaAlerter) { enabled in
-                    if enabled { startHookServer() } else { stopHookServer() }
-                }
-                .appThemeProvider(themeModeId: settings.themeMode)
-                .environment(\.sparkleUpdater, sparkleUpdater)
-            #else
-            MenuContentView(monitor: monitor, sessionMonitor: sessionMonitor, quotaAlerter: quotaAlerter) { enabled in
-                    if enabled { startHookServer() } else { stopHookServer() }
-                }
-                .appThemeProvider(themeModeId: settings.themeMode)
-            #endif
-        } label: {
-            // Show overall status + active session indicator in menu bar
-            StatusBarIcon(status: effectiveSelectedProviderStatus, activeSession: sessionMonitor.activeSession)
-                .appThemeProvider(themeModeId: settings.themeMode)
-        }
-        .menuBarExtraStyle(.window)
-    }
+    // MARK: - Notification Permission
 
+    private func requestNotificationPermission() {
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
+    }
 }
 
-/// The menu bar icon that reflects the overall quota status.
-/// When a Claude Code session is active, shows a terminal icon with phase color.
-/// Uses theme's `statusBarIconName` if set, otherwise shows status-based icons.
-struct StatusBarIcon: View {
-    let status: QuotaStatus
-    var activeSession: ClaudeSession? = nil
+// MARK: - PreviewProvider
 
-    @Environment(\.appTheme) private var theme
-
-    var body: some View {
-        if let session = activeSession {
-            // Active session: show terminal icon with phase color
-            HStack(spacing: 3) {
-                Image(systemName: "terminal.fill")
+struct StatusBarIcon_Previews: PreviewProvider {
+    static var previews: some View {
+        HStack(spacing: 30) {
+            VStack {
+                Image(systemName: "chart.bar.fill")
                     .symbolRenderingMode(.palette)
-                    .foregroundStyle(sessionPhaseColor(session.phase))
-                Image(systemName: iconName)
-                    .symbolRenderingMode(.palette)
-                    .foregroundStyle(iconColor)
+                    .foregroundColor(.green)
+                Text("HEALTHY")
+                    .font(.caption)
+                    .foregroundColor(.green)
             }
-        } else {
-            Image(systemName: iconName)
-                .symbolRenderingMode(.palette)
-                .foregroundStyle(iconColor)
+            VStack {
+                Image(systemName: "chart.bar.fill")
+                    .symbolRenderingMode(.palette)
+                    .foregroundColor(.orange)
+                Text("WARNING")
+                    .font(.caption)
+                    .foregroundColor(.orange)
+            }
+            VStack {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .symbolRenderingMode(.palette)
+                    .foregroundColor(.red)
+                Text("CRITICAL")
+                    .font(.caption)
+                    .foregroundColor(.red)
+            }
+            VStack {
+                Image(systemName: "chart.bar.xaxis")
+                    .symbolRenderingMode(.palette)
+                    .foregroundColor(.red)
+                Text("DEPLETED")
+                    .font(.caption)
+                    .foregroundColor(.red)
+            }
         }
+        .padding(40)
+        .background(Color.black)
     }
-
-    private var iconName: String {
-        // Use theme's custom icon if provided
-        if let themeIcon = theme.statusBarIconName {
-            return themeIcon
-        }
-        // Otherwise use status-based icon
-        switch status {
-        case .depleted:
-            return "chart.bar.xaxis"
-        case .critical:
-            return "exclamationmark.triangle.fill"
-        case .warning, .healthy:
-            return "chart.bar.fill"
-        }
-    }
-
-    private var iconColor: Color {
-        theme.statusColor(for: status)
-    }
-
-    private func sessionPhaseColor(_ phase: ClaudeSession.Phase) -> Color {
-        phase.color
-    }
-}
-
-// MARK: - StatusBarIcon Preview
-
-#Preview("StatusBarIcon - All States") {
-    HStack(spacing: 30) {
-        VStack {
-            StatusBarIcon(status: .healthy)
-            Text("HEALTHY")
-                .font(.caption)
-                .foregroundStyle(.green)
-        }
-        VStack {
-            StatusBarIcon(status: .warning)
-            Text("WARNING")
-                .font(.caption)
-                .foregroundStyle(.orange)
-        }
-        VStack {
-            StatusBarIcon(status: .critical)
-            Text("CRITICAL")
-                .font(.caption)
-                .foregroundStyle(.red)
-        }
-        VStack {
-            StatusBarIcon(status: .depleted)
-            Text("DEPLETED")
-                .font(.caption)
-                .foregroundStyle(.red)
-        }
-        VStack {
-            StatusBarIcon(status: .healthy)
-                .appThemeProvider(themeModeId: "cli")
-            Text("CLI")
-                .font(.caption)
-                .foregroundStyle(CLITheme().accentPrimary)
-        }
-        VStack {
-            StatusBarIcon(status: .healthy)
-                .appThemeProvider(themeModeId: "christmas")
-            Text("CHRISTMAS")
-                .font(.caption)
-                .foregroundStyle(ChristmasTheme().accentPrimary)
-        }
-    }
-    .padding(40)
-    .background(Color.black)
 }

--- a/Sources/App/ClaudeBarApp.swift
+++ b/Sources/App/ClaudeBarApp.swift
@@ -199,6 +199,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         guard let popover = popover, let button = statusItem?.button else { return }
 
         if popover.isShown {
+            windowObservation = nil
             popover.performClose(nil)
         } else {
             // Update theme when opening
@@ -223,7 +224,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 vc.rootView = rootView
             }
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
-            constrainPopoverToScreen()
+            DispatchQueue.main.async { [weak self] in
+                self?.constrainPopoverToScreen()
+                self?.observePopoverWindow()
+            }
         }
     }
 
@@ -243,6 +247,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if windowFrame.maxY > screenFrame.maxY {
             let shift = windowFrame.maxY - screenFrame.maxY
             window.setFrameOrigin(NSPoint(x: windowFrame.origin.x, y: windowFrame.origin.y - shift))
+        }
+    }
+
+    /// Observe window frame changes and re-constrain (macOS 12 popover resizes after show).
+    private var windowObservation: NSKeyValueObservation?
+
+    private func observePopoverWindow() {
+        guard let window = popover?.contentViewController?.view.window else { return }
+        windowObservation = window.observe(\.frame, options: [.new]) { [weak self] window, _ in
+            self?.constrainPopoverToScreen()
         }
     }
 

--- a/Sources/App/Info.plist
+++ b/Sources/App/Info.plist
@@ -23,7 +23,7 @@
     <key>LSApplicationCategoryType</key>
     <string>public.app-category.utilities</string>
     <key>LSMinimumSystemVersion</key>
-    <string>15.0</string>
+    <string>12.0</string>
     <key>LSUIElement</key>
     <true/>
     <key>NSHumanReadableCopyright</key>

--- a/Sources/App/Settings/AppSettings.swift
+++ b/Sources/App/Settings/AppSettings.swift
@@ -1,14 +1,15 @@
 import Foundation
 import Domain
 import Infrastructure
+import Combine
 import ServiceManagement
 
 /// Observable settings manager for ClaudeBar preferences.
-/// Thin `@Observable` wrapper around `AppSettingsRepository` for SwiftUI reactivity.
+/// Thin `ObservableObject` wrapper around `AppSettingsRepository` for SwiftUI reactivity.
 /// All persistence is delegated to the repository (`~/.claudebar/settings.json`).
 @MainActor
-@Observable
-public final class AppSettings {
+public final class AppSettings: ObservableObject {
+    nonisolated(unsafe) public let objectWillChange = ObservableObjectPublisher()
     public static let shared = AppSettings()
 
     /// The underlying repository (internal - views access settings through AppSettings properties/methods)
@@ -17,7 +18,7 @@ public final class AppSettings {
     // MARK: - Theme Settings
 
     /// The current theme mode (light, dark, system, christmas)
-    public var themeMode: String {
+    @Published public var themeMode: String {
         didSet {
             repository.setThemeMode(themeMode)
             if !isInitializing {
@@ -27,7 +28,7 @@ public final class AppSettings {
     }
 
     /// Whether the user has explicitly chosen a theme (vs auto-enabled Christmas)
-    public var userHasChosenTheme: Bool {
+    @Published public var userHasChosenTheme: Bool {
         didSet {
             repository.setUserHasChosenTheme(userHasChosenTheme)
         }
@@ -36,14 +37,14 @@ public final class AppSettings {
     // MARK: - Display Settings
 
     /// Whether to show quota as "remaining" or "used"
-    public var usageDisplayMode: UsageDisplayMode {
+    @Published public var usageDisplayMode: UsageDisplayMode {
         didSet {
             repository.setUsageDisplayMode(usageDisplayMode.rawValue)
         }
     }
 
     /// Whether to show daily usage report cards (API Cost, Token Usage, Working Time)
-    public var showDailyUsageCards: Bool {
+    @Published public var showDailyUsageCards: Bool {
         didSet {
             repository.setShowDailyUsageCards(showDailyUsageCards)
         }
@@ -52,7 +53,7 @@ public final class AppSettings {
     // MARK: - Overview Mode Settings
 
     /// Whether to show all enabled providers at once instead of one at a time
-    public var overviewModeEnabled: Bool {
+    @Published public var overviewModeEnabled: Bool {
         didSet {
             repository.setOverviewModeEnabled(overviewModeEnabled)
         }
@@ -61,14 +62,14 @@ public final class AppSettings {
     // MARK: - Background Sync Settings
 
     /// Whether background sync is enabled (default: false)
-    public var backgroundSyncEnabled: Bool {
+    @Published public var backgroundSyncEnabled: Bool {
         didSet {
             repository.setBackgroundSyncEnabled(backgroundSyncEnabled)
         }
     }
 
     /// Background sync interval in seconds (default: 60)
-    public var backgroundSyncInterval: TimeInterval {
+    @Published public var backgroundSyncInterval: TimeInterval {
         didSet {
             repository.setBackgroundSyncInterval(backgroundSyncInterval)
         }
@@ -77,14 +78,14 @@ public final class AppSettings {
     // MARK: - Claude API Budget Settings
 
     /// Whether Claude API budget tracking is enabled
-    public var claudeApiBudgetEnabled: Bool {
+    @Published public var claudeApiBudgetEnabled: Bool {
         didSet {
             repository.setClaudeApiBudgetEnabled(claudeApiBudgetEnabled)
         }
     }
 
     /// The budget threshold for Claude API usage (in dollars)
-    public var claudeApiBudget: Decimal {
+    @Published public var claudeApiBudget: Decimal {
         didSet {
             repository.setClaudeApiBudget(NSDecimalNumber(decimal: claudeApiBudget).doubleValue)
         }
@@ -93,14 +94,14 @@ public final class AppSettings {
     // MARK: - Burn Rate Warning Settings
 
     /// Whether burn rate-based warnings are enabled (default: false, uses absolute thresholds)
-    public var burnRateWarningEnabled: Bool {
+    @Published public var burnRateWarningEnabled: Bool {
         didSet {
             repository.setBurnRateWarningEnabled(burnRateWarningEnabled)
         }
     }
 
     /// The burn rate multiplier threshold above which warnings fire (default: 1.5)
-    public var burnRateThreshold: Double {
+    @Published public var burnRateThreshold: Double {
         didSet {
             repository.setBurnRateThreshold(burnRateThreshold)
         }
@@ -109,7 +110,7 @@ public final class AppSettings {
     // MARK: - Update Settings
 
     /// Whether to receive beta updates (default: false)
-    public var receiveBetaUpdates: Bool {
+    @Published public var receiveBetaUpdates: Bool {
         didSet {
             repository.setReceiveBetaUpdates(receiveBetaUpdates)
             NotificationCenter.default.post(name: .betaUpdatesSettingChanged, object: nil)
@@ -119,17 +120,20 @@ public final class AppSettings {
     // MARK: - Launch at Login Settings
 
     /// Whether the app should launch at login (backed by SMAppService, not JSON)
-    public var launchAtLogin: Bool {
+    /// Only available on macOS 13+. Defaults to false on older systems.
+    @Published public var launchAtLogin: Bool {
         didSet {
             guard !isInitializing else { return }
-            do {
-                if launchAtLogin {
-                    try SMAppService.mainApp.register()
-                } else {
-                    try SMAppService.mainApp.unregister()
+            if #available(macOS 13, *) {
+                do {
+                    if launchAtLogin {
+                        try SMAppService.mainApp.register()
+                    } else {
+                        try SMAppService.mainApp.unregister()
+                    }
+                } catch {
+                    launchAtLogin = SMAppService.mainApp.status == .enabled
                 }
-            } catch {
-                launchAtLogin = SMAppService.mainApp.status == .enabled
             }
         }
     }
@@ -163,7 +167,11 @@ public final class AppSettings {
         }
 
         // Launch at login - read from SMAppService (system service, not JSON)
-        self.launchAtLogin = SMAppService.mainApp.status == .enabled
+        if #available(macOS 13, *) {
+            self.launchAtLogin = SMAppService.mainApp.status == .enabled
+        } else {
+            self.launchAtLogin = false
+        }
 
         applySeasonalTheme()
         self.isInitializing = false
@@ -195,7 +203,7 @@ public final class AppSettings {
     // MARK: - Provider Settings Access
 
     /// Access provider-specific settings for reading/writing in Settings UI.
-    /// These are non-observable (loaded into @State) - only app-level settings are @Observable.
+    /// These are non-observable (loaded into @State) - only app-level settings are ObservableObject.
     public var provider: ProviderSettingsRepository { repository }
     public var claude: ClaudeSettingsRepository { repository }
     public var codex: CodexSettingsRepository { repository }

--- a/Sources/App/Settings/ThemeImportView.swift
+++ b/Sources/App/Settings/ThemeImportView.swift
@@ -24,7 +24,7 @@ struct ThemeImportButton: View {
                     Text("Import Theme")
                         .font(theme.font(size: 11, weight: .medium))
                 }
-                .foregroundStyle(theme.accentPrimary)
+                .foregroundColor(theme.accentPrimary)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 6)
                 .background(
@@ -48,13 +48,13 @@ struct ThemeImportButton: View {
             if let error = importError {
                 Text(error)
                     .font(theme.font(size: 9))
-                    .foregroundStyle(theme.statusCritical)
+                    .foregroundColor(theme.statusCritical)
             }
 
             if let name = importedThemeName {
                 Text("Imported: \(name)")
                     .font(theme.font(size: 9))
-                    .foregroundStyle(theme.statusHealthy)
+                    .foregroundColor(theme.statusHealthy)
             }
         }
     }

--- a/Sources/App/SparkleUpdater.swift
+++ b/Sources/App/SparkleUpdater.swift
@@ -1,6 +1,7 @@
 #if ENABLE_SPARKLE
 import Sparkle
 import SwiftUI
+import Combine
 
 /// Delegate to receive update notifications from Sparkle
 private class SparkleUpdaterDelegate: NSObject, SPUUpdaterDelegate, @unchecked Sendable {
@@ -44,8 +45,9 @@ private class SparkleUserDriverDelegate: NSObject, SPUStandardUserDriverDelegate
 /// This class manages the Sparkle update lifecycle and provides
 /// observable properties for UI binding.
 @MainActor
-@Observable
-final class SparkleUpdater {
+final class SparkleUpdater: ObservableObject {
+    nonisolated(unsafe) public let objectWillChange = ObservableObjectPublisher()
+
     /// The underlying Sparkle updater controller (nil if bundle is invalid)
     private var controller: SPUStandardUpdaterController?
 
@@ -59,13 +61,13 @@ final class SparkleUpdater {
     nonisolated(unsafe) private var betaSettingObserver: NSObjectProtocol?
 
     /// Whether an update check is currently in progress
-    private(set) var isCheckingForUpdates = false
+    @Published private(set) var isCheckingForUpdates = false
 
     /// Whether a new update is available
-    private(set) var isUpdateAvailable = false
+    @Published private(set) var isUpdateAvailable = false
 
     /// The version string of the available update
-    private(set) var availableVersion: String?
+    @Published private(set) var availableVersion: String?
 
     /// Whether the updater is available (bundle is properly configured)
     var isAvailable: Bool {

--- a/Sources/App/Theme/AppThemeProvider.swift
+++ b/Sources/App/Theme/AppThemeProvider.swift
@@ -17,7 +17,7 @@ import Domain
 /// @Environment(\.appTheme) var theme
 ///
 /// Text("Hello")
-///     .foregroundStyle(theme.textPrimary)
+///     .foregroundColor(theme.textPrimary)
 ///     .font(.system(size: 14, design: theme.fontDesign))
 /// ```
 public protocol AppThemeProvider {

--- a/Sources/App/Theme/ThemeEnvironment.swift
+++ b/Sources/App/Theme/ThemeEnvironment.swift
@@ -17,7 +17,7 @@ extension EnvironmentValues {
     ///
     ///     var body: some View {
     ///         Text("Hello")
-    ///             .foregroundStyle(theme.textPrimary)
+    ///             .foregroundColor(theme.textPrimary)
     ///     }
     /// }
     /// ```
@@ -116,7 +116,7 @@ private struct ThemeTextModifier: ViewModifier {
     @Environment(\.appTheme) private var theme
 
     func body(content: Content) -> some View {
-        content.foregroundStyle(color)
+        content.foregroundColor(color)
     }
 
     private var color: Color {

--- a/Sources/App/Theme/Themes/ChristmasTheme.swift
+++ b/Sources/App/Theme/Themes/ChristmasTheme.swift
@@ -369,7 +369,7 @@ struct SnowfallOverlay: View {
             } symbols: {
                 Image(systemName: "snowflake")
                     .font(.system(size: 14, weight: .light))
-                    .foregroundStyle(ChristmasTheme.snow)
+                    .foregroundColor(ChristmasTheme.snow)
                     .tag(0)
             }
         }

--- a/Sources/App/Views/AccountPickerView.swift
+++ b/Sources/App/Views/AccountPickerView.swift
@@ -50,12 +50,12 @@ struct AccountPill: View {
 
                     Text(account.initialLetter)
                         .font(.system(size: 8, weight: .bold, design: theme.fontDesign))
-                        .foregroundStyle(isActive ? .white : theme.textSecondary)
+                        .foregroundColor(isActive ? .white : theme.textSecondary)
                 }
 
                 Text(account.displayName)
                     .font(.system(size: 10, weight: isActive ? .semibold : .medium, design: theme.fontDesign))
-                    .foregroundStyle(isActive ? theme.textPrimary : theme.textSecondary)
+                    .foregroundColor(isActive ? theme.textPrimary : theme.textSecondary)
                     .lineLimit(1)
             }
             .padding(.horizontal, 8)

--- a/Sources/App/Views/ComponentPreviews.swift
+++ b/Sources/App/Views/ComponentPreviews.swift
@@ -6,41 +6,44 @@ import Domain
 
 // MARK: - Provider Icons Preview
 
-#Preview("Provider Icons") {
+struct ProviderIcons_Previews: PreviewProvider {
+    static var previews: some View {
     let theme = DarkTheme()
     return HStack(spacing: 40) {
         VStack(spacing: 8) {
             ProviderIconView(providerId: "claude", size: 32)
             Text("Claude")
                 .font(.caption)
-                .foregroundStyle(.white)
+                .foregroundColor(.white)
         }
         VStack(spacing: 8) {
             ProviderIconView(providerId: "codex", size: 32)
             Text("Codex")
                 .font(.caption)
-                .foregroundStyle(.white)
+                .foregroundColor(.white)
         }
         VStack(spacing: 8) {
             ProviderIconView(providerId: "gemini", size: 32)
             Text("Gemini")
                 .font(.caption)
-                .foregroundStyle(.white)
+                .foregroundColor(.white)
         }
         VStack(spacing: 8) {
             ProviderIconView(providerId: "zai", size: 32)
             Text("Z.ai")
                 .font(.caption)
-                .foregroundStyle(.white)
+                .foregroundColor(.white)
         }
     }
     .padding(40)
     .background(theme.backgroundGradient)
+    }
 }
 
 // MARK: - Provider Pills Preview
 
-#Preview("Provider Pills") {
+struct ProviderPills_Previews: PreviewProvider {
+    static var previews: some View {
     let theme = DarkTheme()
     return VStack(spacing: 20) {
         // Selected states
@@ -61,11 +64,13 @@ import Domain
     }
     .padding(40)
     .background(theme.backgroundGradient)
+    }
 }
 
 // MARK: - Stat Cards Preview
 
-#Preview("Stat Cards - Healthy") {
+struct StatCardsHealthy_Previews: PreviewProvider {
+    static var previews: some View {
     let healthyQuota = UsageQuota(
         percentRemaining: 85,
         quotaType: .session,
@@ -77,9 +82,11 @@ import Domain
         .frame(width: 160)
         .padding(20)
         .background(DarkTheme().backgroundGradient)
+    }
 }
 
-#Preview("Stat Cards - Warning") {
+struct StatCardsWarning_Previews: PreviewProvider {
+    static var previews: some View {
     let warningQuota = UsageQuota(
         percentRemaining: 35,
         quotaType: .weekly,
@@ -91,9 +98,11 @@ import Domain
         .frame(width: 160)
         .padding(20)
         .background(DarkTheme().backgroundGradient)
+    }
 }
 
-#Preview("Stat Cards - Critical") {
+struct StatCardsCritical_Previews: PreviewProvider {
+    static var previews: some View {
     let criticalQuota = UsageQuota(
         percentRemaining: 12,
         quotaType: .modelSpecific("Opus"),
@@ -105,9 +114,11 @@ import Domain
         .frame(width: 160)
         .padding(20)
         .background(DarkTheme().backgroundGradient)
+    }
 }
 
-#Preview("Stat Cards Grid") {
+struct StatCardsGrid_Previews: PreviewProvider {
+    static var previews: some View {
     let quotas = [
         UsageQuota(percentRemaining: 94, quotaType: .session, providerId: "claude", resetText: "Resets 11am"),
         UsageQuota(percentRemaining: 33, quotaType: .weekly, providerId: "claude", resetText: "Resets Dec 25"),
@@ -123,9 +134,11 @@ import Domain
     .padding(20)
     .frame(width: 360)
     .background(DarkTheme().backgroundGradient)
+    }
 }
 
-#Preview("Stat Cards - Z.ai") {
+struct StatCardsZai_Previews: PreviewProvider {
+    static var previews: some View {
     // Z.ai quotas showing session and time limit (MCP) usage
     let quotas = [
         UsageQuota(percentRemaining: 35, quotaType: .session, providerId: "zai"),
@@ -140,27 +153,31 @@ import Domain
     .padding(20)
     .frame(width: 360)
     .background(DarkTheme().backgroundGradient)
+    }
 }
 
 // MARK: - Status Badges Preview
 
-#Preview("Status Badges") {
+struct StatusBadges_Previews: PreviewProvider {
+    static var previews: some View {
     let theme = DarkTheme()
     return VStack(spacing: 16) {
         HStack(spacing: 12) {
-            Text("HEALTHY").badge(theme.statusHealthy)
-            Text("WARNING").badge(theme.statusWarning)
-            Text("LOW").badge(theme.statusCritical)
-            Text("EMPTY").badge(theme.statusDepleted)
+            Text("HEALTHY")
+            Text("WARNING")
+            Text("LOW")
+            Text("EMPTY")
         }
     }
     .padding(40)
     .background(theme.backgroundGradient)
+    }
 }
 
 // MARK: - Action Buttons Preview
 
-#Preview("Action Buttons") {
+struct ActionButtons_Previews: PreviewProvider {
+    static var previews: some View {
     let theme = DarkTheme()
     return HStack(spacing: 12) {
         WrappedActionButton(
@@ -184,23 +201,27 @@ import Domain
     }
     .padding(40)
     .background(theme.backgroundGradient)
+    }
 }
 
 // MARK: - Loading Spinner Preview
 
-#Preview("Loading Spinner") {
+struct LoadingSpinner_Previews: PreviewProvider {
+    static var previews: some View {
     LoadingSpinnerView()
         .frame(width: 300)
         .background(DarkTheme().backgroundGradient)
+    }
 }
 
 // MARK: - Glass Card Preview
 
-#Preview("Glass Cards") {
+struct GlassCards_Previews: PreviewProvider {
+    static var previews: some View {
     VStack(spacing: 16) {
         Text("Glass Card Style")
             .font(.headline)
-            .foregroundStyle(.white)
+            .foregroundColor(.white)
             .glassCard()
 
         HStack {
@@ -208,75 +229,79 @@ import Domain
             Text("user@example.com")
             Spacer()
             Text("Just now")
-                .foregroundStyle(.secondary)
+                .foregroundColor(.secondary)
         }
         .font(.caption)
-        .foregroundStyle(.white)
+        .foregroundColor(.white)
         .glassCard(cornerRadius: 12, padding: 10)
     }
     .padding(40)
     .frame(width: 300)
     .background(DarkTheme().backgroundGradient)
+    }
 }
 
 // MARK: - Theme Colors Preview
 
-#Preview("Theme Colors") {
+struct ThemeColors_Previews: PreviewProvider {
+    static var previews: some View {
     let theme = DarkTheme()
     return VStack(spacing: 20) {
         Text("Provider Colors")
             .font(.headline)
-            .foregroundStyle(.white)
+            .foregroundColor(.white)
 
         HStack(spacing: 20) {
             VStack {
                 Circle().fill(ProviderVisualIdentityLookup.color(for: "claude", scheme: .dark)).frame(width: 40, height: 40)
-                Text("Claude").font(.caption).foregroundStyle(.white)
+                Text("Claude").font(.caption).foregroundColor(.white)
             }
             VStack {
                 Circle().fill(ProviderVisualIdentityLookup.color(for: "codex", scheme: .dark)).frame(width: 40, height: 40)
-                Text("Codex").font(.caption).foregroundStyle(.white)
+                Text("Codex").font(.caption).foregroundColor(.white)
             }
             VStack {
                 Circle().fill(ProviderVisualIdentityLookup.color(for: "gemini", scheme: .dark)).frame(width: 40, height: 40)
-                Text("Gemini").font(.caption).foregroundStyle(.white)
+                Text("Gemini").font(.caption).foregroundColor(.white)
             }
             VStack {
                 Circle().fill(ProviderVisualIdentityLookup.color(for: "zai", scheme: .dark)).frame(width: 40, height: 40)
-                Text("Z.ai").font(.caption).foregroundStyle(.white)
+                Text("Z.ai").font(.caption).foregroundColor(.white)
             }
         }
 
         Text("Status Colors")
             .font(.headline)
-            .foregroundStyle(.white)
+            .foregroundColor(.white)
 
         HStack(spacing: 20) {
             VStack {
                 Circle().fill(theme.statusHealthy).frame(width: 40, height: 40)
-                Text("Healthy").font(.caption).foregroundStyle(.white)
+                Text("Healthy").font(.caption).foregroundColor(.white)
             }
             VStack {
                 Circle().fill(theme.statusWarning).frame(width: 40, height: 40)
-                Text("Warning").font(.caption).foregroundStyle(.white)
+                Text("Warning").font(.caption).foregroundColor(.white)
             }
             VStack {
                 Circle().fill(theme.statusCritical).frame(width: 40, height: 40)
-                Text("Critical").font(.caption).foregroundStyle(.white)
+                Text("Critical").font(.caption).foregroundColor(.white)
             }
             VStack {
                 Circle().fill(theme.statusDepleted).frame(width: 40, height: 40)
-                Text("Depleted").font(.caption).foregroundStyle(.white)
+                Text("Depleted").font(.caption).foregroundColor(.white)
             }
         }
     }
     .padding(40)
     .background(theme.backgroundGradient)
+    }
 }
 
 // MARK: - Update Badge Preview
 
-#Preview("Update Badge") {
+struct UpdateBadge_Previews: PreviewProvider {
+    static var previews: some View {
     let darkTheme = DarkTheme()
     let lightTheme = LightTheme()
     let christmasTheme = ChristmasTheme()
@@ -290,13 +315,13 @@ import Domain
                     .frame(width: 32, height: 32)
                 Image(systemName: "gearshape.fill")
                     .font(.system(size: 12, weight: .bold))
-                    .foregroundStyle(darkTheme.textSecondary)
+                    .foregroundColor(darkTheme.textSecondary)
                 UpdateBadge()
                     .offset(x: 14, y: -14)
             }
             Text("Dark")
                 .font(.caption)
-                .foregroundStyle(.white)
+                .foregroundColor(.white)
         }
 
         // Light mode
@@ -307,14 +332,14 @@ import Domain
                     .frame(width: 32, height: 32)
                 Image(systemName: "gearshape.fill")
                     .font(.system(size: 12, weight: .bold))
-                    .foregroundStyle(lightTheme.textSecondary)
+                    .foregroundColor(lightTheme.textSecondary)
                 UpdateBadge()
                     .offset(x: 14, y: -14)
             }
             .environment(\.colorScheme, .light)
             Text("Light")
                 .font(.caption)
-                .foregroundStyle(.white)
+                .foregroundColor(.white)
         }
 
         // Christmas mode
@@ -325,22 +350,24 @@ import Domain
                     .frame(width: 32, height: 32)
                 Image(systemName: "gearshape.fill")
                     .font(.system(size: 12, weight: .bold))
-                    .foregroundStyle(christmasTheme.textSecondary)
+                    .foregroundColor(christmasTheme.textSecondary)
                 UpdateBadge(accentColor: christmasTheme.accentPrimary)
                     .offset(x: 14, y: -14)
             }
             Text("Christmas")
                 .font(.caption)
-                .foregroundStyle(.white)
+                .foregroundColor(.white)
         }
     }
     .padding(40)
     .background(darkTheme.backgroundGradient)
+    }
 }
 
 // MARK: - Full Header Preview
 
-#Preview("Header Section") {
+struct HeaderSection_Previews: PreviewProvider {
+    static var previews: some View {
     let theme = DarkTheme()
     return VStack(spacing: 16) {
         // Header mock
@@ -350,11 +377,11 @@ import Domain
             VStack(alignment: .leading, spacing: 2) {
                 Text("ClaudeBar")
                     .font(.system(size: 18, weight: .bold, design: theme.fontDesign))
-                    .foregroundStyle(.white)
+                    .foregroundColor(.white)
 
                 Text("AI Usage Monitor")
                     .font(.system(size: 11, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(.white.opacity(0.7))
+                    .foregroundColor(.white.opacity(0.7))
             }
 
             Spacer()
@@ -366,7 +393,7 @@ import Domain
                     .frame(width: 8, height: 8)
                 Text("HEALTHY")
                     .font(.system(size: 11, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(.white)
+                    .foregroundColor(.white)
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
@@ -388,4 +415,5 @@ import Domain
     .padding(.vertical, 20)
     .frame(width: 420)
     .background(theme.backgroundGradient)
+    }
 }

--- a/Sources/App/Views/CostStatCard.swift
+++ b/Sources/App/Views/CostStatCard.swift
@@ -43,12 +43,11 @@ struct CostStatCard: View {
                 HStack(spacing: 5) {
                     Image(systemName: "dollarsign.circle.fill")
                         .font(.system(size: 9, weight: .bold))
-                        .foregroundStyle(budgetStatusColor)
+                        .foregroundColor(budgetStatusColor)
 
                     Text("API COST")
                         .font(.system(size: 8, weight: .semibold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textSecondary)
-                        .tracking(0.3)
+                        .foregroundColor(theme.textSecondary)
                 }
 
                 Spacer(minLength: 4)
@@ -56,7 +55,6 @@ struct CostStatCard: View {
                 // Status badge
                 if let status = budgetStatus {
                     Text(status.badgeText)
-                        .badge(theme.statusColor(for: status.toQuotaStatus))
                 }
             }
 
@@ -64,8 +62,7 @@ struct CostStatCard: View {
             HStack(alignment: .firstTextBaseline, spacing: 2) {
                 Text(costUsage.formattedCost)
                     .font(.system(size: 28, weight: .heavy, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
-                    .contentTransition(.numericText())
+                    .foregroundColor(theme.textPrimary)
             }
 
             // Budget progress bar (if budget is set)
@@ -82,7 +79,7 @@ struct CostStatCard: View {
                     Text("API Time: \(costUsage.formattedApiDuration)")
                         .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
                 }
-                .foregroundStyle(theme.textTertiary)
+                .foregroundColor(theme.textTertiary)
                 .lineLimit(1)
             } else if let resetText = costUsage.resetText {
                 HStack(spacing: 3) {
@@ -92,7 +89,7 @@ struct CostStatCard: View {
                     Text(resetText)
                         .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
                 }
-                .foregroundStyle(theme.textTertiary)
+                .foregroundColor(theme.textTertiary)
                 .lineLimit(1)
             }
         }
@@ -137,7 +134,7 @@ struct CostStatCard: View {
                     RoundedRectangle(cornerRadius: 3)
                         .fill(budgetProgressGradient)
                         .frame(width: animateProgress ? geo.size.width * budgetPercentUsed / 100 : 0)
-                        .animation(.spring(response: 0.8, dampingFraction: 0.7).delay(delay + 0.2), value: animateProgress)
+                        .animation(.spring().delay(delay + 0.2), value: animateProgress)
                 }
             }
             .frame(height: 5)
@@ -146,7 +143,7 @@ struct CostStatCard: View {
             HStack {
                 Text("\(Int(budgetPercentUsed))% of \(formatBudget(budget)) budget")
                     .font(.system(size: 8, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
 
                 Spacer()
             }
@@ -196,7 +193,8 @@ struct CostStatCard: View {
 
 // MARK: - Preview
 
-#Preview("Cost Card - Dark") {
+struct CostCardDark_Previews: PreviewProvider {
+    static var previews: some View {
     ZStack {
         DarkTheme().backgroundGradient
 
@@ -215,9 +213,11 @@ struct CostStatCard: View {
     }
     .frame(width: 380, height: 200)
     .preferredColorScheme(.dark)
+    }
 }
 
-#Preview("Cost Card - Light") {
+struct CostCardLight_Previews: PreviewProvider {
+    static var previews: some View {
     ZStack {
         LightTheme().backgroundGradient
 
@@ -236,9 +236,11 @@ struct CostStatCard: View {
     }
     .frame(width: 380, height: 200)
     .preferredColorScheme(.light)
+    }
 }
 
-#Preview("Cost Card - No Budget") {
+struct CostCardNoBudget_Previews: PreviewProvider {
+    static var previews: some View {
     ZStack {
         DarkTheme().backgroundGradient
 
@@ -256,4 +258,5 @@ struct CostStatCard: View {
     }
     .frame(width: 380, height: 180)
     .preferredColorScheme(.dark)
+    }
 }

--- a/Sources/App/Views/CustomWebCardView.swift
+++ b/Sources/App/Views/CustomWebCardView.swift
@@ -16,11 +16,11 @@ struct CustomWebCardView: View {
             HStack(spacing: 5) {
                 Image(systemName: "globe")
                     .font(.system(size: 9, weight: .bold))
-                    .foregroundStyle(theme.accentPrimary)
+                    .foregroundColor(theme.accentPrimary)
 
                 Text(url.host ?? url.absoluteString)
                     .font(.system(size: 9, weight: .bold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textSecondary)
+                    .foregroundColor(theme.textSecondary)
                     .textCase(.uppercase)
                     .lineLimit(1)
 
@@ -32,7 +32,7 @@ struct CustomWebCardView: View {
                 } label: {
                     Image(systemName: "arrow.up.right.square")
                         .font(.system(size: 10))
-                        .foregroundStyle(theme.textTertiary)
+                        .foregroundColor(theme.textTertiary)
                 }
                 .buttonStyle(.plain)
             }

--- a/Sources/App/Views/DailyUsageCardView.swift
+++ b/Sources/App/Views/DailyUsageCardView.swift
@@ -19,12 +19,11 @@ struct DailyUsageCardView: View {
                 HStack(spacing: 5) {
                     Image(systemName: metric.iconName)
                         .font(.system(size: 9, weight: .bold))
-                        .foregroundStyle(metric.color)
+                        .foregroundColor(metric.color)
 
                     Text(metric.label.uppercased())
                         .font(.system(size: 8, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textSecondary)
-                        .tracking(0.3)
+                        .foregroundColor(theme.textSecondary)
                 }
 
                 Spacer(minLength: 4)
@@ -34,14 +33,13 @@ struct DailyUsageCardView: View {
             HStack(alignment: .firstTextBaseline) {
                 Text(primaryValue)
                     .font(.system(size: 24, weight: .bold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
-                    .contentTransition(.numericText())
+                    .foregroundColor(theme.textPrimary)
 
                 Spacer()
 
                 Text(metric.unitLabel)
                     .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
             }
 
             // Progress bar
@@ -57,7 +55,7 @@ struct DailyUsageCardView: View {
                             endPoint: .trailing
                         ))
                         .frame(width: animateProgress ? geo.size.width * progress : 0)
-                        .animation(.spring(response: 0.8, dampingFraction: 0.7).delay(delay + 0.2), value: animateProgress)
+                        .animation(.spring().delay(delay + 0.2), value: animateProgress)
                 }
             }
             .frame(height: 5)
@@ -71,7 +69,7 @@ struct DailyUsageCardView: View {
                     Text(deltaText)
                         .font(.system(size: 8, weight: .medium, design: theme.fontDesign))
                 }
-                .foregroundStyle(deltaColor)
+                .foregroundColor(deltaColor)
                 .lineLimit(1)
             }
         }

--- a/Sources/App/Views/ExtensionMetricCardView.swift
+++ b/Sources/App/Views/ExtensionMetricCardView.swift
@@ -19,13 +19,12 @@ struct ExtensionMetricCardView: View {
                     if let iconName = metric.icon {
                         Image(systemName: iconName)
                             .font(.system(size: 9, weight: .bold))
-                            .foregroundStyle(accentColor)
+                            .foregroundColor(accentColor)
                     }
 
                     Text(metric.label.uppercased())
                         .font(.system(size: 8, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textSecondary)
-                        .tracking(0.3)
+                        .foregroundColor(theme.textSecondary)
                 }
 
                 Spacer(minLength: 4)
@@ -35,8 +34,7 @@ struct ExtensionMetricCardView: View {
             HStack(alignment: .firstTextBaseline) {
                 Text(metric.value)
                     .font(.system(size: 24, weight: .bold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
-                    .contentTransition(.numericText())
+                    .foregroundColor(theme.textPrimary)
                     .lineLimit(1)
                     .minimumScaleFactor(0.6)
 
@@ -44,7 +42,7 @@ struct ExtensionMetricCardView: View {
 
                 Text(metric.unit)
                     .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
                     .lineLimit(1)
                     .minimumScaleFactor(0.7)
             }
@@ -63,7 +61,7 @@ struct ExtensionMetricCardView: View {
                                 endPoint: .trailing
                             ))
                             .frame(width: animateProgress ? geo.size.width * min(1, max(0, progress)) : 0)
-                            .animation(.spring(response: 0.8, dampingFraction: 0.7).delay(delay + 0.2), value: animateProgress)
+                            .animation(.spring().delay(delay + 0.2), value: animateProgress)
                     }
                 }
                 .frame(height: 5)
@@ -78,7 +76,7 @@ struct ExtensionMetricCardView: View {
                     Text(deltaText(delta))
                         .font(.system(size: 8, weight: .medium, design: theme.fontDesign))
                 }
-                .foregroundStyle(theme.textTertiary)
+                .foregroundColor(theme.textTertiary)
                 .lineLimit(1)
             }
         }

--- a/Sources/App/Views/MenuContentView.swift
+++ b/Sources/App/Views/MenuContentView.swift
@@ -8,8 +8,8 @@ import Sparkle
 /// The main menu content view with adaptive theme support via AppThemeProvider.
 /// Uses the pluggable theme system for consistent styling across all themes.
 struct MenuContentView: View {
-    let monitor: QuotaMonitor
-    let sessionMonitor: SessionMonitor
+    @ObservedObject var monitor: QuotaMonitor
+    @ObservedObject var sessionMonitor: SessionMonitor
     let quotaAlerter: QuotaAlerter
     var onHookSettingsChanged: ((Bool) -> Void)?
 
@@ -22,7 +22,7 @@ struct MenuContentView: View {
     @State private var animateIn = false
     @State private var showSettings = false
     @State private var showSharePass = false
-    @State private var settings = AppSettings.shared
+    @ObservedObject var settings = AppSettings.shared
     @State private var hasRequestedNotificationPermission = false
 
     /// The currently selected provider ID (from monitor, which is @Observable)
@@ -142,13 +142,13 @@ struct MenuContentView: View {
             }
             #endif
         }
-        .onChange(of: selectedProviderId) { _, newProviderId in
+        .onChange(of: selectedProviderId) { newProviderId in
             // Refresh when user switches provider
             Task {
                 await refresh(providerId: newProviderId)
             }
         }
-        .onChange(of: settings.backgroundSyncEnabled) { _, enabled in
+        .onChange(of: settings.backgroundSyncEnabled) { enabled in
             // React to background sync toggle
             if enabled {
                 startBackgroundSync()
@@ -156,7 +156,7 @@ struct MenuContentView: View {
                 stopBackgroundSync()
             }
         }
-        .onChange(of: settings.backgroundSyncInterval) { _, _ in
+        .onChange(of: settings.backgroundSyncInterval) { _ in
             // Restart sync with new interval
             if settings.backgroundSyncEnabled {
                 restartBackgroundSync()
@@ -167,10 +167,9 @@ struct MenuContentView: View {
     // MARK: - Background Sync Control
 
     private func startBackgroundSync() {
-        let interval = Duration.seconds(settings.backgroundSyncInterval)
         AppLog.monitor.info("Starting background sync (interval: \(settings.backgroundSyncInterval)s)")
         Task {
-            let stream = monitor.startMonitoring(interval: interval)
+            let stream = monitor.startMonitoring(interval: settings.backgroundSyncInterval)
             for await _ in stream {
                 // Events handled internally by QuotaMonitor
             }
@@ -255,7 +254,7 @@ struct MenuContentView: View {
                 if theme.id == "christmas" {
                     Image(systemName: "sparkle")
                         .font(.system(size: 10))
-                        .foregroundStyle(theme.accentPrimary)
+                        .foregroundColor(theme.accentPrimary)
                         .offset(x: 14, y: -14)
                 }
             }
@@ -264,19 +263,19 @@ struct MenuContentView: View {
                 HStack(spacing: 4) {
                     Text("ClaudeBar")
                         .font(.system(size: 18, weight: .bold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textPrimary)
+                        .foregroundColor(theme.textPrimary)
 
                     // Christmas gift icon
                     if theme.id == "christmas" {
                         Image(systemName: "gift.fill")
                             .font(.system(size: 12))
-                            .foregroundStyle(theme.accentPrimary)
+                            .foregroundColor(theme.accentPrimary)
                     }
                 }
 
                 Text(headerSubtitle)
                     .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.id == "cli" ? theme.accentPrimary : theme.textSecondary)
+                    .foregroundColor(theme.id == "cli" ? theme.accentPrimary : theme.textSecondary)
             }
 
             Spacer()
@@ -322,7 +321,7 @@ struct MenuContentView: View {
 
             Text(statusText)
                 .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
-                .foregroundStyle(theme.textPrimary)
+                .foregroundColor(theme.textPrimary)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
@@ -450,13 +449,12 @@ struct MenuContentView: View {
 
             Text(provider.name)
                 .font(.system(size: 13, weight: .semibold, design: theme.fontDesign))
-                .foregroundStyle(theme.textPrimary)
+                .foregroundColor(theme.textPrimary)
 
             Spacer()
 
             let status = provider.snapshot?.overallStatus ?? .healthy
             Text(provider.isSyncing ? "Syncing..." : status.badgeText)
-                .badge(theme.statusColor(for: status))
         }
         .padding(.horizontal, 4)
     }
@@ -465,11 +463,11 @@ struct MenuContentView: View {
         HStack(spacing: 8) {
             Image(systemName: "exclamationmark.triangle.fill")
                 .font(.system(size: 12))
-                .foregroundStyle(theme.statusWarning)
+                .foregroundColor(theme.statusWarning)
 
             Text(provider.lastError?.localizedDescription ?? "Unavailable")
                 .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
-                .foregroundStyle(theme.textTertiary)
+                .foregroundColor(theme.textTertiary)
                 .lineLimit(1)
 
             Spacer()
@@ -488,21 +486,21 @@ struct MenuContentView: View {
 
                 Text(String(displayName.prefix(1)).uppercased())
                     .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
-                    .foregroundStyle(.white)
+                    .foregroundColor(.white)
             }
 
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 6) {
                     Text(displayName)
                         .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textPrimary)
+                        .foregroundColor(theme.textPrimary)
                         .lineLimit(1)
 
                     // Account tier badge
                     if let accountTier = snapshot.accountTier {
                         Text(accountTier.badgeText)
                             .font(.system(size: 8, weight: .semibold, design: theme.fontDesign))
-                            .foregroundStyle(.white)
+                            .foregroundColor(.white)
                             .padding(.horizontal, 5)
                             .padding(.vertical, 2)
                             .background(
@@ -514,7 +512,7 @@ struct MenuContentView: View {
 
                 Text("Updated \(snapshot.ageDescription)")
                     .font(.system(size: 10, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
             }
 
             Spacer()
@@ -523,7 +521,7 @@ struct MenuContentView: View {
             if snapshot.isStale {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .font(.system(size: 12))
-                    .foregroundStyle(theme.statusWarning)
+                    .foregroundColor(theme.statusWarning)
             }
         }
         .glassCard(cornerRadius: 12, padding: 10)
@@ -616,17 +614,17 @@ struct MenuContentView: View {
 
                 Image(systemName: "exclamationmark.triangle.fill")
                     .font(.system(size: 28))
-                    .foregroundStyle(theme.statusWarning)
+                    .foregroundColor(theme.statusWarning)
             }
 
             Text("\(selectedProvider?.name ?? selectedProviderId) Unavailable")
                 .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
-                .foregroundStyle(theme.textPrimary)
+                .foregroundColor(theme.textPrimary)
 
             // Show actual error message if available, otherwise generic message
             Text(selectedProvider?.lastError?.localizedDescription ?? "Install CLI or check configuration")
                 .font(.system(size: 11, weight: .semibold, design: theme.fontDesign))
-                .foregroundStyle(theme.textTertiary)
+                .foregroundColor(theme.textTertiary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 16)
         }
@@ -690,7 +688,7 @@ struct MenuContentView: View {
                         } else {
                             Image(systemName: "gift.fill")
                                 .font(.system(size: 12, weight: .bold))
-                                .foregroundStyle(.white)
+                                .foregroundColor(.white)
                         }
                     }
                 }
@@ -711,7 +709,7 @@ struct MenuContentView: View {
 
                     Image(systemName: "gearshape.fill")
                         .font(.system(size: 12, weight: .bold))
-                        .foregroundStyle(theme.textSecondary)
+                        .foregroundColor(theme.textSecondary)
 
                     // Update available indicator
                     #if ENABLE_SPARKLE
@@ -737,7 +735,7 @@ struct MenuContentView: View {
 
                     Image(systemName: "xmark")
                         .font(.system(size: 12, weight: .bold))
-                        .foregroundStyle(theme.textSecondary)
+                        .foregroundColor(theme.textSecondary)
                 }
             }
             .buttonStyle(.plain)
@@ -825,7 +823,7 @@ struct ProviderPill: View {
                     .lineLimit(1)
                     .fixedSize()
             }
-            .foregroundStyle(isSelected ? (theme.id == "cli" ? theme.textPrimary : .white) : theme.textPrimary)
+            .foregroundColor(isSelected ? (theme.id == "cli" ? theme.textPrimary : .white) : theme.textPrimary)
             .padding(.horizontal, 10)
             .padding(.vertical, 6)
             .background(
@@ -862,7 +860,7 @@ struct WrappedStatCard: View {
     @Environment(\.appTheme) private var theme
     @State private var isHovering = false
     @State private var animateProgress = false
-    @State private var settings = AppSettings.shared
+    @ObservedObject var settings = AppSettings.shared
 
     private var displayMode: UsageDisplayMode {
         settings.usageDisplayMode
@@ -893,12 +891,11 @@ struct WrappedStatCard: View {
                 HStack(spacing: 5) {
                     Image(systemName: iconName)
                         .font(.system(size: 9, weight: .bold))
-                        .foregroundStyle(statusColor)
+                        .foregroundColor(statusColor)
 
                     Text(quota.quotaType.displayName.uppercased())
                         .font(.system(size: 8, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textSecondary)
-                        .tracking(0.3)
+                        .foregroundColor(theme.textSecondary)
                 }
 
                 Spacer(minLength: 4)
@@ -906,10 +903,8 @@ struct WrappedStatCard: View {
                 // Status badge - pace mode shows pace badge, others show status
                 if effectiveDisplayMode == .pace {
                     Text(quota.pace.displayName.uppercased())
-                        .badge(paceColor)
                 } else {
                     Text(quota.status.badgeText)
-                        .badge(statusColor)
                 }
             }
 
@@ -918,18 +913,16 @@ struct WrappedStatCard: View {
                 if let dollarText = quota.formattedDollarRemaining {
                     Text(dollarText)
                         .font(.system(size: 18, weight: .bold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textPrimary)
-                        .contentTransition(.numericText())
+                        .foregroundColor(theme.textPrimary)
                 } else {
                     HStack(alignment: .firstTextBaseline, spacing: 1) {
                         Text("\(Int(quota.displayPercent(mode: effectiveDisplayMode)))")
                             .font(.system(size: 32, weight: .bold, design: theme.fontDesign))
-                            .foregroundStyle(effectiveDisplayMode == .pace ? paceColor : theme.textPrimary)
-                            .contentTransition(.numericText())
+                            .foregroundColor(effectiveDisplayMode == .pace ? paceColor : theme.textPrimary)
 
                         Text("%")
                             .font(.system(size: 16, weight: .medium, design: theme.fontDesign))
-                            .foregroundStyle(effectiveDisplayMode == .pace ? paceColor.opacity(0.7) : theme.textTertiary)
+                            .foregroundColor(effectiveDisplayMode == .pace ? paceColor.opacity(0.7) : theme.textTertiary)
                     }
                 }
 
@@ -937,7 +930,7 @@ struct WrappedStatCard: View {
 
                 Text(quota.isDollarBased ? "Remaining" : effectiveDisplayMode.displayLabel)
                     .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(effectiveDisplayMode == .pace ? paceColor.opacity(0.8) : theme.textTertiary)
+                    .foregroundColor(effectiveDisplayMode == .pace ? paceColor.opacity(0.8) : theme.textTertiary)
             }
 
             // Pace insight line
@@ -948,7 +941,7 @@ struct WrappedStatCard: View {
                     Text(insight)
                         .font(.system(size: 8, weight: .medium, design: theme.fontDesign))
                 }
-                .foregroundStyle(paceColor.opacity(0.8))
+                .foregroundColor(paceColor.opacity(0.8))
                 .lineLimit(1)
             }
 
@@ -965,7 +958,7 @@ struct WrappedStatCard: View {
                         RoundedRectangle(cornerRadius: 3)
                             .fill(theme.progressGradient(for: quota.percentRemaining))
                             .frame(width: animateProgress ? geo.size.width * max(0, min(100, progressPercent)) / 100 : 0)
-                            .animation(.spring(response: 0.8, dampingFraction: 0.7).delay(delay + 0.2), value: animateProgress)
+                            .animation(.spring().delay(delay + 0.2), value: animateProgress)
                     }
                 }
                 .frame(height: 5)
@@ -997,7 +990,7 @@ struct WrappedStatCard: View {
                     Text(resetText)
                         .font(.system(size: 8, weight: .medium, design: theme.fontDesign))
                 }
-                .foregroundStyle(theme.textTertiary)
+                .foregroundColor(theme.textTertiary)
                 .lineLimit(1)
             }
         }
@@ -1058,7 +1051,7 @@ struct LoadingSpinnerView: View {
 
             Text("Fetching usage data...")
                 .font(.system(size: 13, weight: .medium, design: theme.fontDesign))
-                .foregroundStyle(theme.textSecondary)
+                .foregroundColor(theme.textSecondary)
         }
         .frame(height: 140)
         .frame(maxWidth: .infinity)
@@ -1098,7 +1091,7 @@ struct WrappedActionButton: View {
                     .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
                     .fixedSize()
             }
-            .foregroundStyle(isHovering ? .white : theme.textPrimary)
+            .foregroundColor(isHovering ? .white : theme.textPrimary)
             .padding(.horizontal, 14)
             .padding(.vertical, 8)
             .background(
@@ -1258,7 +1251,7 @@ struct PulsingStatusDot: View {
                     .opacity(0.5)
             }
         }
-        .onChange(of: isSyncing) { _, syncing in
+        .onChange(of: isSyncing) { syncing in
             if syncing {
                 startPulsing()
             } else {
@@ -1322,7 +1315,7 @@ struct UpdateBadge: View {
             // Arrow up icon
             Image(systemName: "arrow.up")
                 .font(.system(size: 7, weight: .black))
-                .foregroundStyle(.white)
+                .foregroundColor(.white)
         }
     }
 }
@@ -1347,19 +1340,17 @@ struct BedrockUsageCard: View {
                     HStack(spacing: 5) {
                         Image(systemName: "cloud.fill")
                             .font(.system(size: 10, weight: .bold))
-                            .foregroundStyle(ProviderVisualIdentityLookup.color(for: "bedrock", scheme: colorScheme))
+                            .foregroundColor(ProviderVisualIdentityLookup.color(for: "bedrock", scheme: colorScheme))
 
                         Text("TODAY'S USAGE")
                             .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                            .foregroundStyle(theme.textSecondary)
-                            .tracking(0.5)
+                            .foregroundColor(theme.textSecondary)
                     }
 
                     // Large cost number
                     Text(usage.formattedTotalCost)
                         .font(.system(size: 36, weight: .bold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textPrimary)
-                        .contentTransition(.numericText())
+                        .foregroundColor(theme.textPrimary)
                 }
 
                 Spacer()
@@ -1381,14 +1372,14 @@ struct BedrockUsageCard: View {
                         HStack {
                             Text(modelUsage.model.displayName)
                                 .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
-                                .foregroundStyle(theme.textSecondary)
+                                .foregroundColor(theme.textSecondary)
                                 .lineLimit(1)
 
                             Spacer()
 
                             Text(modelUsage.formattedCost)
                                 .font(.system(size: 11, weight: .semibold, design: theme.fontDesign))
-                                .foregroundStyle(theme.textPrimary)
+                                .foregroundColor(theme.textPrimary)
                         }
                     }
 
@@ -1396,7 +1387,7 @@ struct BedrockUsageCard: View {
                     if usage.modelUsages.count > 3 {
                         Text("and \(usage.modelUsages.count - 3) more...")
                             .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                            .foregroundStyle(theme.textTertiary)
+                            .foregroundColor(theme.textTertiary)
                     }
                 }
             }
@@ -1411,13 +1402,13 @@ struct BedrockUsageCard: View {
                     HStack {
                         Text("Daily Budget")
                             .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                            .foregroundStyle(theme.textSecondary)
+                            .foregroundColor(theme.textSecondary)
 
                         Spacer()
 
                         Text("\(Int(min(budgetPercent, 100)))% of \(budgetFormatted)")
                             .font(.system(size: 10, weight: .semibold, design: theme.fontDesign))
-                            .foregroundStyle(budgetPercent > 90 ? theme.statusCritical : theme.textPrimary)
+                            .foregroundColor(budgetPercent > 90 ? theme.statusCritical : theme.textPrimary)
                     }
 
                     GeometryReader { geo in
@@ -1442,7 +1433,7 @@ struct BedrockUsageCard: View {
                 Text("Since \(formattedPeriodStart)")
                     .font(.system(size: 9, weight: .medium, design: theme.fontDesign))
             }
-            .foregroundStyle(theme.textTertiary)
+            .foregroundColor(theme.textTertiary)
         }
         .padding(14)
         .background(
@@ -1488,15 +1479,15 @@ private struct StatPill: View {
         HStack(spacing: 4) {
             Image(systemName: icon)
                 .font(.system(size: 8, weight: .bold))
-                .foregroundStyle(theme.textTertiary)
+                .foregroundColor(theme.textTertiary)
 
             Text(value)
                 .font(.system(size: 11, weight: .semibold, design: theme.fontDesign))
-                .foregroundStyle(theme.textPrimary)
+                .foregroundColor(theme.textPrimary)
 
             Text(label)
                 .font(.system(size: 9, weight: .medium, design: theme.fontDesign))
-                .foregroundStyle(theme.textTertiary)
+                .foregroundColor(theme.textTertiary)
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)

--- a/Sources/App/Views/ProviderIcons.swift
+++ b/Sources/App/Views/ProviderIcons.swift
@@ -54,7 +54,7 @@ struct ProviderIconView: View {
 
                     Image(systemName: providerSymbol(for: providerId))
                         .font(.system(size: size * 0.45, weight: .bold))
-                        .foregroundStyle(.white)
+                        .foregroundColor(.white)
                 }
                 .overlay(
                     Circle()
@@ -102,59 +102,64 @@ struct ProviderIconView: View {
 
 // MARK: - Preview
 
-#Preview("Provider Icons - Dark") {
+struct ProviderIconsDark_Previews: PreviewProvider {
+    static var previews: some View {
     HStack(spacing: 30) {
         VStack {
             ProviderIconView(providerId: "claude", size: 40)
             Text("Claude")
                 .font(.caption)
-                .foregroundStyle(.white)
+                .foregroundColor(.white)
         }
         VStack {
             ProviderIconView(providerId: "codex", size: 40)
             Text("Codex")
                 .font(.caption)
-                .foregroundStyle(.white)
+                .foregroundColor(.white)
         }
         VStack {
             ProviderIconView(providerId: "gemini", size: 40)
             Text("Gemini")
                 .font(.caption)
-                .foregroundStyle(.white)
+                .foregroundColor(.white)
         }
     }
     .padding(40)
     .background(DarkTheme().backgroundGradient)
     .preferredColorScheme(.dark)
+    }
 }
 
-#Preview("Provider Icons - Light") {
+struct ProviderIconsLight_Previews: PreviewProvider {
+    static var previews: some View {
     HStack(spacing: 30) {
         VStack {
             ProviderIconView(providerId: "claude", size: 40)
             Text("Claude")
                 .font(.caption)
-                .foregroundStyle(LightTheme().textPrimary)
+                .foregroundColor(LightTheme().textPrimary)
         }
         VStack {
             ProviderIconView(providerId: "codex", size: 40)
             Text("Codex")
                 .font(.caption)
-                .foregroundStyle(LightTheme().textPrimary)
+                .foregroundColor(LightTheme().textPrimary)
         }
         VStack {
             ProviderIconView(providerId: "gemini", size: 40)
             Text("Gemini")
                 .font(.caption)
-                .foregroundStyle(LightTheme().textPrimary)
+                .foregroundColor(LightTheme().textPrimary)
         }
     }
     .padding(40)
     .background(LightTheme().backgroundGradient)
     .preferredColorScheme(.light)
+    }
 }
 
-#Preview("Provider Icons - Sizes") {
+struct ProviderIconsSizes_Previews: PreviewProvider {
+    static var previews: some View {
     HStack(spacing: 20) {
         ProviderIconView(providerId: "claude", size: 24)
         ProviderIconView(providerId: "claude", size: 32)
@@ -164,4 +169,5 @@ struct ProviderIconView: View {
     .padding(40)
     .background(DarkTheme().backgroundGradient)
     .preferredColorScheme(.dark)
+    }
 }

--- a/Sources/App/Views/ProviderSectionView.swift
+++ b/Sources/App/Views/ProviderSectionView.swift
@@ -6,7 +6,7 @@ import Domain
 struct ProviderSectionView: View {
     let snapshot: UsageSnapshot
 
-    @State private var settings = AppSettings.shared
+    @ObservedObject var settings = AppSettings.shared
 
     private var effectiveOverallStatus: QuotaStatus {
         if settings.burnRateWarningEnabled {
@@ -31,7 +31,7 @@ struct ProviderSectionView: View {
                 if let email = snapshot.accountEmail {
                     Text(email)
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.secondary)
                 }
             }
 
@@ -46,12 +46,12 @@ struct ProviderSectionView: View {
             HStack {
                 Text("Updated \(snapshot.ageDescription)")
                     .font(.caption2)
-                    .foregroundStyle(.tertiary)
+                    .foregroundColor(Color(.tertiaryLabelColor))
 
                 if snapshot.isStale {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .font(.caption2)
-                        .foregroundStyle(.orange)
+                        .foregroundColor(.orange)
                 }
             }
         }

--- a/Sources/App/Views/QuotaCardView.swift
+++ b/Sources/App/Views/QuotaCardView.swift
@@ -6,7 +6,7 @@ import Domain
 struct QuotaCardView: View {
     let quota: UsageQuota
 
-    @State private var settings = AppSettings.shared
+    @ObservedObject var settings = AppSettings.shared
 
     private var displayMode: UsageDisplayMode {
         settings.usageDisplayMode
@@ -42,19 +42,19 @@ struct QuotaCardView: View {
             // Label
             Text(quota.quotaType.displayName)
                 .font(.caption)
-                .foregroundStyle(.secondary)
+                .foregroundColor(.secondary)
 
             // Value display
             if let dollarText = quota.formattedDollarRemaining {
                 Text("\(dollarText) remaining")
                     .font(.headline)
                     .fontWeight(.semibold)
-                    .foregroundStyle(dollarDisplayColor)
+                    .foregroundColor(dollarDisplayColor)
             } else {
                 Text("\(Int(quota.displayPercent(mode: effectiveDisplayMode)))%")
                     .font(.title2)
                     .fontWeight(.semibold)
-                    .foregroundStyle(effectiveDisplayMode == .pace ? quota.pace.displayColor : effectiveStatus.displayColor)
+                    .foregroundColor(effectiveDisplayMode == .pace ? quota.pace.displayColor : effectiveStatus.displayColor)
             }
 
             // Progress bar with pace tick

--- a/Sources/App/Views/SessionIndicatorView.swift
+++ b/Sources/App/Views/SessionIndicatorView.swift
@@ -24,11 +24,11 @@ struct SessionIndicatorView: View {
                 HStack(spacing: 6) {
                     Text("Claude Code")
                         .font(.system(size: 11, weight: .semibold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textPrimary)
+                        .foregroundColor(theme.textPrimary)
 
                     Text(phaseLabel)
                         .font(.system(size: 9, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(phaseLabelColor)
+                        .foregroundColor(phaseLabelColor)
                         .padding(.horizontal, 6)
                         .padding(.vertical, 2)
                         .background(
@@ -41,25 +41,25 @@ struct SessionIndicatorView: View {
                     if session.completedTaskCount > 0 {
                         Label("\(session.completedTaskCount) tasks", systemImage: "checkmark.circle.fill")
                             .font(.system(size: 9, weight: .medium, design: theme.fontDesign))
-                            .foregroundStyle(theme.textSecondary)
+                            .foregroundColor(theme.textSecondary)
                     }
 
                     if session.activeSubagentCount > 0 {
                         Label("\(session.activeSubagentCount) agents", systemImage: "person.2.fill")
                             .font(.system(size: 9, weight: .medium, design: theme.fontDesign))
-                            .foregroundStyle(theme.textSecondary)
+                            .foregroundColor(theme.textSecondary)
                     }
 
                     Text(session.durationDescription)
                         .font(.system(size: 9, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textTertiary)
+                        .foregroundColor(theme.textTertiary)
 
                     Spacer()
 
                     // Working directory (last path component)
                     Text(cwdShort)
                         .font(.system(size: 9, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textTertiary)
+                        .foregroundColor(theme.textTertiary)
                         .lineLimit(1)
                 }
             }

--- a/Sources/App/Views/Settings/AccountManagementCard.swift
+++ b/Sources/App/Views/Settings/AccountManagementCard.swift
@@ -8,7 +8,7 @@ import Domain
 /// to `MultiAccountProvider`.
 struct AccountManagementCard: View {
     let provider: any MultiAccountProvider
-    let monitor: QuotaMonitor
+    @ObservedObject var monitor: QuotaMonitor
 
     @Environment(\.appTheme) private var theme
     @State private var isExpanded = false
@@ -58,17 +58,17 @@ struct AccountManagementCard: View {
 
                 Image(systemName: "person.2.fill")
                     .font(.system(size: 12, weight: .bold))
-                    .foregroundStyle(.white)
+                    .foregroundColor(.white)
             }
 
             VStack(alignment: .leading, spacing: 2) {
                 Text("Accounts")
                     .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
+                    .foregroundColor(theme.textPrimary)
 
                 Text("\(provider.accounts.count) account\(provider.accounts.count == 1 ? "" : "s") configured")
                     .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
             }
 
             Spacer()
@@ -76,7 +76,7 @@ struct AccountManagementCard: View {
             // Aggregate status badge
             let statusColor = theme.statusColor(for: provider.aggregateStatus)
             Text(provider.aggregateStatus.badgeText)
-                .badge(statusColor)
+                .foregroundColor(statusColor)
         }
     }
 
@@ -96,7 +96,7 @@ struct AccountManagementCard: View {
 
                 Text(account.initialLetter)
                     .font(.system(size: 10, weight: .bold, design: theme.fontDesign))
-                    .foregroundStyle(
+                    .foregroundColor(
                         account.accountId == provider.activeAccount.accountId
                             ? .white
                             : theme.textSecondary
@@ -107,13 +107,13 @@ struct AccountManagementCard: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(account.displayName)
                     .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
+                    .foregroundColor(theme.textPrimary)
                     .lineLimit(1)
 
                 if let email = account.email {
                     Text(email)
                         .font(.system(size: 9, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textTertiary)
+                        .foregroundColor(theme.textTertiary)
                         .lineLimit(1)
                 }
             }
@@ -132,7 +132,7 @@ struct AccountManagementCard: View {
             if account.accountId == provider.activeAccount.accountId {
                 Image(systemName: "checkmark.circle.fill")
                     .font(.system(size: 14))
-                    .foregroundStyle(theme.statusHealthy)
+                    .foregroundColor(theme.statusHealthy)
             } else {
                 // Switch button
                 Button {
@@ -140,7 +140,7 @@ struct AccountManagementCard: View {
                 } label: {
                     Text("Switch")
                         .font(.system(size: 9, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.accentPrimary)
+                        .foregroundColor(theme.accentPrimary)
                         .padding(.horizontal, 8)
                         .padding(.vertical, 3)
                         .background(
@@ -167,7 +167,7 @@ struct AccountManagementCard: View {
                 Text("Add Account")
                     .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
             }
-            .foregroundStyle(theme.accentPrimary)
+            .foregroundColor(theme.accentPrimary)
             .frame(maxWidth: .infinity)
             .padding(.vertical, 8)
             .background(

--- a/Sources/App/Views/Settings/AlibabaConfigCard.swift
+++ b/Sources/App/Views/Settings/AlibabaConfigCard.swift
@@ -4,9 +4,9 @@ import Infrastructure
 
 /// Alibaba Coding Plan provider configuration card for SettingsView.
 struct AlibabaConfigCard: View {
-    let monitor: QuotaMonitor
+    @ObservedObject var monitor: QuotaMonitor
 
-    @State private var settings = AppSettings.shared
+    @ObservedObject var settings = AppSettings.shared
     @Environment(\.appTheme) private var theme
 
     @State private var alibabaConfigExpanded: Bool = false
@@ -81,17 +81,17 @@ struct AlibabaConfigCard: View {
 
                 Image(systemName: "cloud.fill")
                     .font(.system(size: 12, weight: .bold))
-                    .foregroundStyle(.white)
+                    .foregroundColor(.white)
             }
 
             VStack(alignment: .leading, spacing: 2) {
                 Text("Alibaba Configuration")
                     .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
+                    .foregroundColor(theme.textPrimary)
 
                 Text("Coding Plan quota tracking")
                     .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
             }
 
             Spacer()
@@ -104,8 +104,7 @@ struct AlibabaConfigCard: View {
             VStack(alignment: .leading, spacing: 6) {
                 Text("REGION")
                     .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textSecondary)
-                    .tracking(0.5)
+                    .foregroundColor(theme.textSecondary)
 
                 Picker("", selection: $alibabaRegion) {
                     ForEach(AlibabaRegion.allCases, id: \.self) { region in
@@ -113,7 +112,7 @@ struct AlibabaConfigCard: View {
                     }
                 }
                 .pickerStyle(.segmented)
-                .onChange(of: alibabaRegion) { _, newValue in
+                .onChange(of: alibabaRegion) { newValue in
                     settings.alibaba.setAlibabaRegion(newValue)
                     Task {
                         await monitor.refresh(providerId: "alibaba")
@@ -125,8 +124,7 @@ struct AlibabaConfigCard: View {
             VStack(alignment: .leading, spacing: 6) {
                 Text("COOKIE SOURCE")
                     .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textSecondary)
-                    .tracking(0.5)
+                    .foregroundColor(theme.textSecondary)
 
                 Picker("", selection: $alibabaCookieSource) {
                     ForEach(AlibabaCookieSource.allCases, id: \.self) { source in
@@ -134,7 +132,7 @@ struct AlibabaConfigCard: View {
                     }
                 }
                 .pickerStyle(.segmented)
-                .onChange(of: alibabaCookieSource) { _, newValue in
+                .onChange(of: alibabaCookieSource) { newValue in
                     settings.alibaba.setAlibabaCookieSource(newValue)
                 }
             }
@@ -144,12 +142,11 @@ struct AlibabaConfigCard: View {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("COOKIE STRING")
                         .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textSecondary)
-                        .tracking(0.5)
+                        .foregroundColor(theme.textSecondary)
 
-                    TextField("", text: $alibabaManualCookieInput, prompt: Text("Paste cookie string...").foregroundStyle(theme.textTertiary))
+                    TextField("", text: $alibabaManualCookieInput, prompt: Text("Paste cookie string...").foregroundColor(theme.textTertiary))
                         .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textPrimary)
+                        .foregroundColor(theme.textPrimary)
                         .padding(.horizontal, 10)
                         .padding(.vertical, 8)
                         .background(
@@ -160,7 +157,7 @@ struct AlibabaConfigCard: View {
                                         .stroke(theme.glassBorder, lineWidth: 1)
                                 )
                         )
-                        .onChange(of: alibabaManualCookieInput) { _, newValue in
+                        .onChange(of: alibabaManualCookieInput) { newValue in
                             if !newValue.isEmpty {
                                 settings.alibaba.saveAlibabaManualCookie(newValue)
                             }
@@ -168,7 +165,7 @@ struct AlibabaConfigCard: View {
 
                     Text("Copy the cookie from your browser's developer tools after logging in to Alibaba Cloud.")
                         .font(.system(size: 9, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textTertiary)
+                        .foregroundColor(theme.textTertiary)
                 }
             }
 
@@ -177,8 +174,7 @@ struct AlibabaConfigCard: View {
                 HStack {
                     Text("API KEY")
                         .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textSecondary)
-                        .tracking(0.5)
+                        .foregroundColor(theme.textSecondary)
 
                     Spacer()
 
@@ -189,20 +185,20 @@ struct AlibabaConfigCard: View {
                             Text("Configured")
                                 .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
                         }
-                        .foregroundStyle(theme.statusHealthy)
+                        .foregroundColor(theme.statusHealthy)
                     }
                 }
 
                 HStack(spacing: 6) {
                     Group {
                         if showAlibabaApiKey {
-                            TextField("", text: $alibabaApiKeyInput, prompt: Text("sk-...").foregroundStyle(theme.textTertiary))
+                            TextField("", text: $alibabaApiKeyInput, prompt: Text("sk-...").foregroundColor(theme.textTertiary))
                         } else {
-                            SecureField("", text: $alibabaApiKeyInput, prompt: Text("sk-...").foregroundStyle(theme.textTertiary))
+                            SecureField("", text: $alibabaApiKeyInput, prompt: Text("sk-...").foregroundColor(theme.textTertiary))
                         }
                     }
                     .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
+                    .foregroundColor(theme.textPrimary)
                     .padding(.horizontal, 10)
                     .padding(.vertical, 8)
                     .background(
@@ -219,7 +215,7 @@ struct AlibabaConfigCard: View {
                     } label: {
                         Image(systemName: showAlibabaApiKey ? "eye.slash.fill" : "eye.fill")
                             .font(.system(size: 11))
-                            .foregroundStyle(theme.textSecondary)
+                            .foregroundColor(theme.textSecondary)
                             .frame(width: 28, height: 28)
                             .background(
                                 Circle()
@@ -237,7 +233,7 @@ struct AlibabaConfigCard: View {
                         .scaleEffect(0.7)
                     Text("Testing connection...")
                         .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textSecondary)
+                        .foregroundColor(theme.textSecondary)
                 }
             } else {
                 Button {
@@ -247,7 +243,7 @@ struct AlibabaConfigCard: View {
                 } label: {
                     Text("Save & Test Connection")
                         .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(.white)
+                        .foregroundColor(.white)
                         .padding(.horizontal, 12)
                         .padding(.vertical, 6)
                         .background(
@@ -261,7 +257,7 @@ struct AlibabaConfigCard: View {
             if let result = alibabaTestResult {
                 Text(result)
                     .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(result.contains("Success") ? theme.statusHealthy : theme.statusCritical)
+                    .foregroundColor(result.contains("Success") ? theme.statusHealthy : theme.statusCritical)
             }
 
             // Dashboard link
@@ -272,7 +268,7 @@ struct AlibabaConfigCard: View {
                     Image(systemName: "arrow.up.right")
                         .font(.system(size: 7, weight: .bold))
                 }
-                .foregroundStyle(theme.accentPrimary)
+                .foregroundColor(theme.accentPrimary)
             }
 
             // Delete credentials
@@ -288,7 +284,7 @@ struct AlibabaConfigCard: View {
                         Text("Remove API Key")
                             .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
                     }
-                    .foregroundStyle(theme.statusCritical)
+                    .foregroundColor(theme.statusCritical)
                 }
                 .buttonStyle(.plain)
             }

--- a/Sources/App/Views/Settings/BedrockConfigCard.swift
+++ b/Sources/App/Views/Settings/BedrockConfigCard.swift
@@ -4,9 +4,9 @@ import Infrastructure
 
 /// AWS Bedrock provider configuration card for SettingsView.
 struct BedrockConfigCard: View {
-    let monitor: QuotaMonitor
+    @ObservedObject var monitor: QuotaMonitor
 
-    @State private var settings = AppSettings.shared
+    @ObservedObject var settings = AppSettings.shared
     @Environment(\.appTheme) private var theme
 
     @State private var bedrockConfigExpanded: Bool = false
@@ -25,12 +25,11 @@ struct BedrockConfigCard: View {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("AWS PROFILE NAME")
                         .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textSecondary)
-                        .tracking(0.5)
+                        .foregroundColor(theme.textSecondary)
 
-                    TextField("", text: $awsProfileNameInput, prompt: Text("default").foregroundStyle(theme.textTertiary))
+                    TextField("", text: $awsProfileNameInput, prompt: Text("default").foregroundColor(theme.textTertiary))
                         .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textPrimary)
+                        .foregroundColor(theme.textPrimary)
                         .padding(.horizontal, 10)
                         .padding(.vertical, 8)
                         .background(
@@ -41,7 +40,7 @@ struct BedrockConfigCard: View {
                                         .stroke(theme.glassBorder, lineWidth: 1)
                                 )
                         )
-                        .onChange(of: awsProfileNameInput) { _, newValue in
+                        .onChange(of: awsProfileNameInput) { newValue in
                             settings.bedrock.setAWSProfileName(newValue)
                         }
                 }
@@ -50,12 +49,11 @@ struct BedrockConfigCard: View {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("REGIONS (COMMA-SEPARATED)")
                         .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textSecondary)
-                        .tracking(0.5)
+                        .foregroundColor(theme.textSecondary)
 
-                    TextField("", text: $bedrockRegionsInput, prompt: Text("us-east-1, us-west-2").foregroundStyle(theme.textTertiary))
+                    TextField("", text: $bedrockRegionsInput, prompt: Text("us-east-1, us-west-2").foregroundColor(theme.textTertiary))
                         .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textPrimary)
+                        .foregroundColor(theme.textPrimary)
                         .padding(.horizontal, 10)
                         .padding(.vertical, 8)
                         .background(
@@ -66,7 +64,7 @@ struct BedrockConfigCard: View {
                                         .stroke(theme.glassBorder, lineWidth: 1)
                                 )
                         )
-                        .onChange(of: bedrockRegionsInput) { _, newValue in
+                        .onChange(of: bedrockRegionsInput) { newValue in
                             let regions = newValue.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
                             settings.bedrock.setBedrockRegions(regions)
                         }
@@ -76,17 +74,16 @@ struct BedrockConfigCard: View {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("DAILY BUDGET (USD, OPTIONAL)")
                         .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textSecondary)
-                        .tracking(0.5)
+                        .foregroundColor(theme.textSecondary)
 
                     HStack(spacing: 6) {
                         Text("$")
                             .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
-                            .foregroundStyle(theme.textSecondary)
+                            .foregroundColor(theme.textSecondary)
 
-                        TextField("", text: $bedrockDailyBudgetInput, prompt: Text("50.00").foregroundStyle(theme.textTertiary))
+                        TextField("", text: $bedrockDailyBudgetInput, prompt: Text("50.00").foregroundColor(theme.textTertiary))
                             .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
-                            .foregroundStyle(theme.textPrimary)
+                            .foregroundColor(theme.textPrimary)
                             .padding(.horizontal, 10)
                             .padding(.vertical, 8)
                             .background(
@@ -97,7 +94,7 @@ struct BedrockConfigCard: View {
                                             .stroke(theme.glassBorder, lineWidth: 1)
                                     )
                             )
-                            .onChange(of: bedrockDailyBudgetInput) { _, newValue in
+                            .onChange(of: bedrockDailyBudgetInput) { newValue in
                                 if newValue.isEmpty {
                                     settings.bedrock.setBedrockDailyBudget(nil)
                                 } else if let value = Decimal(string: newValue) {
@@ -111,11 +108,11 @@ struct BedrockConfigCard: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("AWS credentials are loaded from your configured profile.")
                         .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textTertiary)
+                        .foregroundColor(theme.textTertiary)
 
                     Text("Configure with: aws configure --profile <name>")
                         .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textTertiary)
+                        .foregroundColor(theme.textTertiary)
                 }
 
                 // Link to AWS console
@@ -126,7 +123,7 @@ struct BedrockConfigCard: View {
                         Image(systemName: "arrow.up.right")
                             .font(.system(size: 7, weight: .bold))
                     }
-                    .foregroundStyle(theme.accentPrimary)
+                    .foregroundColor(theme.accentPrimary)
                 }
             }
         } label: {
@@ -147,17 +144,17 @@ struct BedrockConfigCard: View {
 
                     Image(systemName: "mountain.2.fill")
                         .font(.system(size: 12, weight: .bold))
-                        .foregroundStyle(.white)
+                        .foregroundColor(.white)
                 }
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text("AWS Bedrock Configuration")
                         .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textPrimary)
+                        .foregroundColor(theme.textPrimary)
 
                     Text("CloudWatch usage tracking")
                         .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textTertiary)
+                        .foregroundColor(theme.textTertiary)
                 }
 
                 Spacer()

--- a/Sources/App/Views/Settings/ClaudeConfigCard.swift
+++ b/Sources/App/Views/Settings/ClaudeConfigCard.swift
@@ -4,9 +4,9 @@ import Infrastructure
 
 /// Claude provider configuration card for SettingsView.
 struct ClaudeConfigCard: View {
-    let monitor: QuotaMonitor
+    @ObservedObject var monitor: QuotaMonitor
 
-    @State private var settings = AppSettings.shared
+    @ObservedObject var settings = AppSettings.shared
     @Environment(\.appTheme) private var theme
 
     @State private var claudeConfigExpanded: Bool = false
@@ -85,17 +85,17 @@ struct ClaudeConfigCard: View {
 
                 Image(systemName: "gear")
                     .font(.system(size: 12, weight: .bold))
-                    .foregroundStyle(.white)
+                    .foregroundColor(.white)
             }
 
             VStack(alignment: .leading, spacing: 2) {
                 Text("Claude Configuration")
                     .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
+                    .foregroundColor(theme.textPrimary)
 
                 Text("Data fetching method")
                     .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
             }
 
             Spacer()
@@ -107,8 +107,7 @@ struct ClaudeConfigCard: View {
             VStack(alignment: .leading, spacing: 6) {
                 Text("PROBE MODE")
                     .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textSecondary)
-                    .tracking(0.5)
+                    .foregroundColor(theme.textSecondary)
 
                 Picker("", selection: $claudeProbeMode) {
                     ForEach(ClaudeProbeMode.allCases, id: \.self) { mode in
@@ -116,7 +115,7 @@ struct ClaudeConfigCard: View {
                     }
                 }
                 .pickerStyle(.segmented)
-                .onChange(of: claudeProbeMode) { _, newValue in
+                .onChange(of: claudeProbeMode) { newValue in
                     settings.claude.setClaudeProbeMode(newValue)
                     Task {
                         await monitor.refresh(providerId: "claude")
@@ -128,34 +127,34 @@ struct ClaudeConfigCard: View {
                 HStack(alignment: .top, spacing: 8) {
                     Image(systemName: "terminal")
                         .font(.system(size: 10))
-                        .foregroundStyle(claudeProbeMode == .cli ? theme.accentPrimary : theme.textTertiary)
+                        .foregroundColor(claudeProbeMode == .cli ? theme.accentPrimary : theme.textTertiary)
                         .frame(width: 16)
 
                     VStack(alignment: .leading, spacing: 2) {
                         Text("CLI Mode")
                             .font(.system(size: 10, weight: .semibold, design: theme.fontDesign))
-                            .foregroundStyle(claudeProbeMode == .cli ? theme.textPrimary : theme.textSecondary)
+                            .foregroundColor(claudeProbeMode == .cli ? theme.textPrimary : theme.textSecondary)
 
                         Text("Runs `claude /usage` command. Works with any auth method.")
                             .font(.system(size: 9, weight: .medium, design: theme.fontDesign))
-                            .foregroundStyle(theme.textTertiary)
+                            .foregroundColor(theme.textTertiary)
                     }
                 }
 
                 HStack(alignment: .top, spacing: 8) {
                     Image(systemName: "network")
                         .font(.system(size: 10))
-                        .foregroundStyle(claudeProbeMode == .api ? theme.accentPrimary : theme.textTertiary)
+                        .foregroundColor(claudeProbeMode == .api ? theme.accentPrimary : theme.textTertiary)
                         .frame(width: 16)
 
                     VStack(alignment: .leading, spacing: 2) {
                         Text("API Mode")
                             .font(.system(size: 10, weight: .semibold, design: theme.fontDesign))
-                            .foregroundStyle(claudeProbeMode == .api ? theme.textPrimary : theme.textSecondary)
+                            .foregroundColor(claudeProbeMode == .api ? theme.textPrimary : theme.textSecondary)
 
                         Text("Calls Anthropic API directly. Faster, uses OAuth credentials.")
                             .font(.system(size: 9, weight: .medium, design: theme.fontDesign))
-                            .foregroundStyle(theme.textTertiary)
+                            .foregroundColor(theme.textTertiary)
                     }
                 }
             }
@@ -167,32 +166,32 @@ struct ClaudeConfigCard: View {
                 HStack(spacing: 6) {
                     Image(systemName: hasCredentials ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
                         .font(.system(size: 10))
-                        .foregroundStyle(hasCredentials ? theme.statusHealthy : theme.statusWarning)
+                        .foregroundColor(hasCredentials ? theme.statusHealthy : theme.statusWarning)
 
                     Text(hasCredentials ? "OAuth credentials found" : "No OAuth credentials found")
                         .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                        .foregroundStyle(hasCredentials ? theme.statusHealthy : theme.statusWarning)
+                        .foregroundColor(hasCredentials ? theme.statusHealthy : theme.statusWarning)
                 }
 
                 if !hasCredentials {
                     Text("Run `claude` in terminal to authenticate, then credentials will be available.")
                         .font(.system(size: 9, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textTertiary)
+                        .foregroundColor(theme.textTertiary)
                 }
 
                 Toggle(isOn: $claudeCliFallbackEnabled) {
                     VStack(alignment: .leading, spacing: 2) {
                         Text("CLI fallback")
                             .font(.system(size: 10, weight: .semibold, design: theme.fontDesign))
-                            .foregroundStyle(theme.textPrimary)
+                            .foregroundColor(theme.textPrimary)
                         Text("Fall back to `claude /usage` if OAuth API is unavailable.")
                             .font(.system(size: 9, weight: .medium, design: theme.fontDesign))
-                            .foregroundStyle(theme.textTertiary)
+                            .foregroundColor(theme.textTertiary)
                     }
                 }
                 .toggleStyle(.switch)
                 .tint(theme.accentPrimary)
-                .onChange(of: claudeCliFallbackEnabled) { _, newValue in
+                .onChange(of: claudeCliFallbackEnabled) { newValue in
                     settings.claude.setClaudeCliFallbackEnabled(newValue)
                 }
             }
@@ -257,17 +256,17 @@ struct ClaudeConfigCard: View {
 
                 Image(systemName: "dollarsign.circle.fill")
                     .font(.system(size: 12, weight: .bold))
-                    .foregroundStyle(.white)
+                    .foregroundColor(.white)
             }
 
             VStack(alignment: .leading, spacing: 2) {
                 Text("Claude API Budget")
                     .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
+                    .foregroundColor(theme.textPrimary)
 
                 Text("Cost threshold warnings")
                     .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
             }
 
             Spacer()
@@ -285,17 +284,16 @@ struct ClaudeConfigCard: View {
             VStack(alignment: .leading, spacing: 6) {
                 Text("MONTHLY BUDGET (USD)")
                     .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textSecondary)
-                    .tracking(0.5)
+                    .foregroundColor(theme.textSecondary)
 
                 HStack(spacing: 6) {
                     Text("$")
                         .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textSecondary)
+                        .foregroundColor(theme.textSecondary)
 
-                    TextField("", text: $budgetInput, prompt: Text("10.00").foregroundStyle(theme.textTertiary))
+                    TextField("", text: $budgetInput, prompt: Text("10.00").foregroundColor(theme.textTertiary))
                         .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textPrimary)
+                        .foregroundColor(theme.textPrimary)
                         .padding(.horizontal, 10)
                         .padding(.vertical, 8)
                         .background(
@@ -306,7 +304,7 @@ struct ClaudeConfigCard: View {
                                         .stroke(theme.glassBorder, lineWidth: 1)
                                 )
                         )
-                        .onChange(of: budgetInput) { _, newValue in
+                        .onChange(of: budgetInput) { newValue in
                             if let value = Decimal(string: newValue) {
                                 settings.claudeApiBudget = value
                             }
@@ -317,11 +315,11 @@ struct ClaudeConfigCard: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text("Get warnings when approaching your budget threshold.")
                     .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
 
                 Text("Only applies to Claude API accounts, not Claude Max.")
                     .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
             }
         }
     }

--- a/Sources/App/Views/Settings/CodexConfigCard.swift
+++ b/Sources/App/Views/Settings/CodexConfigCard.swift
@@ -4,9 +4,9 @@ import Infrastructure
 
 /// Codex provider configuration card for SettingsView.
 struct CodexConfigCard: View {
-    let monitor: QuotaMonitor
+    @ObservedObject var monitor: QuotaMonitor
 
-    @State private var settings = AppSettings.shared
+    @ObservedObject var settings = AppSettings.shared
     @Environment(\.appTheme) private var theme
 
     @State private var codexConfigExpanded: Bool = false
@@ -66,17 +66,17 @@ struct CodexConfigCard: View {
 
                 Image(systemName: "terminal")
                     .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(theme.accentPrimary)
+                    .foregroundColor(theme.accentPrimary)
             }
 
             VStack(alignment: .leading, spacing: 2) {
                 Text("Codex Configuration")
                     .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
+                    .foregroundColor(theme.textPrimary)
 
                 Text("Data fetching method")
                     .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
             }
 
             Spacer()
@@ -88,8 +88,7 @@ struct CodexConfigCard: View {
             VStack(alignment: .leading, spacing: 6) {
                 Text("PROBE MODE")
                     .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textSecondary)
-                    .tracking(0.5)
+                    .foregroundColor(theme.textSecondary)
 
                 Picker("", selection: $codexProbeMode) {
                     ForEach(CodexProbeMode.allCases, id: \.self) { mode in
@@ -97,7 +96,7 @@ struct CodexConfigCard: View {
                     }
                 }
                 .pickerStyle(.segmented)
-                .onChange(of: codexProbeMode) { _, newValue in
+                .onChange(of: codexProbeMode) { newValue in
                     settings.codex.setCodexProbeMode(newValue)
                     Task {
                         await monitor.refresh(providerId: "codex")
@@ -109,34 +108,34 @@ struct CodexConfigCard: View {
                 HStack(alignment: .top, spacing: 8) {
                     Image(systemName: "terminal")
                         .font(.system(size: 10))
-                        .foregroundStyle(codexProbeMode == .rpc ? theme.accentPrimary : theme.textTertiary)
+                        .foregroundColor(codexProbeMode == .rpc ? theme.accentPrimary : theme.textTertiary)
                         .frame(width: 16)
 
                     VStack(alignment: .leading, spacing: 2) {
                         Text("RPC Mode")
                             .font(.system(size: 10, weight: .semibold, design: theme.fontDesign))
-                            .foregroundStyle(codexProbeMode == .rpc ? theme.textPrimary : theme.textSecondary)
+                            .foregroundColor(codexProbeMode == .rpc ? theme.textPrimary : theme.textSecondary)
 
                         Text("Uses codex app-server via JSON-RPC. Default, works with any auth.")
                             .font(.system(size: 9, weight: .medium, design: theme.fontDesign))
-                            .foregroundStyle(theme.textTertiary)
+                            .foregroundColor(theme.textTertiary)
                     }
                 }
 
                 HStack(alignment: .top, spacing: 8) {
                     Image(systemName: "network")
                         .font(.system(size: 10))
-                        .foregroundStyle(codexProbeMode == .api ? theme.accentPrimary : theme.textTertiary)
+                        .foregroundColor(codexProbeMode == .api ? theme.accentPrimary : theme.textTertiary)
                         .frame(width: 16)
 
                     VStack(alignment: .leading, spacing: 2) {
                         Text("API Mode")
                             .font(.system(size: 10, weight: .semibold, design: theme.fontDesign))
-                            .foregroundStyle(codexProbeMode == .api ? theme.textPrimary : theme.textSecondary)
+                            .foregroundColor(codexProbeMode == .api ? theme.textPrimary : theme.textSecondary)
 
                         Text("Calls ChatGPT API directly. Faster, uses OAuth credentials.")
                             .font(.system(size: 9, weight: .medium, design: theme.fontDesign))
-                            .foregroundStyle(theme.textTertiary)
+                            .foregroundColor(theme.textTertiary)
                     }
                 }
             }
@@ -148,17 +147,17 @@ struct CodexConfigCard: View {
                 HStack(spacing: 6) {
                     Image(systemName: hasCredentials ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
                         .font(.system(size: 10))
-                        .foregroundStyle(hasCredentials ? theme.statusHealthy : theme.statusWarning)
+                        .foregroundColor(hasCredentials ? theme.statusHealthy : theme.statusWarning)
 
                     Text(hasCredentials ? "OAuth credentials found" : "No OAuth credentials found")
                         .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                        .foregroundStyle(hasCredentials ? theme.statusHealthy : theme.statusWarning)
+                        .foregroundColor(hasCredentials ? theme.statusHealthy : theme.statusWarning)
                 }
 
                 if !hasCredentials {
                     Text("Run `codex` in terminal to authenticate, then credentials will be available.")
                         .font(.system(size: 9, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textTertiary)
+                        .foregroundColor(theme.textTertiary)
                 }
             }
         }

--- a/Sources/App/Views/Settings/CopilotConfigCard.swift
+++ b/Sources/App/Views/Settings/CopilotConfigCard.swift
@@ -4,9 +4,9 @@ import Infrastructure
 
 /// GitHub Copilot provider configuration card for SettingsView.
 struct CopilotConfigCard: View {
-    let monitor: QuotaMonitor
+    @ObservedObject var monitor: QuotaMonitor
 
-    @State private var settings = AppSettings.shared
+    @ObservedObject var settings = AppSettings.shared
     @Environment(\.appTheme) private var theme
 
     // Token input state
@@ -105,17 +105,17 @@ struct CopilotConfigCard: View {
 
                 Image(systemName: "chevron.left.forwardslash.chevron.right")
                     .font(.system(size: 12, weight: .bold))
-                    .foregroundStyle(.white)
+                    .foregroundColor(.white)
             }
 
             VStack(alignment: .leading, spacing: 2) {
                 Text("GitHub Copilot Configuration")
                     .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
+                    .foregroundColor(theme.textPrimary)
 
                 Text("Premium usage tracking")
                     .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
             }
 
             Spacer()
@@ -128,8 +128,7 @@ struct CopilotConfigCard: View {
             VStack(alignment: .leading, spacing: 6) {
                 Text("PROBE MODE")
                     .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textSecondary)
-                    .tracking(0.5)
+                    .foregroundColor(theme.textSecondary)
 
                 Picker("", selection: $copilotProbeMode) {
                     ForEach(CopilotProbeMode.allCases, id: \.self) { mode in
@@ -137,7 +136,7 @@ struct CopilotConfigCard: View {
                     }
                 }
                 .pickerStyle(.segmented)
-                .onChange(of: copilotProbeMode) { _, newValue in
+                .onChange(of: copilotProbeMode) { newValue in
                     settings.copilot.setCopilotProbeMode(newValue)
                     AppLog.probes.info("Copilot probe mode changed to \(newValue.rawValue)")
                     Task {
@@ -151,34 +150,34 @@ struct CopilotConfigCard: View {
                 HStack(alignment: .top, spacing: 8) {
                     Image(systemName: "creditcard")
                         .font(.system(size: 10))
-                        .foregroundStyle(copilotProbeMode == .billing ? theme.accentPrimary : theme.textTertiary)
+                        .foregroundColor(copilotProbeMode == .billing ? theme.accentPrimary : theme.textTertiary)
                         .frame(width: 16)
 
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Billing Mode")
                             .font(.system(size: 10, weight: .semibold, design: theme.fontDesign))
-                            .foregroundStyle(copilotProbeMode == .billing ? theme.textPrimary : theme.textSecondary)
+                            .foregroundColor(copilotProbeMode == .billing ? theme.textPrimary : theme.textSecondary)
 
                         Text("Uses GitHub Billing API. Requires fine-grained PAT with 'Plan: read'.")
                             .font(.system(size: 9, weight: .medium, design: theme.fontDesign))
-                            .foregroundStyle(theme.textTertiary)
+                            .foregroundColor(theme.textTertiary)
                     }
                 }
 
                 HStack(alignment: .top, spacing: 8) {
                     Image(systemName: "network")
                         .font(.system(size: 10))
-                        .foregroundStyle(copilotProbeMode == .copilotAPI ? theme.accentPrimary : theme.textTertiary)
+                        .foregroundColor(copilotProbeMode == .copilotAPI ? theme.accentPrimary : theme.textTertiary)
                         .frame(width: 16)
 
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Copilot API Mode")
                             .font(.system(size: 10, weight: .semibold, design: theme.fontDesign))
-                            .foregroundStyle(copilotProbeMode == .copilotAPI ? theme.textPrimary : theme.textSecondary)
+                            .foregroundColor(copilotProbeMode == .copilotAPI ? theme.textPrimary : theme.textSecondary)
 
                         Text("Uses Copilot Internal API. Works for all plans (incl. Business/Enterprise). Requires Classic PAT with 'copilot' scope.")
                             .font(.system(size: 9, weight: .medium, design: theme.fontDesign))
-                            .foregroundStyle(theme.textTertiary)
+                            .foregroundColor(theme.textTertiary)
                     }
                 }
             }
@@ -188,12 +187,11 @@ struct CopilotConfigCard: View {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("GITHUB USERNAME")
                         .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textSecondary)
-                        .tracking(0.5)
+                        .foregroundColor(theme.textSecondary)
 
-                    TextField("", text: copilotUsernameBinding, prompt: Text("username").foregroundStyle(theme.textTertiary))
+                    TextField("", text: copilotUsernameBinding, prompt: Text("username").foregroundColor(theme.textTertiary))
                         .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textPrimary)
+                        .foregroundColor(theme.textPrimary)
                         .padding(.horizontal, 10)
                         .padding(.vertical, 8)
                         .background(
@@ -212,8 +210,7 @@ struct CopilotConfigCard: View {
                 HStack {
                     Text("PERSONAL ACCESS TOKEN")
                         .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textSecondary)
-                        .tracking(0.5)
+                        .foregroundColor(theme.textSecondary)
 
                     Spacer()
 
@@ -224,20 +221,20 @@ struct CopilotConfigCard: View {
                             Text("Configured")
                                 .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
                         }
-                        .foregroundStyle(theme.statusHealthy)
+                        .foregroundColor(theme.statusHealthy)
                     }
                 }
 
                 HStack(spacing: 6) {
                     Group {
                         if showToken {
-                            TextField("", text: $copilotTokenInput, prompt: Text("ghp_xxxx...").foregroundStyle(theme.textTertiary))
+                            TextField("", text: $copilotTokenInput, prompt: Text("ghp_xxxx...").foregroundColor(theme.textTertiary))
                         } else {
-                            SecureField("", text: $copilotTokenInput, prompt: Text("ghp_xxxx...").foregroundStyle(theme.textTertiary))
+                            SecureField("", text: $copilotTokenInput, prompt: Text("ghp_xxxx...").foregroundColor(theme.textTertiary))
                         }
                     }
                     .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
+                    .foregroundColor(theme.textPrimary)
                     .padding(.horizontal, 10)
                     .padding(.vertical, 8)
                     .background(
@@ -254,7 +251,7 @@ struct CopilotConfigCard: View {
                     } label: {
                         Image(systemName: showToken ? "eye.slash.fill" : "eye.fill")
                             .font(.system(size: 11))
-                            .foregroundStyle(theme.textSecondary)
+                            .foregroundColor(theme.textSecondary)
                             .frame(width: 28, height: 28)
                             .background(
                                 Circle()
@@ -271,7 +268,7 @@ struct CopilotConfigCard: View {
                         Text(error)
                             .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
                     }
-                    .foregroundStyle(theme.statusCritical)
+                    .foregroundColor(theme.statusCritical)
                 } else if saveSuccess {
                     HStack(spacing: 4) {
                         Image(systemName: "checkmark.circle.fill")
@@ -279,7 +276,7 @@ struct CopilotConfigCard: View {
                         Text("Token saved!")
                             .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
                     }
-                    .foregroundStyle(theme.statusHealthy)
+                    .foregroundColor(theme.statusHealthy)
                 }
             }
 
@@ -287,12 +284,11 @@ struct CopilotConfigCard: View {
             VStack(alignment: .leading, spacing: 6) {
                 Text("AUTH TOKEN ENV VAR (ALTERNATIVE)")
                     .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textSecondary)
-                    .tracking(0.5)
+                    .foregroundColor(theme.textSecondary)
 
-                TextField("", text: $copilotAuthEnvVarInput, prompt: Text("GITHUB_TOKEN").foregroundStyle(theme.textTertiary))
+                TextField("", text: $copilotAuthEnvVarInput, prompt: Text("GITHUB_TOKEN").foregroundColor(theme.textTertiary))
                     .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
+                    .foregroundColor(theme.textPrimary)
                     .padding(.horizontal, 10)
                     .padding(.vertical, 8)
                     .background(
@@ -303,7 +299,7 @@ struct CopilotConfigCard: View {
                                     .stroke(theme.glassBorder, lineWidth: 1)
                             )
                     )
-                    .onChange(of: copilotAuthEnvVarInput) { _, newValue in
+                    .onChange(of: copilotAuthEnvVarInput) { newValue in
                         settings.copilot.setCopilotAuthEnvVar(newValue)
                     }
             }
@@ -314,8 +310,7 @@ struct CopilotConfigCard: View {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("MONTHLY PREMIUM REQUEST LIMIT")
                         .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textSecondary)
-                        .tracking(0.5)
+                        .foregroundColor(theme.textSecondary)
 
                     Picker("", selection: $copilotMonthlyLimit) {
                         Text("Free/Pro (50)").tag(50)
@@ -325,7 +320,7 @@ struct CopilotConfigCard: View {
                     }
                     .pickerStyle(.menu)
                     .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
+                    .foregroundColor(theme.textPrimary)
                     .padding(.horizontal, 10)
                     .padding(.vertical, 6)
                     .background(
@@ -336,13 +331,13 @@ struct CopilotConfigCard: View {
                                     .stroke(theme.glassBorder, lineWidth: 1)
                             )
                     )
-                    .onChange(of: copilotMonthlyLimit) { _, newValue in
+                    .onChange(of: copilotMonthlyLimit) { newValue in
                         settings.copilot.setCopilotMonthlyLimit(newValue)
                     }
 
                     Text("Note: This is for premium requests (Copilot Chat with advanced models), not code completions")
                         .font(.system(size: 9, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textTertiary)
+                        .foregroundColor(theme.textTertiary)
                 }
 
                 // Warning banner for org-based subscriptions
@@ -351,15 +346,15 @@ struct CopilotConfigCard: View {
                         HStack(spacing: 6) {
                             Image(systemName: "exclamationmark.triangle.fill")
                                 .font(.system(size: 10))
-                                .foregroundStyle(theme.statusWarning)
+                                .foregroundColor(theme.statusWarning)
                             Text("API returned no usage data")
                                 .font(.system(size: 10, weight: .semibold, design: theme.fontDesign))
-                                .foregroundStyle(theme.textPrimary)
+                                .foregroundColor(theme.textPrimary)
                         }
 
                         Text("This is common for Copilot Business subscriptions. Try switching to Copilot API mode.")
                             .font(.system(size: 9, weight: .medium, design: theme.fontDesign))
-                            .foregroundStyle(theme.textSecondary)
+                            .foregroundColor(theme.textSecondary)
 
                         Link(destination: URL(string: "https://github.com/settings/copilot/features")!) {
                             HStack(spacing: 4) {
@@ -368,7 +363,7 @@ struct CopilotConfigCard: View {
                                 Image(systemName: "arrow.up.right")
                                     .font(.system(size: 8))
                             }
-                            .foregroundStyle(theme.accentPrimary)
+                            .foregroundColor(theme.accentPrimary)
                         }
                     }
                     .padding(10)
@@ -385,9 +380,9 @@ struct CopilotConfigCard: View {
                 // Manual override toggle
                 Toggle("Enable manual usage entry", isOn: $copilotManualOverrideEnabled)
                     .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
+                    .foregroundColor(theme.textPrimary)
                     .toggleStyle(.switch)
-                    .onChange(of: copilotManualOverrideEnabled) { _, newValue in
+                    .onChange(of: copilotManualOverrideEnabled) { newValue in
                         settings.copilot.setCopilotManualOverrideEnabled(newValue)
                     }
 
@@ -396,12 +391,11 @@ struct CopilotConfigCard: View {
                     VStack(alignment: .leading, spacing: 6) {
                         Text("CURRENT PREMIUM REQUEST USAGE")
                             .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                            .foregroundStyle(theme.textSecondary)
-                            .tracking(0.5)
+                            .foregroundColor(theme.textSecondary)
 
-                        TextField("", text: $copilotManualUsageInput, prompt: Text("99 or 198%").foregroundStyle(theme.textTertiary))
+                        TextField("", text: $copilotManualUsageInput, prompt: Text("99 or 198%").foregroundColor(theme.textTertiary))
                             .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
-                            .foregroundStyle(theme.textPrimary)
+                            .foregroundColor(theme.textPrimary)
                             .padding(.horizontal, 10)
                             .padding(.vertical, 8)
                             .background(
@@ -415,7 +409,7 @@ struct CopilotConfigCard: View {
                                             )
                                     )
                             )
-                            .onChange(of: copilotManualUsageInput) { _, newValue in
+                            .onChange(of: copilotManualUsageInput) { newValue in
                                 let trimmed = newValue.trimmingCharacters(in: .whitespaces)
 
                                 if trimmed.isEmpty {
@@ -444,11 +438,11 @@ struct CopilotConfigCard: View {
                         if let error = copilotManualUsageInputError {
                             Text(error)
                                 .font(.system(size: 9, weight: .medium, design: theme.fontDesign))
-                                .foregroundStyle(.red)
+                                .foregroundColor(.red)
                         } else {
                             Text("Enter request count (e.g., 99) or percentage (e.g., 198%)")
                                 .font(.system(size: 9, weight: .medium, design: theme.fontDesign))
-                                .foregroundStyle(theme.textTertiary)
+                                .foregroundColor(theme.textTertiary)
                         }
                     }
                 }
@@ -458,15 +452,14 @@ struct CopilotConfigCard: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text("TOKEN LOOKUP ORDER")
                     .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textSecondary)
-                    .tracking(0.5)
+                    .foregroundColor(theme.textSecondary)
 
                 Text("1. First checks environment variable if specified")
                     .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
                 Text("2. Falls back to direct token entry above")
                     .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
             }
 
             // Save & Test button
@@ -476,7 +469,7 @@ struct CopilotConfigCard: View {
                         .scaleEffect(0.7)
                     Text("Testing connection...")
                         .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textSecondary)
+                        .foregroundColor(theme.textSecondary)
                 }
             } else {
                 Button {
@@ -486,7 +479,7 @@ struct CopilotConfigCard: View {
                 } label: {
                     Text("Save & Test Connection")
                         .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(.white)
+                        .foregroundColor(.white)
                         .padding(.horizontal, 12)
                         .padding(.vertical, 6)
                         .background(
@@ -500,7 +493,7 @@ struct CopilotConfigCard: View {
             if let result = copilotTestResult {
                 Text(result)
                     .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(result.contains("Success") ? theme.statusHealthy : theme.statusCritical)
+                    .foregroundColor(result.contains("Success") ? theme.statusHealthy : theme.statusCritical)
             }
 
             // Help text and link
@@ -508,7 +501,7 @@ struct CopilotConfigCard: View {
                 if copilotProbeMode == .billing {
                     Text("Create a fine-grained PAT with 'Plan: read' permission")
                         .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textTertiary)
+                        .foregroundColor(theme.textTertiary)
 
                     Link(destination: URL(string: "https://github.com/settings/tokens?type=beta")!) {
                         HStack(spacing: 3) {
@@ -517,12 +510,12 @@ struct CopilotConfigCard: View {
                             Image(systemName: "arrow.up.right")
                                 .font(.system(size: 7, weight: .bold))
                         }
-                        .foregroundStyle(theme.accentPrimary)
+                        .foregroundColor(theme.accentPrimary)
                     }
                 } else {
                     Text("Create a Classic PAT with 'copilot' scope")
                         .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textTertiary)
+                        .foregroundColor(theme.textTertiary)
 
                     Link(destination: URL(string: "https://github.com/settings/tokens/new")!) {
                         HStack(spacing: 3) {
@@ -531,7 +524,7 @@ struct CopilotConfigCard: View {
                             Image(systemName: "arrow.up.right")
                                 .font(.system(size: 7, weight: .bold))
                         }
-                        .foregroundStyle(theme.accentPrimary)
+                        .foregroundColor(theme.accentPrimary)
                     }
                 }
             }
@@ -547,7 +540,7 @@ struct CopilotConfigCard: View {
                         Text("Remove Token")
                             .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
                     }
-                    .foregroundStyle(theme.statusCritical)
+                    .foregroundColor(theme.statusCritical)
                 }
                 .buttonStyle(.plain)
             }

--- a/Sources/App/Views/Settings/CustomCardURLField.swift
+++ b/Sources/App/Views/Settings/CustomCardURLField.swift
@@ -6,7 +6,7 @@ import Domain
 struct CustomCardURLField: View {
     let providerId: String
 
-    @State private var settings = AppSettings.shared
+    @ObservedObject var settings = AppSettings.shared
     @Environment(\.appTheme) private var theme
 
     @State private var urlText: String = ""
@@ -17,12 +17,11 @@ struct CustomCardURLField: View {
             HStack(spacing: 6) {
                 Image(systemName: "globe")
                     .font(.system(size: 9))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
 
                 Text("CUSTOM CARD")
                     .font(.system(size: 8, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
-                    .tracking(0.5)
+                    .foregroundColor(theme.textTertiary)
 
                 Spacer()
 
@@ -33,7 +32,7 @@ struct CustomCardURLField: View {
                     } label: {
                         Image(systemName: "xmark.circle.fill")
                             .font(.system(size: 10))
-                            .foregroundStyle(theme.textTertiary)
+                            .foregroundColor(theme.textTertiary)
                     }
                     .buttonStyle(.plain)
                 }
@@ -42,7 +41,7 @@ struct CustomCardURLField: View {
             TextField("https://example.com", text: $urlText)
                 .textFieldStyle(.plain)
                 .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                .foregroundStyle(theme.textPrimary)
+                .foregroundColor(theme.textPrimary)
                 .padding(6)
                 .background(
                     RoundedRectangle(cornerRadius: 6)
@@ -55,7 +54,7 @@ struct CustomCardURLField: View {
                 .onSubmit {
                     saveURL()
                 }
-                .onChange(of: urlText) { _, _ in
+                .onChange(of: urlText) { _ in
                     saveURL()
                 }
         }

--- a/Sources/App/Views/Settings/ExtensionConfigCard.swift
+++ b/Sources/App/Views/Settings/ExtensionConfigCard.swift
@@ -65,17 +65,17 @@ struct ExtensionConfigCard: View {
 
                 Image(systemName: manifest.icon ?? "puzzlepiece.extension.fill")
                     .font(.system(size: 12, weight: .bold))
-                    .foregroundStyle(.white)
+                    .foregroundColor(.white)
             }
 
             VStack(alignment: .leading, spacing: 2) {
                 Text("\(manifest.name) Configuration")
                     .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
+                    .foregroundColor(theme.textPrimary)
 
                 Text(manifest.description ?? "Extension settings")
                     .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
             }
 
             Spacer()
@@ -89,8 +89,7 @@ struct ExtensionConfigCard: View {
         VStack(alignment: .leading, spacing: 6) {
             Text(field.label.uppercased())
                 .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                .foregroundStyle(theme.textSecondary)
-                .tracking(0.5)
+                .foregroundColor(theme.textSecondary)
 
             switch field.type {
             case .string, .number, .path:
@@ -106,7 +105,7 @@ struct ExtensionConfigCard: View {
             if let helpText = field.helpText {
                 Text(helpText)
                     .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
             }
         }
     }
@@ -115,10 +114,10 @@ struct ExtensionConfigCard: View {
         TextField(
             "",
             text: binding(for: field),
-            prompt: Text(field.placeholder ?? "").foregroundStyle(theme.textTertiary)
+            prompt: Text(field.placeholder ?? "").foregroundColor(theme.textTertiary)
         )
         .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
-        .foregroundStyle(theme.textPrimary)
+        .foregroundColor(theme.textPrimary)
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
         .background(inputBackground)
@@ -131,25 +130,25 @@ struct ExtensionConfigCard: View {
                     TextField(
                         "",
                         text: binding(for: field),
-                        prompt: Text(field.placeholder ?? "").foregroundStyle(theme.textTertiary)
+                        prompt: Text(field.placeholder ?? "").foregroundColor(theme.textTertiary)
                     )
                 } else {
                     SecureField(
                         "",
                         text: binding(for: field),
-                        prompt: Text(field.placeholder ?? "").foregroundStyle(theme.textTertiary)
+                        prompt: Text(field.placeholder ?? "").foregroundColor(theme.textTertiary)
                     )
                 }
             }
             .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
-            .foregroundStyle(theme.textPrimary)
+            .foregroundColor(theme.textPrimary)
 
             Button {
                 secretVisible[field.id] = !(secretVisible[field.id] ?? false)
             } label: {
                 Image(systemName: secretVisible[field.id] == true ? "eye.slash.fill" : "eye.fill")
                     .font(.system(size: 10))
-                    .foregroundStyle(theme.textSecondary)
+                    .foregroundColor(theme.textSecondary)
             }
             .buttonStyle(.plain)
         }

--- a/Sources/App/Views/Settings/KimiConfigCard.swift
+++ b/Sources/App/Views/Settings/KimiConfigCard.swift
@@ -4,9 +4,9 @@ import Infrastructure
 
 /// Kimi provider configuration card for SettingsView.
 struct KimiConfigCard: View {
-    let monitor: QuotaMonitor
+    @ObservedObject var monitor: QuotaMonitor
 
-    @State private var settings = AppSettings.shared
+    @ObservedObject var settings = AppSettings.shared
     @Environment(\.appTheme) private var theme
 
     @State private var kimiConfigExpanded: Bool = false
@@ -66,17 +66,17 @@ struct KimiConfigCard: View {
 
                 Image(systemName: "terminal")
                     .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(theme.accentPrimary)
+                    .foregroundColor(theme.accentPrimary)
             }
 
             VStack(alignment: .leading, spacing: 2) {
                 Text("Kimi Configuration")
                     .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
+                    .foregroundColor(theme.textPrimary)
 
                 Text("Data fetching method")
                     .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
             }
 
             Spacer()
@@ -88,8 +88,7 @@ struct KimiConfigCard: View {
             VStack(alignment: .leading, spacing: 6) {
                 Text("PROBE MODE")
                     .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textSecondary)
-                    .tracking(0.5)
+                    .foregroundColor(theme.textSecondary)
 
                 Picker("", selection: $kimiProbeMode) {
                     ForEach(KimiProbeMode.allCases, id: \.self) { mode in
@@ -97,7 +96,7 @@ struct KimiConfigCard: View {
                     }
                 }
                 .pickerStyle(.segmented)
-                .onChange(of: kimiProbeMode) { _, newValue in
+                .onChange(of: kimiProbeMode) { newValue in
                     settings.kimi.setKimiProbeMode(newValue)
                     Task {
                         await monitor.refresh(providerId: "kimi")
@@ -109,34 +108,34 @@ struct KimiConfigCard: View {
                 HStack(alignment: .top, spacing: 8) {
                     Image(systemName: "terminal")
                         .font(.system(size: 10))
-                        .foregroundStyle(kimiProbeMode == .cli ? theme.accentPrimary : theme.textTertiary)
+                        .foregroundColor(kimiProbeMode == .cli ? theme.accentPrimary : theme.textTertiary)
                         .frame(width: 16)
 
                     VStack(alignment: .leading, spacing: 2) {
                         Text("CLI Mode")
                             .font(.system(size: 10, weight: .semibold, design: theme.fontDesign))
-                            .foregroundStyle(kimiProbeMode == .cli ? theme.textPrimary : theme.textSecondary)
+                            .foregroundColor(kimiProbeMode == .cli ? theme.textPrimary : theme.textSecondary)
 
                         Text("Uses kimi CLI with /usage command. Requires kimi installed.")
                             .font(.system(size: 9, weight: .medium, design: theme.fontDesign))
-                            .foregroundStyle(theme.textTertiary)
+                            .foregroundColor(theme.textTertiary)
                     }
                 }
 
                 HStack(alignment: .top, spacing: 8) {
                     Image(systemName: "network")
                         .font(.system(size: 10))
-                        .foregroundStyle(kimiProbeMode == .api ? theme.accentPrimary : theme.textTertiary)
+                        .foregroundColor(kimiProbeMode == .api ? theme.accentPrimary : theme.textTertiary)
                         .frame(width: 16)
 
                     VStack(alignment: .leading, spacing: 2) {
                         Text("API Mode")
                             .font(.system(size: 10, weight: .semibold, design: theme.fontDesign))
-                            .foregroundStyle(kimiProbeMode == .api ? theme.textPrimary : theme.textSecondary)
+                            .foregroundColor(kimiProbeMode == .api ? theme.textPrimary : theme.textSecondary)
 
                         Text("Calls Kimi API directly. Uses browser cookie authentication.")
                             .font(.system(size: 9, weight: .medium, design: theme.fontDesign))
-                            .foregroundStyle(theme.textTertiary)
+                            .foregroundColor(theme.textTertiary)
                     }
                 }
             }

--- a/Sources/App/Views/Settings/MiniMaxConfigCard.swift
+++ b/Sources/App/Views/Settings/MiniMaxConfigCard.swift
@@ -4,9 +4,9 @@ import Infrastructure
 
 /// MiniMax provider configuration card for SettingsView.
 struct MiniMaxConfigCard: View {
-    let monitor: QuotaMonitor
+    @ObservedObject var monitor: QuotaMonitor
 
-    @State private var settings = AppSettings.shared
+    @ObservedObject var settings = AppSettings.shared
     @Environment(\.appTheme) private var theme
 
     @State private var miniMaxConfigExpanded: Bool = false
@@ -75,17 +75,17 @@ struct MiniMaxConfigCard: View {
 
                 Image(systemName: "waveform")
                     .font(.system(size: 12, weight: .bold))
-                    .foregroundStyle(.white)
+                    .foregroundColor(.white)
             }
 
             VStack(alignment: .leading, spacing: 2) {
                 Text("MiniMax Configuration")
                     .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
+                    .foregroundColor(theme.textPrimary)
 
                 Text("Coding Plan quota tracking")
                     .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
             }
 
             Spacer()
@@ -98,8 +98,7 @@ struct MiniMaxConfigCard: View {
             VStack(alignment: .leading, spacing: 6) {
                 Text("REGION")
                     .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textSecondary)
-                    .tracking(0.5)
+                    .foregroundColor(theme.textSecondary)
 
                 Picker("", selection: $miniMaxRegion) {
                     ForEach(MiniMaxRegion.allCases, id: \.self) { region in
@@ -107,7 +106,7 @@ struct MiniMaxConfigCard: View {
                     }
                 }
                 .pickerStyle(.segmented)
-                .onChange(of: miniMaxRegion) { _, newValue in
+                .onChange(of: miniMaxRegion) { newValue in
                     settings.minimax.setMinimaxRegion(newValue)
                     Task {
                         await monitor.refresh(providerId: "minimax")
@@ -120,8 +119,7 @@ struct MiniMaxConfigCard: View {
                 HStack {
                     Text("API KEY")
                         .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textSecondary)
-                        .tracking(0.5)
+                        .foregroundColor(theme.textSecondary)
 
                     Spacer()
 
@@ -132,20 +130,20 @@ struct MiniMaxConfigCard: View {
                             Text("Configured")
                                 .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
                         }
-                        .foregroundStyle(theme.statusHealthy)
+                        .foregroundColor(theme.statusHealthy)
                     }
                 }
 
                 HStack(spacing: 6) {
                     Group {
                         if showMiniMaxApiKey {
-                            TextField("", text: $miniMaxApiKeyInput, prompt: Text("eyJhbGci...").foregroundStyle(theme.textTertiary))
+                            TextField("", text: $miniMaxApiKeyInput, prompt: Text("eyJhbGci...").foregroundColor(theme.textTertiary))
                         } else {
-                            SecureField("", text: $miniMaxApiKeyInput, prompt: Text("eyJhbGci...").foregroundStyle(theme.textTertiary))
+                            SecureField("", text: $miniMaxApiKeyInput, prompt: Text("eyJhbGci...").foregroundColor(theme.textTertiary))
                         }
                     }
                     .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
+                    .foregroundColor(theme.textPrimary)
                     .padding(.horizontal, 10)
                     .padding(.vertical, 8)
                     .background(
@@ -162,7 +160,7 @@ struct MiniMaxConfigCard: View {
                     } label: {
                         Image(systemName: showMiniMaxApiKey ? "eye.slash.fill" : "eye.fill")
                             .font(.system(size: 11))
-                            .foregroundStyle(theme.textSecondary)
+                            .foregroundColor(theme.textSecondary)
                             .frame(width: 28, height: 28)
                             .background(
                                 Circle()
@@ -177,12 +175,11 @@ struct MiniMaxConfigCard: View {
             VStack(alignment: .leading, spacing: 6) {
                 Text("API KEY ENV VAR (ALTERNATIVE)")
                     .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textSecondary)
-                    .tracking(0.5)
+                    .foregroundColor(theme.textSecondary)
 
-                TextField("", text: $miniMaxAuthEnvVarInput, prompt: Text("MINIMAX_API_KEY").foregroundStyle(theme.textTertiary))
+                TextField("", text: $miniMaxAuthEnvVarInput, prompt: Text("MINIMAX_API_KEY").foregroundColor(theme.textTertiary))
                     .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
+                    .foregroundColor(theme.textPrimary)
                     .padding(.horizontal, 10)
                     .padding(.vertical, 8)
                     .background(
@@ -193,7 +190,7 @@ struct MiniMaxConfigCard: View {
                                     .stroke(theme.glassBorder, lineWidth: 1)
                             )
                     )
-                    .onChange(of: miniMaxAuthEnvVarInput) { _, newValue in
+                    .onChange(of: miniMaxAuthEnvVarInput) { newValue in
                         settings.minimax.setMinimaxAuthEnvVar(newValue)
                     }
             }
@@ -202,15 +199,14 @@ struct MiniMaxConfigCard: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text("API KEY LOOKUP ORDER")
                     .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textSecondary)
-                    .tracking(0.5)
+                    .foregroundColor(theme.textSecondary)
 
                 Text("1. First checks environment variable (default: MINIMAX_API_KEY)")
                     .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
                 Text("2. Falls back to API key entered above")
                     .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
             }
 
             // Save & Test button
@@ -220,7 +216,7 @@ struct MiniMaxConfigCard: View {
                         .scaleEffect(0.7)
                     Text("Testing connection...")
                         .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textSecondary)
+                        .foregroundColor(theme.textSecondary)
                 }
             } else {
                 Button {
@@ -230,7 +226,7 @@ struct MiniMaxConfigCard: View {
                 } label: {
                     Text("Save & Test Connection")
                         .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(.white)
+                        .foregroundColor(.white)
                         .padding(.horizontal, 12)
                         .padding(.vertical, 6)
                         .background(
@@ -244,14 +240,14 @@ struct MiniMaxConfigCard: View {
             if let result = miniMaxTestResult {
                 Text(result)
                     .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(result.contains("Success") ? theme.statusHealthy : theme.statusCritical)
+                    .foregroundColor(result.contains("Success") ? theme.statusHealthy : theme.statusCritical)
             }
 
             // Help link
             VStack(alignment: .leading, spacing: 4) {
                 Text("Get your API key from MiniMax platform")
                     .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
 
                 Link(destination: miniMaxRegion.apiKeysURL) {
                     HStack(spacing: 3) {
@@ -260,7 +256,7 @@ struct MiniMaxConfigCard: View {
                         Image(systemName: "arrow.up.right")
                             .font(.system(size: 7, weight: .bold))
                     }
-                    .foregroundStyle(theme.accentPrimary)
+                    .foregroundColor(theme.accentPrimary)
                 }
             }
 
@@ -277,7 +273,7 @@ struct MiniMaxConfigCard: View {
                         Text("Remove API Key")
                             .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
                     }
-                    .foregroundStyle(theme.statusCritical)
+                    .foregroundColor(theme.statusCritical)
                 }
                 .buttonStyle(.plain)
             }

--- a/Sources/App/Views/Settings/ZaiConfigCard.swift
+++ b/Sources/App/Views/Settings/ZaiConfigCard.swift
@@ -4,9 +4,9 @@ import Infrastructure
 
 /// Z.ai / GLM provider configuration card for SettingsView.
 struct ZaiConfigCard: View {
-    let monitor: QuotaMonitor
+    @ObservedObject var monitor: QuotaMonitor
 
-    @State private var settings = AppSettings.shared
+    @ObservedObject var settings = AppSettings.shared
     @Environment(\.appTheme) private var theme
 
     @State private var zaiConfigExpanded: Bool = false
@@ -24,26 +24,24 @@ struct ZaiConfigCard: View {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("TOKEN LOOKUP ORDER")
                         .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textSecondary)
-                        .tracking(0.5)
+                        .foregroundColor(theme.textSecondary)
 
                     Text("1. First looks for token in the settings.json file")
                         .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textTertiary)
+                        .foregroundColor(theme.textTertiary)
                     Text("2. Falls back to environment variable if not found in file")
                         .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textTertiary)
+                        .foregroundColor(theme.textTertiary)
                 }
 
                 VStack(alignment: .leading, spacing: 6) {
                     Text("SETTINGS.JSON PATH")
                         .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textSecondary)
-                        .tracking(0.5)
+                        .foregroundColor(theme.textSecondary)
 
-                    TextField("", text: $zaiConfigPathInput, prompt: Text("~/.claude/settings.json").foregroundStyle(theme.textTertiary))
+                    TextField("", text: $zaiConfigPathInput, prompt: Text("~/.claude/settings.json").foregroundColor(theme.textTertiary))
                         .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textPrimary)
+                        .foregroundColor(theme.textPrimary)
                         .padding(.horizontal, 10)
                         .padding(.vertical, 8)
                         .background(
@@ -54,7 +52,7 @@ struct ZaiConfigCard: View {
                                         .stroke(theme.glassBorder, lineWidth: 1)
                                 )
                         )
-                        .onChange(of: zaiConfigPathInput) { _, newValue in
+                        .onChange(of: zaiConfigPathInput) { newValue in
                             settings.zai.setZaiConfigPath(newValue)
                         }
                 }
@@ -62,12 +60,11 @@ struct ZaiConfigCard: View {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("AUTH TOKEN ENV VAR (FALLBACK)")
                         .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textSecondary)
-                        .tracking(0.5)
+                        .foregroundColor(theme.textSecondary)
 
-                    TextField("", text: $glmAuthEnvVarInput, prompt: Text("GLM_AUTH_TOKEN").foregroundStyle(theme.textTertiary))
+                    TextField("", text: $glmAuthEnvVarInput, prompt: Text("GLM_AUTH_TOKEN").foregroundColor(theme.textTertiary))
                         .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textPrimary)
+                        .foregroundColor(theme.textPrimary)
                         .padding(.horizontal, 10)
                         .padding(.vertical, 8)
                         .background(
@@ -78,7 +75,7 @@ struct ZaiConfigCard: View {
                                         .stroke(theme.glassBorder, lineWidth: 1)
                                 )
                         )
-                        .onChange(of: glmAuthEnvVarInput) { _, newValue in
+                        .onChange(of: glmAuthEnvVarInput) { newValue in
                             settings.zai.setGlmAuthEnvVar(newValue)
                         }
                 }
@@ -86,7 +83,7 @@ struct ZaiConfigCard: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Leave both empty to use default path with no env var fallback")
                         .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textTertiary)
+                        .foregroundColor(theme.textTertiary)
                 }
             }
         } label: {
@@ -107,17 +104,17 @@ struct ZaiConfigCard: View {
 
                     Image(systemName: "gearshape.fill")
                         .font(.system(size: 12, weight: .bold))
-                        .foregroundStyle(.white)
+                        .foregroundColor(.white)
                 }
 
             VStack(alignment: .leading, spacing: 2) {
                 Text("Z.ai / GLM Configuration")
                     .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
+                    .foregroundColor(theme.textPrimary)
 
                 Text("Authentication fallback settings")
                     .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
             }
 
                 Spacer()

--- a/Sources/App/Views/SettingsView.swift
+++ b/Sources/App/Views/SettingsView.swift
@@ -8,9 +8,9 @@ import Sparkle
 /// Inline settings content view that fits within the menu bar popup.
 struct SettingsContentView: View {
     @Binding var showSettings: Bool
-    let monitor: QuotaMonitor
+    @ObservedObject var monitor: QuotaMonitor
     @Environment(\.appTheme) private var theme
-    @State private var settings = AppSettings.shared
+    @ObservedObject var settings = AppSettings.shared
 
     #if ENABLE_SPARKLE
     @Environment(\.sparkleUpdater) private var sparkleUpdater
@@ -36,6 +36,13 @@ struct SettingsContentView: View {
         static let minimax = "minimax"
         static let alibaba = "alibaba"
     }
+
+    private static let lastCheckFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .medium
+        f.timeStyle = .short
+        return f
+    }()
 
     private var isCopilotEnabled: Bool {
         monitor.provider(for: ProviderID.copilot)?.isEnabled ?? false
@@ -183,17 +190,17 @@ struct SettingsContentView: View {
 
                     Image(systemName: currentThemeMode.icon)
                         .font(.system(size: 12, weight: .bold))
-                        .foregroundStyle(theme.id == "cli" ? theme.textPrimary : .white)
+                        .foregroundColor(theme.id == "cli" ? theme.textPrimary : .white)
                 }
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Appearance")
                         .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textPrimary)
+                        .foregroundColor(theme.textPrimary)
 
                     Text("Choose your theme")
                         .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textTertiary)
+                        .foregroundColor(theme.textTertiary)
                 }
 
                 Spacer()
@@ -209,7 +216,7 @@ struct SettingsContentView: View {
                         themeProvider: registeredTheme,
                         isSelected: settings.themeMode == registeredTheme.id
                     ) {
-                        withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+                        withAnimation(.spring()) {
                             settings.themeMode = registeredTheme.id
                         }
                     }
@@ -258,17 +265,17 @@ struct SettingsContentView: View {
 
                 Image(systemName: "percent")
                     .font(.system(size: 12, weight: .bold))
-                    .foregroundStyle(theme.id == "cli" ? theme.textPrimary : .white)
+                    .foregroundColor(theme.id == "cli" ? theme.textPrimary : .white)
             }
 
             VStack(alignment: .leading, spacing: 2) {
                 Text("Quota Display")
                     .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
+                    .foregroundColor(theme.textPrimary)
 
                 Text("Show remaining or used percentage")
                     .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
             }
 
             Spacer()
@@ -282,7 +289,7 @@ struct SettingsContentView: View {
                     mode: mode,
                     isSelected: settings.usageDisplayMode == mode
                 ) {
-                    withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+                    withAnimation(.spring()) {
                         settings.usageDisplayMode = mode
                     }
                 }
@@ -294,7 +301,7 @@ struct SettingsContentView: View {
         HStack {
             Text("Daily Usage Cards")
                 .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
-                .foregroundStyle(theme.textSecondary)
+                .foregroundColor(theme.textSecondary)
 
             Spacer()
 
@@ -317,17 +324,17 @@ struct SettingsContentView: View {
 
                 Image(systemName: "square.grid.2x2")
                     .font(.system(size: 12, weight: .bold))
-                    .foregroundStyle(theme.id == "cli" ? theme.textPrimary : .white)
+                    .foregroundColor(theme.id == "cli" ? theme.textPrimary : .white)
             }
 
             VStack(alignment: .leading, spacing: 2) {
                 Text("Overview")
                     .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
+                    .foregroundColor(theme.textPrimary)
 
                 Text("Show all providers at once")
                     .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
             }
 
             Spacer()
@@ -398,17 +405,17 @@ struct SettingsContentView: View {
 
                 Image(systemName: "cpu")
                     .font(.system(size: 12, weight: .bold))
-                    .foregroundStyle(.white)
+                    .foregroundColor(.white)
             }
 
             VStack(alignment: .leading, spacing: 2) {
                 Text("Providers")
                     .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
+                    .foregroundColor(theme.textPrimary)
 
                 Text("Enable or disable AI providers")
                     .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
             }
 
             Spacer()
@@ -423,7 +430,7 @@ struct SettingsContentView: View {
 
                 Text(provider.name)
                     .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
+                    .foregroundColor(theme.textPrimary)
 
                 Spacer()
 
@@ -463,7 +470,7 @@ struct SettingsContentView: View {
                     Text("Back")
                         .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
                 }
-                .foregroundStyle(theme.textPrimary)
+                .foregroundColor(theme.textPrimary)
                 .padding(.horizontal, 10)
                 .padding(.vertical, 6)
                 .background(
@@ -481,7 +488,7 @@ struct SettingsContentView: View {
 
             Text("Settings")
                 .font(.system(size: 16, weight: .bold, design: theme.fontDesign))
-                .foregroundStyle(theme.textPrimary)
+                .foregroundColor(theme.textPrimary)
 
             Spacer()
 
@@ -514,7 +521,7 @@ struct SettingsContentView: View {
                             Text(sparkleUpdater?.isCheckingForUpdates == true ? "Checking..." : "Check for Updates")
                                 .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
                         }
-                        .foregroundStyle(.white)
+                        .foregroundColor(.white)
                         .padding(.horizontal, 14)
                         .padding(.vertical, 8)
                         .frame(maxWidth: .infinity)
@@ -541,16 +548,16 @@ struct SettingsContentView: View {
                             Image(systemName: "clock.fill")
                                 .font(.system(size: 8))
 
-                            Text("Last checked: \(lastCheck.formatted(date: .abbreviated, time: .shortened))")
+                            Text("Last checked: \(Self.lastCheckFormatter.string(from: lastCheck))")
                                 .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
                         }
-                        .foregroundStyle(theme.textTertiary)
+                        .foregroundColor(theme.textTertiary)
                     }
 
                     HStack {
                         Text("Check automatically")
                             .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
-                            .foregroundStyle(theme.textPrimary)
+                            .foregroundColor(theme.textPrimary)
 
                         Spacer()
 
@@ -568,11 +575,11 @@ struct SettingsContentView: View {
                         VStack(alignment: .leading, spacing: 2) {
                             Text("Include beta versions")
                                 .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
-                                .foregroundStyle(theme.textPrimary)
+                                .foregroundColor(theme.textPrimary)
 
                             Text("Get early access to new features")
                                 .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                                .foregroundStyle(theme.textTertiary)
+                                .foregroundColor(theme.textTertiary)
                         }
 
                         Spacer()
@@ -590,7 +597,7 @@ struct SettingsContentView: View {
                         Text("Updates unavailable in debug builds")
                             .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
                     }
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
                 }
             }
         } label: {
@@ -638,17 +645,17 @@ struct SettingsContentView: View {
 
                 Image(systemName: "arrow.down.circle.fill")
                     .font(.system(size: 12, weight: .bold))
-                    .foregroundStyle(.white)
+                    .foregroundColor(.white)
             }
 
             VStack(alignment: .leading, spacing: 2) {
                 Text("Updates")
                     .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
+                    .foregroundColor(theme.textPrimary)
 
                 Text("Version \(appVersion)")
                     .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
             }
 
             Spacer()
@@ -688,17 +695,17 @@ struct SettingsContentView: View {
 
                     Image(systemName: "doc.text.fill")
                         .font(.system(size: 12, weight: .bold))
-                        .foregroundStyle(.white)
+                        .foregroundColor(.white)
                 }
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Logs")
                         .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textPrimary)
+                        .foregroundColor(theme.textPrimary)
 
                     Text("View application logs")
                         .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textTertiary)
+                        .foregroundColor(theme.textTertiary)
                 }
 
                 Spacer()
@@ -714,7 +721,7 @@ struct SettingsContentView: View {
                     Text("Open Log File")
                         .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
                 }
-                .foregroundStyle(.white)
+                .foregroundColor(.white)
                 .padding(.horizontal, 14)
                 .padding(.vertical, 8)
                 .frame(maxWidth: .infinity)
@@ -736,7 +743,7 @@ struct SettingsContentView: View {
 
             Text("Opens ClaudeBar.log in TextEdit")
                 .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                .foregroundStyle(theme.textTertiary)
+                .foregroundColor(theme.textTertiary)
         }
         .padding(14)
         .background(
@@ -768,17 +775,17 @@ struct SettingsContentView: View {
 
                     Image(systemName: "info.circle.fill")
                         .font(.system(size: 12, weight: .bold))
-                        .foregroundStyle(.white)
+                        .foregroundColor(.white)
                 }
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text("About")
                         .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textPrimary)
+                        .foregroundColor(theme.textPrimary)
 
                     Text("Version \(appVersion) (\(appBuild))")
                         .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textTertiary)
+                        .foregroundColor(theme.textTertiary)
                 }
 
                 Spacer()
@@ -797,7 +804,7 @@ struct SettingsContentView: View {
                     Image(systemName: "arrow.up.right")
                         .font(.system(size: 9, weight: .bold))
                 }
-                .foregroundStyle(.white)
+                .foregroundColor(.white)
                 .padding(.horizontal, 14)
                 .padding(.vertical, 8)
                 .background(
@@ -818,7 +825,7 @@ struct SettingsContentView: View {
 
             Text("Report issues or contribute on GitHub")
                 .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                .foregroundStyle(theme.textTertiary)
+                .foregroundColor(theme.textTertiary)
         }
         .padding(14)
         .background(
@@ -858,17 +865,17 @@ struct SettingsContentView: View {
 
                 Image(systemName: "power")
                     .font(.system(size: 12, weight: .bold))
-                    .foregroundStyle(.white)
+                    .foregroundColor(.white)
             }
 
             VStack(alignment: .leading, spacing: 2) {
                 Text("Launch at Login")
                     .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
+                    .foregroundColor(theme.textPrimary)
 
                 Text("Start ClaudeBar when you log in")
                     .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
             }
 
             Spacer()
@@ -902,8 +909,7 @@ struct SettingsContentView: View {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("SYNC INTERVAL")
                         .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textSecondary)
-                        .tracking(0.5)
+                        .foregroundColor(theme.textSecondary)
 
                     Picker("", selection: $settings.backgroundSyncInterval) {
                         Text("30 seconds").tag(30.0)
@@ -917,7 +923,7 @@ struct SettingsContentView: View {
 
                 Text("Sync usage data in the background so it's always fresh when you check.")
                     .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
             }
             .opacity(settings.backgroundSyncEnabled ? 1 : 0.6)
         } label: {
@@ -958,17 +964,17 @@ struct SettingsContentView: View {
 
                 Image(systemName: "arrow.triangle.2.circlepath")
                     .font(.system(size: 12, weight: .bold))
-                    .foregroundStyle(.white)
+                    .foregroundColor(.white)
             }
 
             VStack(alignment: .leading, spacing: 2) {
                 Text("Background Sync")
                     .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
+                    .foregroundColor(theme.textPrimary)
 
                 Text("Keep data fresh automatically")
                     .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
             }
 
             Spacer()
@@ -993,17 +999,17 @@ struct SettingsContentView: View {
 
                     Image(systemName: "flame")
                         .font(.system(size: 12, weight: .bold))
-                        .foregroundStyle(theme.id == "cli" ? theme.textPrimary : .white)
+                        .foregroundColor(theme.id == "cli" ? theme.textPrimary : .white)
                 }
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Burn Rate Warnings")
                         .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textPrimary)
+                        .foregroundColor(theme.textPrimary)
 
                     Text("Warn based on consumption pace, not fixed thresholds")
                         .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textTertiary)
+                        .foregroundColor(theme.textTertiary)
                 }
 
                 Spacer()
@@ -1019,7 +1025,7 @@ struct SettingsContentView: View {
                 HStack {
                     Text("Threshold")
                         .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textSecondary)
+                        .foregroundColor(theme.textSecondary)
 
                     Spacer()
 
@@ -1060,18 +1066,18 @@ struct SettingsContentView: View {
                         .frame(width: 6, height: 6)
                     Text(hooksInstalled ? "Hooks installed in ~/.claude/settings.json" : "Hooks not installed")
                         .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textSecondary)
+                        .foregroundColor(theme.textSecondary)
                 }
 
                 if let hookError {
                     Text(hookError)
                         .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                        .foregroundStyle(.red)
+                        .foregroundColor(.red)
                 }
 
                 Text("Track Claude Code sessions in real-time. Shows active session status, subagent activity, and task completion.")
                     .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
             }
         } label: {
             hooksHeader
@@ -1111,17 +1117,17 @@ struct SettingsContentView: View {
 
                 Image(systemName: "antenna.radiowaves.left.and.right")
                     .font(.system(size: 12, weight: .bold))
-                    .foregroundStyle(.white)
+                    .foregroundColor(.white)
             }
 
             VStack(alignment: .leading, spacing: 2) {
                 Text("Claude Code Hooks")
                     .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textPrimary)
+                    .foregroundColor(theme.textPrimary)
 
                 Text("Live session tracking")
                     .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
             }
 
             Spacer()
@@ -1131,7 +1137,7 @@ struct SettingsContentView: View {
                 .tint(theme.accentPrimary)
                 .scaleEffect(0.8)
                 .labelsHidden()
-                .onChange(of: hooksEnabled) { _, newValue in
+                .onChange(of: hooksEnabled) { newValue in
                     hookError = nil
                     do {
                         if newValue {
@@ -1168,7 +1174,7 @@ struct SettingsContentView: View {
             } label: {
                 Text("Done")
                     .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
-                    .foregroundStyle(.white)
+                    .foregroundColor(.white)
                     .padding(.horizontal, 16)
                     .padding(.vertical, 7)
                     .background(
@@ -1206,19 +1212,19 @@ struct ThemeOptionButton: View {
 
                     Image(systemName: themeProvider.icon)
                         .font(.system(size: 11, weight: .bold))
-                        .foregroundStyle(themeProvider.id == "cli" ? Color.black : .white)
+                        .foregroundColor(themeProvider.id == "cli" ? Color.black : .white)
                 }
 
                 VStack(alignment: .leading, spacing: 1) {
                     Text(themeProvider.displayName)
                         .font(.system(size: 11, weight: .medium, design: themeProvider.fontDesign))
-                        .foregroundStyle(theme.textPrimary)
+                        .foregroundColor(theme.textPrimary)
                         .lineLimit(1)
 
                     if let subtitle = themeProvider.subtitle {
                         Text(subtitle)
                             .font(.system(size: 8, weight: .medium))
-                            .foregroundStyle(themeProvider.accentPrimary)
+                            .foregroundColor(themeProvider.accentPrimary)
                     }
                 }
 
@@ -1230,7 +1236,7 @@ struct ThemeOptionButton: View {
                     } label: {
                         Image(systemName: "xmark.circle.fill")
                             .font(.system(size: 12))
-                            .foregroundStyle(theme.textTertiary)
+                            .foregroundColor(theme.textTertiary)
                     }
                     .buttonStyle(.plain)
                 }
@@ -1238,7 +1244,7 @@ struct ThemeOptionButton: View {
                 if isSelected {
                     Image(systemName: "checkmark.circle.fill")
                         .font(.system(size: 14))
-                        .foregroundStyle(theme.statusHealthy)
+                        .foregroundColor(theme.statusHealthy)
                 }
             }
             .padding(.horizontal, 10)
@@ -1288,7 +1294,7 @@ struct DisplayModeButton: View {
             .frame(maxWidth: .infinity)
             .padding(.vertical, 8)
             .background(buttonBackground)
-            .foregroundStyle(isSelected ? theme.accentPrimary : theme.textSecondary)
+            .foregroundColor(isSelected ? theme.accentPrimary : theme.textSecondary)
         }
         .buttonStyle(.plain)
         .onHover { isHovering = $0 }
@@ -1306,20 +1312,24 @@ struct DisplayModeButton: View {
 
 // MARK: - Preview
 
-#Preview("Settings - Dark") {
-    ZStack {
-        DarkTheme().backgroundGradient
-        SettingsContentView(showSettings: .constant(true), monitor: QuotaMonitor(providers: AIProviders(providers: [])))
+struct SettingsDark_Previews: PreviewProvider {
+    static var previews: some View {
+        ZStack {
+            DarkTheme().backgroundGradient
+            SettingsContentView(showSettings: .constant(true), monitor: QuotaMonitor(providers: AIProviders(providers: [])))
+        }
+        .appThemeProvider(themeModeId: "dark")
+        .frame(width: 380, height: 420)
     }
-    .appThemeProvider(themeModeId: "dark")
-    .frame(width: 380, height: 420)
 }
 
-#Preview("Settings - Light") {
-    ZStack {
-        LightTheme().backgroundGradient
-        SettingsContentView(showSettings: .constant(true), monitor: QuotaMonitor(providers: AIProviders(providers: [])))
+struct SettingsLight_Previews: PreviewProvider {
+    static var previews: some View {
+        ZStack {
+            LightTheme().backgroundGradient
+            SettingsContentView(showSettings: .constant(true), monitor: QuotaMonitor(providers: AIProviders(providers: [])))
+        }
+        .appThemeProvider(themeModeId: "light")
+        .frame(width: 380, height: 420)
     }
-    .appThemeProvider(themeModeId: "light")
-    .frame(width: 380, height: 420)
 }

--- a/Sources/App/Views/SharePassView.swift
+++ b/Sources/App/Views/SharePassView.swift
@@ -25,11 +25,11 @@ struct SharePassOverlay: View {
                 HStack {
                     Image(systemName: "gift.fill")
                         .font(.system(size: 16, weight: .semibold))
-                        .foregroundStyle(theme.accentPrimary)
+                        .foregroundColor(theme.accentPrimary)
 
                     Text("Share Claude Code")
                         .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
-                        .foregroundStyle(theme.textPrimary)
+                        .foregroundColor(theme.textPrimary)
 
                     Spacer()
 
@@ -38,7 +38,7 @@ struct SharePassOverlay: View {
                     } label: {
                         Image(systemName: "xmark.circle.fill")
                             .font(.system(size: 18))
-                            .foregroundStyle(theme.textTertiary)
+                            .foregroundColor(theme.textTertiary)
                     }
                     .buttonStyle(.plain)
                 }
@@ -47,7 +47,7 @@ struct SharePassOverlay: View {
                 HStack(spacing: 8) {
                     Text(pass.referralURL.absoluteString)
                         .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
-                        .foregroundStyle(theme.textPrimary)
+                        .foregroundColor(theme.textPrimary)
                         .lineLimit(1)
                         .truncationMode(.middle)
 
@@ -58,7 +58,7 @@ struct SharePassOverlay: View {
                     } label: {
                         Image(systemName: copied ? "checkmark.circle.fill" : "doc.on.doc.fill")
                             .font(.system(size: 14))
-                            .foregroundStyle(copied ? theme.statusHealthy : theme.accentPrimary)
+                            .foregroundColor(copied ? theme.statusHealthy : theme.accentPrimary)
                     }
                     .buttonStyle(.plain)
                 }
@@ -79,7 +79,7 @@ struct SharePassOverlay: View {
                             Text(copied ? "Copied!" : "Copy Link")
                                 .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
                         }
-                        .foregroundStyle(.white)
+                        .foregroundColor(.white)
                         .padding(.horizontal, 14)
                         .padding(.vertical, 8)
                         .frame(maxWidth: .infinity)
@@ -100,7 +100,7 @@ struct SharePassOverlay: View {
                             Text("Open")
                                 .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
                         }
-                        .foregroundStyle(theme.textPrimary)
+                        .foregroundColor(theme.textPrimary)
                         .padding(.horizontal, 14)
                         .padding(.vertical, 8)
                         .background(
@@ -118,7 +118,7 @@ struct SharePassOverlay: View {
                 // Help text
                 Text("Share a free week of Claude Code with friends")
                     .font(.system(size: 10, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+                    .foregroundColor(theme.textTertiary)
             }
             .padding(16)
             .background(
@@ -143,7 +143,7 @@ struct SharePassOverlay: View {
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(pass.referralURL.absoluteString, forType: .string)
 
-        withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+        withAnimation(.spring()) {
             copied = true
         }
 
@@ -157,16 +157,18 @@ struct SharePassOverlay: View {
 
 // MARK: - Preview
 
-#Preview("SharePassOverlay") {
-    ZStack {
-        DarkTheme().backgroundGradient
+struct SharePassOverlay_Previews: PreviewProvider {
+    static var previews: some View {
+        ZStack {
+            DarkTheme().backgroundGradient
 
-        SharePassOverlay(
-            pass: ClaudePass(
-                referralURL: URL(string: "https://claude.ai/referral/DJ_kWX90Xw")!
-            ),
-            onDismiss: {}
-        )
+            SharePassOverlay(
+                pass: ClaudePass(
+                    referralURL: URL(string: "https://claude.ai/referral/DJ_kWX90Xw")!
+                ),
+                onDismiss: {}
+            )
+        }
+        .frame(width: 380, height: 400)
     }
-    .frame(width: 380, height: 400)
 }

--- a/Sources/App/Views/Theme.swift
+++ b/Sources/App/Views/Theme.swift
@@ -543,7 +543,7 @@ struct BadgeStyle: ViewModifier {
     func body(content: Content) -> some View {
         content
             .font(AppTheme.captionFont(size: 8))
-            .foregroundStyle(colorScheme == .dark ? .white : .white)
+            .foregroundColor(colorScheme == .dark ? .white : .white)
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
             .background(
@@ -578,7 +578,7 @@ struct AdaptiveTextStyle: ViewModifier {
     }
 
     func body(content: Content) -> some View {
-        content.foregroundStyle(color)
+        content.foregroundColor(color)
     }
 
     private var color: Color {
@@ -851,7 +851,7 @@ struct ThemeSwitcherButton: View {
 
     var body: some View {
         Button {
-            withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+            withAnimation(.spring()) {
                 cycleTheme()
             }
         } label: {
@@ -866,7 +866,7 @@ struct ThemeSwitcherButton: View {
 
                 Image(systemName: themeMode.icon)
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(AppTheme.textPrimary(for: colorScheme))
+                    .foregroundColor(AppTheme.textPrimary(for: colorScheme))
                     .rotationEffect(.degrees(themeMode == .dark ? -15 : 0))
             }
             .scaleEffect(isHovering ? 1.08 : 1.0)

--- a/Sources/Domain/Extension/ConfigField.swift
+++ b/Sources/Domain/Extension/ConfigField.swift
@@ -61,13 +61,19 @@ public struct ConfigField: Sendable, Equatable, Codable {
     /// Converts the field id to CLAUDEBAR_UPPER_SNAKE_CASE.
     /// Examples: "apiKey" → "CLAUDEBAR_API_KEY", "base-url" → "CLAUDEBAR_BASE_URL"
     public var environmentVariableName: String {
-        let snake = id
-            .replacingOccurrences(of: "-", with: "_")
-            .replacing(/([a-z])([A-Z])/) { match in
-                "\(match.output.1)_\(match.output.2)"
+        let snake = id.replacingOccurrences(of: "-", with: "_")
+        var result = ""
+        for (index, char) in snake.enumerated() {
+            if char.isUppercase {
+                if index > 0 {
+                    result.append("_")
+                }
+                result.append(char.lowercased())
+            } else {
+                result.append(char)
             }
-            .uppercased()
-        return "CLAUDEBAR_\(snake)"
+        }
+        return "CLAUDEBAR_\(result.uppercased())"
     }
 
     /// Returns the stored value if present, otherwise the default value.

--- a/Sources/Domain/Extension/ExtensionProvider.swift
+++ b/Sources/Domain/Extension/ExtensionProvider.swift
@@ -1,9 +1,11 @@
 import Foundation
+import Combine
 
 /// An AIProvider backed by an extension manifest and script-based probes.
 /// Each section has its own probe; refresh runs all probes and merges results.
-@Observable
-public final class ExtensionProvider: AIProvider, @unchecked Sendable {
+public final class ExtensionProvider: ObservableObject, AIProvider, @unchecked Sendable {
+    public let objectWillChange = ObservableObjectPublisher()
+
     // MARK: - Identity
 
     public let id: String
@@ -17,13 +19,13 @@ public final class ExtensionProvider: AIProvider, @unchecked Sendable {
 
     // MARK: - State
 
-    public var isEnabled: Bool {
+    @Published public var isEnabled: Bool {
         didSet { settingsRepository.setEnabled(isEnabled, forProvider: id) }
     }
 
-    public private(set) var isSyncing: Bool = false
-    public private(set) var snapshot: UsageSnapshot?
-    public private(set) var lastError: Error?
+    @Published public private(set) var isSyncing: Bool = false
+    @Published public private(set) var snapshot: UsageSnapshot?
+    @Published public private(set) var lastError: Error?
 
     // MARK: - Dependencies
 

--- a/Sources/Domain/Monitor/Clock.swift
+++ b/Sources/Domain/Monitor/Clock.swift
@@ -1,6 +1,5 @@
 import Foundation
 
 public protocol Clock: Sendable {
-    func sleep(for duration: Duration) async throws
-    func sleep(nanoseconds: UInt64) async throws
+    func sleep(for duration: TimeInterval) async throws
 }

--- a/Sources/Domain/Monitor/ObservableForwarding.swift
+++ b/Sources/Domain/Monitor/ObservableForwarding.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Combine
+
+/// Helper for subscribing to an existential ObservableObject's objectWillChange publisher.
+/// Swift cannot directly access objectWillChange on `any ObservableObject` because
+/// the publisher type is generic. This helper opens the existential and bridges it.
+enum ObservableSubscriber {
+    static func subscribe(
+        to object: any ObservableObject,
+        receiveOn scheduler: some Scheduler,
+        onChange: @escaping () -> Void
+    ) -> AnyCancellable {
+        subscribeToConcrete(object, receiveOn: scheduler, onChange: onChange)
+    }
+
+    private static func subscribeToConcrete<T: ObservableObject>(
+        _ object: T,
+        receiveOn scheduler: some Scheduler,
+        onChange: @escaping () -> Void
+    ) -> AnyCancellable {
+        object.objectWillChange
+            .receive(on: scheduler)
+            .sink { _ in onChange() }
+    }
+}

--- a/Sources/Domain/Monitor/QuotaMonitor.swift
+++ b/Sources/Domain/Monitor/QuotaMonitor.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Observation
+import Combine
 
 /// Events emitted during continuous monitoring
 public enum MonitoringEvent: Sendable {
@@ -12,8 +12,8 @@ public enum MonitoringEvent: Sendable {
 /// The main domain service that coordinates quota monitoring across AI providers.
 /// Providers are rich domain models that own their own snapshots.
 /// QuotaMonitor coordinates refreshes and alerts users when status changes.
-@Observable
-public final class QuotaMonitor: @unchecked Sendable {
+public final class QuotaMonitor: ObservableObject, @unchecked Sendable {
+
     /// The providers repository (internal - access via delegation methods)
     private let providers: any AIProviderRepository
 
@@ -29,11 +29,14 @@ public final class QuotaMonitor: @unchecked Sendable {
     /// Current monitoring task
     private var monitoringTask: Task<Void, Never>?
 
+    /// Combine subscriptions for forwarding provider changes
+    private var providerCancellables: Set<AnyCancellable> = []
+
     /// Whether monitoring is active
-    public private(set) var isMonitoring: Bool = false
+    @Published public private(set) var isMonitoring: Bool = false
 
     /// The currently selected provider ID (for UI display)
-    public var selectedProviderId: String = "claude"
+    @Published public var selectedProviderId: String = "claude"
 
     // MARK: - Initialization
 
@@ -48,6 +51,20 @@ public final class QuotaMonitor: @unchecked Sendable {
         self.alerter = alerter
         self.clock = clock
         selectFirstEnabledIfNeeded()
+        forwardProviderChanges()
+    }
+
+    /// Subscribes to all providers' objectWillChange and forwards to our own.
+    private func forwardProviderChanges() {
+        for provider in providers.all {
+            ObservableSubscriber.subscribe(
+                to: provider,
+                receiveOn: RunLoop.main,
+                onChange: { [weak self] in
+                    self?.objectWillChange.send()
+                }
+            ).store(in: &providerCancellables)
+        }
     }
 
     // MARK: - Monitoring Operations
@@ -137,6 +154,13 @@ public final class QuotaMonitor: @unchecked Sendable {
     /// Adds a provider dynamically
     public func addProvider(_ provider: any AIProvider) {
         providers.add(provider)
+        ObservableSubscriber.subscribe(
+            to: provider,
+            receiveOn: RunLoop.main,
+            onChange: { [weak self] in
+                self?.objectWillChange.send()
+            }
+        ).store(in: &providerCancellables)
     }
 
     /// Removes a provider by ID
@@ -212,7 +236,7 @@ public final class QuotaMonitor: @unchecked Sendable {
     /// Starts continuous monitoring at the specified interval.
     /// Only refreshes the currently selected provider each cycle to minimize energy usage.
     /// Returns an AsyncStream of monitoring events.
-    public func startMonitoring(interval: Duration = .seconds(60)) -> AsyncStream<MonitoringEvent> {
+    public func startMonitoring(interval: TimeInterval = 60) -> AsyncStream<MonitoringEvent> {
         // Stop any existing monitoring
         monitoringTask?.cancel()
 

--- a/Sources/Domain/Provider/AIProvider.swift
+++ b/Sources/Domain/Provider/AIProvider.swift
@@ -1,10 +1,11 @@
 import Foundation
+import Combine
 
 /// Protocol defining what an AI provider is.
 /// Each provider (Claude, Codex, Gemini) is a rich domain model implementing this protocol.
-/// Providers are @Observable classes with their own state (isSyncing, snapshot, error).
-/// Providers must be Sendable (use @unchecked Sendable for @Observable classes).
-public protocol AIProvider: AnyObject, Sendable, Identifiable where ID == String {
+/// Providers are ObservableObject classes with their own state (isSyncing, snapshot, error).
+/// Providers must be Sendable (use @unchecked Sendable for ObservableObject classes).
+public protocol AIProvider: AnyObject, ObservableObject, Sendable, Identifiable where ID == String {
     // MARK: - Identity
 
     /// Unique identifier for the provider (e.g., "claude", "codex", "gemini")

--- a/Sources/Domain/Provider/Alibaba/AlibabaProvider.swift
+++ b/Sources/Domain/Provider/Alibaba/AlibabaProvider.swift
@@ -1,10 +1,11 @@
 import Foundation
-import Observation
+import Combine
 
 /// Alibaba Coding Plan AI provider - a rich domain model.
 /// Observable class with its own state (isSyncing, snapshot, error).
-@Observable
-public final class AlibabaProvider: AIProvider, @unchecked Sendable {
+public final class AlibabaProvider: ObservableObject, AIProvider, @unchecked Sendable {
+    public let objectWillChange = ObservableObjectPublisher()
+
     // MARK: - Identity
 
     public let id: String = "alibaba"
@@ -18,7 +19,7 @@ public final class AlibabaProvider: AIProvider, @unchecked Sendable {
     public var statusPageURL: URL? { nil }
 
     /// Whether the provider is enabled (persisted via settingsRepository)
-    public var isEnabled: Bool {
+    @Published public var isEnabled: Bool {
         didSet {
             settingsRepository.setEnabled(isEnabled, forProvider: id)
         }
@@ -26,9 +27,9 @@ public final class AlibabaProvider: AIProvider, @unchecked Sendable {
 
     // MARK: - State (Observable)
 
-    public private(set) var isSyncing: Bool = false
-    public private(set) var snapshot: UsageSnapshot?
-    public private(set) var lastError: Error?
+    @Published public private(set) var isSyncing: Bool = false
+    @Published public private(set) var snapshot: UsageSnapshot?
+    @Published public private(set) var lastError: Error?
 
     // MARK: - Internal
 

--- a/Sources/Domain/Provider/AmpCode/AmpCodeProvider.swift
+++ b/Sources/Domain/Provider/AmpCode/AmpCodeProvider.swift
@@ -1,11 +1,11 @@
 import Foundation
-import Observation
+import Combine
 
 /// AmpCode AI provider (by Sourcegraph).
 /// Observable class with its own state (isSyncing, snapshot, error).
 /// Owns its probe and manages its own data lifecycle.
-@Observable
-public final class AmpCodeProvider: AIProvider, @unchecked Sendable {
+public final class AmpCodeProvider: ObservableObject, AIProvider, @unchecked Sendable {
+    public let objectWillChange = ObservableObjectPublisher()
 
     // MARK: - Identity
 
@@ -22,7 +22,7 @@ public final class AmpCodeProvider: AIProvider, @unchecked Sendable {
     }
 
     /// Whether the provider is enabled (persisted via settingsRepository)
-    public var isEnabled: Bool {
+    @Published public var isEnabled: Bool {
         didSet {
             settingsRepository.setEnabled(isEnabled, forProvider: id)
         }
@@ -31,13 +31,13 @@ public final class AmpCodeProvider: AIProvider, @unchecked Sendable {
     // MARK: - State (Observable)
 
     /// Whether the provider is currently syncing data
-    public private(set) var isSyncing: Bool = false
+    @Published public private(set) var isSyncing: Bool = false
 
     /// The current usage snapshot (nil if never refreshed or unavailable)
-    public private(set) var snapshot: UsageSnapshot?
+    @Published public private(set) var snapshot: UsageSnapshot?
 
     /// The last error that occurred during refresh
-    public private(set) var lastError: Error?
+    @Published public private(set) var lastError: Error?
 
     // MARK: - Internal
 

--- a/Sources/Domain/Provider/Antigravity/AntigravityProvider.swift
+++ b/Sources/Domain/Provider/Antigravity/AntigravityProvider.swift
@@ -1,11 +1,12 @@
 import Foundation
-import Observation
+import Combine
 
 /// Antigravity AI provider - a rich domain model.
 /// Observable class with its own state (isSyncing, snapshot, error).
 /// Owns its probe and manages its own data lifecycle.
-@Observable
-public final class AntigravityProvider: AIProvider, @unchecked Sendable {
+public final class AntigravityProvider: ObservableObject, AIProvider, @unchecked Sendable {
+    public let objectWillChange = ObservableObjectPublisher()
+
     // MARK: - Identity (Protocol Requirement)
 
     public let id: String = "antigravity"
@@ -21,7 +22,7 @@ public final class AntigravityProvider: AIProvider, @unchecked Sendable {
     }
 
     /// Whether the provider is enabled (persisted via settingsRepository)
-    public var isEnabled: Bool {
+    @Published public var isEnabled: Bool {
         didSet {
             settingsRepository.setEnabled(isEnabled, forProvider: id)
         }
@@ -30,13 +31,13 @@ public final class AntigravityProvider: AIProvider, @unchecked Sendable {
     // MARK: - State (Observable)
 
     /// Whether the provider is currently syncing data
-    public private(set) var isSyncing: Bool = false
+    @Published public private(set) var isSyncing: Bool = false
 
     /// The current usage snapshot (nil if never refreshed or unavailable)
-    public private(set) var snapshot: UsageSnapshot?
+    @Published public private(set) var snapshot: UsageSnapshot?
 
     /// The last error that occurred during refresh
-    public private(set) var lastError: Error?
+    @Published public private(set) var lastError: Error?
 
     // MARK: - Internal
 

--- a/Sources/Domain/Provider/Bedrock/BedrockProvider.swift
+++ b/Sources/Domain/Provider/Bedrock/BedrockProvider.swift
@@ -1,11 +1,12 @@
 import Foundation
-import Observation
+import Combine
 
 /// AWS Bedrock AI provider - a rich domain model.
 /// Observable class with its own state (isSyncing, snapshot, error).
 /// Monitors Bedrock usage via CloudWatch metrics and calculates costs.
-@Observable
-public final class BedrockProvider: AIProvider, @unchecked Sendable {
+public final class BedrockProvider: ObservableObject, AIProvider, @unchecked Sendable {
+    public let objectWillChange = ObservableObjectPublisher()
+
     // MARK: - Identity (Protocol Requirement)
 
     public let id: String = "bedrock"
@@ -21,7 +22,7 @@ public final class BedrockProvider: AIProvider, @unchecked Sendable {
     }
 
     /// Whether the provider is enabled (persisted via settingsRepository)
-    public var isEnabled: Bool {
+    @Published public var isEnabled: Bool {
         didSet {
             settingsRepository.setEnabled(isEnabled, forProvider: id)
         }
@@ -30,13 +31,13 @@ public final class BedrockProvider: AIProvider, @unchecked Sendable {
     // MARK: - State (Observable)
 
     /// Whether the provider is currently syncing data
-    public private(set) var isSyncing: Bool = false
+    @Published public private(set) var isSyncing: Bool = false
 
     /// The current usage snapshot (nil if never refreshed or unavailable)
-    public private(set) var snapshot: UsageSnapshot?
+    @Published public private(set) var snapshot: UsageSnapshot?
 
     /// The last error that occurred during refresh
-    public private(set) var lastError: Error?
+    @Published public private(set) var lastError: Error?
 
     // MARK: - Internal
 

--- a/Sources/Domain/Provider/Claude/ClaudeProvider.swift
+++ b/Sources/Domain/Provider/Claude/ClaudeProvider.swift
@@ -1,11 +1,11 @@
 import Foundation
-import Observation
+import Combine
 
 /// Claude AI provider - a rich domain model.
-/// Observable class with its own state (isSyncing, snapshot, error).
+/// ObservableObject class with its own state (isSyncing, snapshot, error).
 /// Supports dual probe modes: CLI (default) and API.
-@Observable
-public final class ClaudeProvider: AIProvider, @unchecked Sendable {
+public final class ClaudeProvider: ObservableObject, AIProvider, @unchecked Sendable {
+    public let objectWillChange = ObservableObjectPublisher()
     // MARK: - Identity (Protocol Requirement)
 
     public let id: String = "claude"
@@ -21,7 +21,7 @@ public final class ClaudeProvider: AIProvider, @unchecked Sendable {
     }
 
     /// Whether the provider is enabled (persisted via settingsRepository)
-    public var isEnabled: Bool {
+    @Published public var isEnabled: Bool {
         didSet {
             settingsRepository.setEnabled(isEnabled, forProvider: id)
         }
@@ -30,19 +30,19 @@ public final class ClaudeProvider: AIProvider, @unchecked Sendable {
     // MARK: - State (Observable)
 
     /// Whether the provider is currently syncing data
-    public private(set) var isSyncing: Bool = false
+    @Published public private(set) var isSyncing: Bool = false
 
     /// The current usage snapshot (nil if never refreshed or unavailable)
-    public private(set) var snapshot: UsageSnapshot?
+    @Published public private(set) var snapshot: UsageSnapshot?
 
     /// The last error that occurred during refresh
-    public private(set) var lastError: Error?
+    @Published public private(set) var lastError: Error?
 
     /// The current guest pass information (nil if never fetched)
-    public private(set) var guestPass: ClaudePass?
+    @Published public private(set) var guestPass: ClaudePass?
 
     /// Whether the provider is currently fetching passes
-    public private(set) var isFetchingPasses: Bool = false
+    @Published public private(set) var isFetchingPasses: Bool = false
 
     // MARK: - Probe Mode
 

--- a/Sources/Domain/Provider/Codex/CodexProvider.swift
+++ b/Sources/Domain/Provider/Codex/CodexProvider.swift
@@ -1,11 +1,11 @@
 import Foundation
-import Observation
+import Combine
 
 /// Codex AI provider - a rich domain model.
 /// Observable class with its own state (isSyncing, snapshot, error).
 /// Supports dual probe modes: RPC (default) and API.
-@Observable
-public final class CodexProvider: AIProvider, @unchecked Sendable {
+public final class CodexProvider: ObservableObject, AIProvider, @unchecked Sendable {
+    public let objectWillChange = ObservableObjectPublisher()
     // MARK: - Identity
 
     public let id: String = "codex"
@@ -21,7 +21,7 @@ public final class CodexProvider: AIProvider, @unchecked Sendable {
     }
 
     /// Whether the provider is enabled (persisted via settingsRepository)
-    public var isEnabled: Bool {
+    @Published public var isEnabled: Bool {
         didSet {
             settingsRepository.setEnabled(isEnabled, forProvider: id)
         }
@@ -29,9 +29,9 @@ public final class CodexProvider: AIProvider, @unchecked Sendable {
 
     // MARK: - State (Observable)
 
-    public private(set) var isSyncing: Bool = false
-    public private(set) var snapshot: UsageSnapshot?
-    public private(set) var lastError: Error?
+    @Published public private(set) var isSyncing: Bool = false
+    @Published public private(set) var snapshot: UsageSnapshot?
+    @Published public private(set) var lastError: Error?
 
     // MARK: - Probe Mode
 

--- a/Sources/Domain/Provider/Copilot/CopilotProvider.swift
+++ b/Sources/Domain/Provider/Copilot/CopilotProvider.swift
@@ -1,12 +1,12 @@
 import Foundation
-import Observation
+import Combine
 
 /// GitHub Copilot AI provider - a rich domain model.
 /// Observable class with its own state (isSyncing, snapshot, error).
 /// Supports dual probe modes: Billing API (default) and Copilot Internal API.
 /// Owns its probe, credentials, and manages its own data lifecycle.
-@Observable
-public final class CopilotProvider: AIProvider, @unchecked Sendable {
+public final class CopilotProvider: ObservableObject, AIProvider, @unchecked Sendable {
+    public let objectWillChange = ObservableObjectPublisher()
     // MARK: - Identity (Protocol Requirement)
 
     public let id: String = "copilot"
@@ -22,7 +22,7 @@ public final class CopilotProvider: AIProvider, @unchecked Sendable {
     }
 
     /// Whether the provider is enabled (persisted via settingsRepository, defaults to false - requires setup)
-    public var isEnabled: Bool {
+    @Published public var isEnabled: Bool {
         didSet {
             settingsRepository.setEnabled(isEnabled, forProvider: id)
         }
@@ -31,18 +31,18 @@ public final class CopilotProvider: AIProvider, @unchecked Sendable {
     // MARK: - State (Observable)
 
     /// Whether the provider is currently syncing data
-    public private(set) var isSyncing: Bool = false
+    @Published public private(set) var isSyncing: Bool = false
 
     /// The current usage snapshot (nil if never refreshed or unavailable)
-    public private(set) var snapshot: UsageSnapshot?
+    @Published public private(set) var snapshot: UsageSnapshot?
 
     /// The last error that occurred during refresh
-    public private(set) var lastError: Error?
+    @Published public private(set) var lastError: Error?
 
     // MARK: - Credentials (Observable)
 
     /// The GitHub username for API calls
-    public var username: String {
+    @Published public var username: String {
         didSet {
             settingsRepository.saveGithubUsername(username)
         }

--- a/Sources/Domain/Provider/Cursor/CursorProvider.swift
+++ b/Sources/Domain/Provider/Cursor/CursorProvider.swift
@@ -1,10 +1,11 @@
 import Foundation
-import Observation
+import Combine
 
 /// Cursor AI provider - a rich domain model.
 /// Observable class with its own state (isSyncing, snapshot, error).
-@Observable
-public final class CursorProvider: AIProvider, @unchecked Sendable {
+public final class CursorProvider: ObservableObject, AIProvider, @unchecked Sendable {
+    public let objectWillChange = ObservableObjectPublisher()
+
     // MARK: - Identity (Protocol Requirement)
 
     public let id: String = "cursor"
@@ -20,7 +21,7 @@ public final class CursorProvider: AIProvider, @unchecked Sendable {
     }
 
     /// Whether the provider is enabled (persisted via settingsRepository)
-    public var isEnabled: Bool {
+    @Published public var isEnabled: Bool {
         didSet {
             settingsRepository.setEnabled(isEnabled, forProvider: id)
         }
@@ -29,13 +30,13 @@ public final class CursorProvider: AIProvider, @unchecked Sendable {
     // MARK: - State (Observable)
 
     /// Whether the provider is currently syncing data
-    public private(set) var isSyncing: Bool = false
+    @Published public private(set) var isSyncing: Bool = false
 
     /// The current usage snapshot (nil if never refreshed or unavailable)
-    public private(set) var snapshot: UsageSnapshot?
+    @Published public private(set) var snapshot: UsageSnapshot?
 
     /// The last error that occurred during refresh
-    public private(set) var lastError: Error?
+    @Published public private(set) var lastError: Error?
 
     // MARK: - Internal
 

--- a/Sources/Domain/Provider/Gemini/GeminiProvider.swift
+++ b/Sources/Domain/Provider/Gemini/GeminiProvider.swift
@@ -1,10 +1,10 @@
 import Foundation
-import Observation
+import Combine
 
 /// Gemini AI provider - a rich domain model.
 /// Observable class with its own state (isSyncing, snapshot, error).
-@Observable
-public final class GeminiProvider: AIProvider, @unchecked Sendable {
+public final class GeminiProvider: ObservableObject, AIProvider, @unchecked Sendable {
+    public let objectWillChange = ObservableObjectPublisher()
     // MARK: - Identity
 
     public let id: String = "gemini"
@@ -20,7 +20,7 @@ public final class GeminiProvider: AIProvider, @unchecked Sendable {
     }
 
     /// Whether the provider is enabled (persisted via settingsRepository)
-    public var isEnabled: Bool {
+    @Published public var isEnabled: Bool {
         didSet {
             settingsRepository.setEnabled(isEnabled, forProvider: id)
         }
@@ -28,9 +28,9 @@ public final class GeminiProvider: AIProvider, @unchecked Sendable {
 
     // MARK: - State (Observable)
 
-    public private(set) var isSyncing: Bool = false
-    public private(set) var snapshot: UsageSnapshot?
-    public private(set) var lastError: Error?
+    @Published public private(set) var isSyncing: Bool = false
+    @Published public private(set) var snapshot: UsageSnapshot?
+    @Published public private(set) var lastError: Error?
 
     // MARK: - Internal
 

--- a/Sources/Domain/Provider/Kimi/KimiProvider.swift
+++ b/Sources/Domain/Provider/Kimi/KimiProvider.swift
@@ -1,11 +1,12 @@
 import Foundation
-import Observation
+import Combine
 
 /// Kimi AI provider - a rich domain model.
 /// Observable class with its own state (isSyncing, snapshot, error).
 /// Supports dual probe modes: CLI (default) and API.
-@Observable
-public final class KimiProvider: AIProvider, @unchecked Sendable {
+public final class KimiProvider: ObservableObject, AIProvider, @unchecked Sendable {
+    public let objectWillChange = ObservableObjectPublisher()
+
     // MARK: - Identity (Protocol Requirement)
 
     public let id: String = "kimi"
@@ -21,7 +22,7 @@ public final class KimiProvider: AIProvider, @unchecked Sendable {
     }
 
     /// Whether the provider is enabled (persisted via settingsRepository)
-    public var isEnabled: Bool {
+    @Published public var isEnabled: Bool {
         didSet {
             settingsRepository.setEnabled(isEnabled, forProvider: id)
         }
@@ -30,13 +31,13 @@ public final class KimiProvider: AIProvider, @unchecked Sendable {
     // MARK: - State (Observable)
 
     /// Whether the provider is currently syncing data
-    public private(set) var isSyncing: Bool = false
+    @Published public private(set) var isSyncing: Bool = false
 
     /// The current usage snapshot (nil if never refreshed or unavailable)
-    public private(set) var snapshot: UsageSnapshot?
+    @Published public private(set) var snapshot: UsageSnapshot?
 
     /// The last error that occurred during refresh
-    public private(set) var lastError: Error?
+    @Published public private(set) var lastError: Error?
 
     // MARK: - Probe Mode
 

--- a/Sources/Domain/Provider/Kiro/KiroProvider.swift
+++ b/Sources/Domain/Provider/Kiro/KiroProvider.swift
@@ -1,10 +1,11 @@
 import Foundation
-import Observation
+import Combine
 
 /// Kiro AI provider - a rich domain model.
 /// Observable class with its own state (isSyncing, snapshot, error).
-@Observable
-public final class KiroProvider: AIProvider, @unchecked Sendable {
+public final class KiroProvider: ObservableObject, AIProvider, @unchecked Sendable {
+    public let objectWillChange = ObservableObjectPublisher()
+
     // MARK: - Identity (Protocol Requirement)
 
     public let id: String = "kiro"
@@ -20,7 +21,7 @@ public final class KiroProvider: AIProvider, @unchecked Sendable {
     }
 
     /// Whether the provider is enabled (persisted via settingsRepository)
-    public var isEnabled: Bool {
+    @Published public var isEnabled: Bool {
         didSet {
             settingsRepository.setEnabled(isEnabled, forProvider: id)
         }
@@ -29,13 +30,13 @@ public final class KiroProvider: AIProvider, @unchecked Sendable {
     // MARK: - State (Observable)
 
     /// Whether the provider is currently syncing data
-    public private(set) var isSyncing: Bool = false
+    @Published public private(set) var isSyncing: Bool = false
 
     /// The current usage snapshot (nil if never refreshed or unavailable)
-    public private(set) var snapshot: UsageSnapshot?
+    @Published public private(set) var snapshot: UsageSnapshot?
 
     /// The last error that occurred during refresh
-    public private(set) var lastError: Error?
+    @Published public private(set) var lastError: Error?
 
     // MARK: - Internal
 

--- a/Sources/Domain/Provider/MiniMax/MiniMaxProvider.swift
+++ b/Sources/Domain/Provider/MiniMax/MiniMaxProvider.swift
@@ -1,11 +1,12 @@
 import Foundation
-import Observation
+import Combine
 
 /// MiniMax AI provider - a rich domain model.
 /// Observable class with its own state (isSyncing, snapshot, error).
 /// Owns its probe and manages its own data lifecycle.
-@Observable
-public final class MiniMaxProvider: AIProvider, @unchecked Sendable {
+public final class MiniMaxProvider: ObservableObject, AIProvider, @unchecked Sendable {
+    public let objectWillChange = ObservableObjectPublisher()
+
     // MARK: - Identity (Protocol Requirement)
 
     public let id: String = "minimax"
@@ -21,7 +22,7 @@ public final class MiniMaxProvider: AIProvider, @unchecked Sendable {
     }
 
     /// Whether the provider is enabled (persisted via settingsRepository)
-    public var isEnabled: Bool {
+    @Published public var isEnabled: Bool {
         didSet {
             settingsRepository.setEnabled(isEnabled, forProvider: id)
         }
@@ -30,13 +31,13 @@ public final class MiniMaxProvider: AIProvider, @unchecked Sendable {
     // MARK: - State (Observable)
 
     /// Whether the provider is currently syncing data
-    public private(set) var isSyncing: Bool = false
+    @Published public private(set) var isSyncing: Bool = false
 
     /// The current usage snapshot (nil if never refreshed or unavailable)
-    public private(set) var snapshot: UsageSnapshot?
+    @Published public private(set) var snapshot: UsageSnapshot?
 
     /// The last error that occurred during refresh
-    public private(set) var lastError: Error?
+    @Published public private(set) var lastError: Error?
 
     // MARK: - Internal
 

--- a/Sources/Domain/Provider/Mistral/MistralProvider.swift
+++ b/Sources/Domain/Provider/Mistral/MistralProvider.swift
@@ -1,11 +1,12 @@
 import Foundation
-import Observation
+import Combine
 
 /// Mistral AI provider - a rich domain model.
 /// Observable class with its own state (isSyncing, snapshot, error).
 /// Owns its probe and manages its own data lifecycle.
-@Observable
-public final class MistralProvider: AIProvider, @unchecked Sendable {
+public final class MistralProvider: ObservableObject, AIProvider, @unchecked Sendable {
+    public let objectWillChange = ObservableObjectPublisher()
+
     // MARK: - Identity (Protocol Requirement)
 
     public let id: String = "mistral"
@@ -21,7 +22,7 @@ public final class MistralProvider: AIProvider, @unchecked Sendable {
     }
 
     /// Whether the provider is enabled (persisted via settingsRepository)
-    public var isEnabled: Bool {
+    @Published public var isEnabled: Bool {
         didSet {
             settingsRepository.setEnabled(isEnabled, forProvider: id)
         }
@@ -30,13 +31,13 @@ public final class MistralProvider: AIProvider, @unchecked Sendable {
     // MARK: - State (Observable)
 
     /// Whether the provider is currently syncing data
-    public private(set) var isSyncing: Bool = false
+    @Published public private(set) var isSyncing: Bool = false
 
     /// The current usage snapshot (nil if never refreshed or unavailable)
-    public private(set) var snapshot: UsageSnapshot?
+    @Published public private(set) var snapshot: UsageSnapshot?
 
     /// The last error that occurred during refresh
-    public private(set) var lastError: Error?
+    @Published public private(set) var lastError: Error?
 
     // MARK: - Internal
 

--- a/Sources/Domain/Provider/Zai/ZaiProvider.swift
+++ b/Sources/Domain/Provider/Zai/ZaiProvider.swift
@@ -1,11 +1,12 @@
 import Foundation
-import Observation
+import Combine
 
 /// Z.ai (GLM Coding Plan) provider - a rich domain model.
 /// Z.ai provides an API-compatible replacement for Anthropic's API,
 /// offering GLM-4.7 models with generous usage quotas.
-@Observable
-public final class ZaiProvider: AIProvider, @unchecked Sendable {
+public final class ZaiProvider: ObservableObject, AIProvider, @unchecked Sendable {
+    public let objectWillChange = ObservableObjectPublisher()
+
     // MARK: - Identity (Protocol Requirement)
 
     public let id: String = "zai"
@@ -21,7 +22,7 @@ public final class ZaiProvider: AIProvider, @unchecked Sendable {
     }
 
     /// Whether the provider is enabled (persisted via settingsRepository)
-    public var isEnabled: Bool {
+    @Published public var isEnabled: Bool {
         didSet {
             settingsRepository.setEnabled(isEnabled, forProvider: id)
         }
@@ -30,13 +31,13 @@ public final class ZaiProvider: AIProvider, @unchecked Sendable {
     // MARK: - State (Observable)
 
     /// Whether the provider is currently syncing data
-    public private(set) var isSyncing: Bool = false
+    @Published public private(set) var isSyncing: Bool = false
 
     /// The current usage snapshot (nil if never refreshed or unavailable)
-    public private(set) var snapshot: UsageSnapshot?
+    @Published public private(set) var snapshot: UsageSnapshot?
 
     /// The last error that occurred during refresh
-    public private(set) var lastError: Error?
+    @Published public private(set) var lastError: Error?
 
     // MARK: - Internal
 

--- a/Sources/Domain/Session/SessionMonitor.swift
+++ b/Sources/Domain/Session/SessionMonitor.swift
@@ -1,17 +1,17 @@
 import Foundation
-import Observation
+import Combine
 
 /// Monitors Claude Code sessions by processing hook events.
 /// Single source of truth for session state, similar to QuotaMonitor for providers.
 /// Isolated to @MainActor since it's consumed by SwiftUI views.
-@MainActor
-@Observable
-public final class SessionMonitor {
+public final class SessionMonitor: ObservableObject, @unchecked Sendable {
+    public let objectWillChange = ObservableObjectPublisher()
+
     /// The currently active session (nil if no session is running)
-    public private(set) var activeSession: ClaudeSession?
+    @Published public private(set) var activeSession: ClaudeSession?
 
     /// Recently completed sessions (most recent first)
-    public private(set) var recentSessions: [ClaudeSession] = []
+    @Published public private(set) var recentSessions: [ClaudeSession] = []
 
     /// Maximum number of recent sessions to keep
     private let maxRecentSessions: Int

--- a/Sources/Infrastructure/Alibaba/AlibabaBrowserCookieProvider.swift
+++ b/Sources/Infrastructure/Alibaba/AlibabaBrowserCookieProvider.swift
@@ -1,56 +1,19 @@
 import Foundation
-import SweetCookieKit
 import Domain
 
 /// Resolves Alibaba Cloud authentication cookies from browser cookie stores.
 ///
-/// Searches for aliyun.com / alibabacloud.com cookies across all supported browsers
-/// using SweetCookieKit. Used when cookie source is set to "auto".
+/// On macOS 13+, uses SweetCookieKit for automatic browser cookie extraction.
+/// On macOS 12, returns nil (manual cookie entry via settings still works).
 public struct AlibabaBrowserCookieProvider: AlibabaCookieProviding {
     public init() {}
 
     public func extractBrowserCookies() -> String? {
-        let cookieClient = BrowserCookieClient()
-        let query = BrowserCookieQuery(
-            domains: [
-                "aliyun.com",
-                "console.aliyun.com",
-                "bailian.console.aliyun.com",
-                "alibabacloud.com",
-                "console.alibabacloud.com",
-                "modelstudio.console.alibabacloud.com",
-            ],
-            domainMatch: .suffix,
-            includeExpired: false
-        )
-
-        for browser in Browser.defaultImportOrder {
-            do {
-                let stores = try cookieClient.records(matching: query, in: browser)
-                for store in stores {
-                    let cookies = store.cookies(origin: query.origin)
-                    // Look for authentication-related cookies
-                    let authCookieNames: Set<String> = [
-                        "login_aliyunid_ticket",
-                        "login_aliyunid_csrf",
-                        "sec_token",
-                        "aliyun_choice",
-                        "cna",
-                    ]
-                    let matchedCookies = cookies.filter { authCookieNames.contains($0.name) }
-                    if !matchedCookies.isEmpty {
-                        let cookieString = matchedCookies
-                            .map { "\($0.name)=\($0.value)" }
-                            .joined(separator: "; ")
-                        AppLog.probes.debug("Alibaba: Found browser cookies from \(browser)")
-                        return cookieString
-                    }
-                }
-            } catch {
-                continue
-            }
+        #if canImport(SweetCookieKit)
+        if #available(macOS 13, *) {
+            return _AlibabaBrowserCookieProvider().extractBrowserCookies()
         }
-        AppLog.probes.debug("Alibaba: No browser cookies found")
+        #endif
         return nil
     }
 }

--- a/Sources/Infrastructure/Alibaba/_AlibabaBrowserCookieProvider.swift
+++ b/Sources/Infrastructure/Alibaba/_AlibabaBrowserCookieProvider.swift
@@ -1,0 +1,54 @@
+import Foundation
+#if canImport(SweetCookieKit)
+import SweetCookieKit
+#endif
+import Domain
+
+#if canImport(SweetCookieKit)
+@available(macOS 13, *)
+struct _AlibabaBrowserCookieProvider: AlibabaCookieProviding {
+    func extractBrowserCookies() -> String? {
+        let cookieClient = BrowserCookieClient()
+        let query = BrowserCookieQuery(
+            domains: [
+                "aliyun.com",
+                "console.aliyun.com",
+                "bailian.console.aliyun.com",
+                "alibabacloud.com",
+                "console.alibabacloud.com",
+                "modelstudio.console.alibabacloud.com",
+            ],
+            domainMatch: .suffix,
+            includeExpired: false
+        )
+
+        for browser in Browser.defaultImportOrder {
+            do {
+                let stores = try cookieClient.records(matching: query, in: browser)
+                for store in stores {
+                    let cookies = store.cookies(origin: query.origin)
+                    let authCookieNames: Set<String> = [
+                        "login_aliyunid_ticket",
+                        "login_aliyunid_csrf",
+                        "sec_token",
+                        "aliyun_choice",
+                        "cna",
+                    ]
+                    let matchedCookies = cookies.filter { authCookieNames.contains($0.name) }
+                    if !matchedCookies.isEmpty {
+                        let cookieString = matchedCookies
+                            .map { "\($0.name)=\($0.value)" }
+                            .joined(separator: "; ")
+                        AppLog.probes.debug("Alibaba: Found browser cookies from \(String(describing: browser))")
+                        return cookieString
+                    }
+                }
+            } catch {
+                continue
+            }
+        }
+        AppLog.probes.debug("Alibaba: No browser cookies found")
+        return nil
+    }
+}
+#endif

--- a/Sources/Infrastructure/Claude/ClaudeUsageProbe.swift
+++ b/Sources/Infrastructure/Claude/ClaudeUsageProbe.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Domain
-import SwiftTerm
 
 /// Infrastructure adapter that probes the Claude CLI to fetch usage quotas.
 /// Implements the UsageProbe protocol from the domain layer.

--- a/Sources/Infrastructure/Extension/ExtensionDirectoryScanner.swift
+++ b/Sources/Infrastructure/Extension/ExtensionDirectoryScanner.swift
@@ -20,7 +20,7 @@ public final class ExtensionDirectoryScanner: Sendable {
     public func scan(directory: URL) -> [ExtensionScanResult] {
         let fileManager = FileManager.default
 
-        guard fileManager.fileExists(atPath: directory.path()) else {
+        guard fileManager.fileExists(atPath: directory.path) else {
             return []
         }
 
@@ -34,12 +34,12 @@ public final class ExtensionDirectoryScanner: Sendable {
 
         return contents.compactMap { subDir -> ExtensionScanResult? in
             var isDirectory: ObjCBool = false
-            guard fileManager.fileExists(atPath: subDir.path(), isDirectory: &isDirectory),
+            guard fileManager.fileExists(atPath: subDir.path, isDirectory: &isDirectory),
                   isDirectory.boolValue else {
                 return nil
             }
 
-            let manifestURL = subDir.appending(path: "manifest.json")
+            let manifestURL = subDir.appendingPathComponent("manifest.json")
             guard let data = try? Data(contentsOf: manifestURL),
                   let manifest = try? ExtensionManifest.parse(from: data) else {
                 return nil

--- a/Sources/Infrastructure/Extension/ExtensionRegistry.swift
+++ b/Sources/Infrastructure/Extension/ExtensionRegistry.swift
@@ -12,8 +12,8 @@ public final class ExtensionRegistry: Sendable {
     /// Default extensions directory: ~/.claudebar/extensions/
     public static var defaultDirectory: URL {
         FileManager.default.homeDirectoryForCurrentUser
-            .appending(path: ".claudebar")
-            .appending(path: "extensions")
+            .appendingPathComponent(".claudebar")
+            .appendingPathComponent("extensions")
     }
 
     public init(
@@ -57,7 +57,7 @@ public final class ExtensionRegistry: Sendable {
 
     private func ensureDirectoryExists() {
         let fm = FileManager.default
-        if !fm.fileExists(atPath: extensionsDirectory.path()) {
+        if !fm.fileExists(atPath: extensionsDirectory.path) {
             try? fm.createDirectory(at: extensionsDirectory, withIntermediateDirectories: true)
         }
     }

--- a/Sources/Infrastructure/Extension/ScriptProbe.swift
+++ b/Sources/Infrastructure/Extension/ScriptProbe.swift
@@ -90,7 +90,7 @@ public final class ScriptProbe: UsageProbe, @unchecked Sendable {
         if scriptPath.hasPrefix("/") {
             return scriptPath
         }
-        return extensionDir.appending(path: scriptPath).path()
+        return extensionDir.appendingPathComponent(scriptPath).path
     }
 
     private func sectionDataToSnapshot(_ data: SectionData) -> UsageSnapshot {

--- a/Sources/Infrastructure/Gemini/GeminiAPIProbe.swift
+++ b/Sources/Infrastructure/Gemini/GeminiAPIProbe.swift
@@ -6,7 +6,6 @@ internal struct GeminiAPIProbe {
     private let timeout: TimeInterval
     private let networkClient: any NetworkClient
     private let cliExecutor: CLIExecutor
-    private let clock: any Clock
 
     private static let quotaEndpoint = "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota"
     private static let credentialsPath = "/.gemini/oauth_creds.json"
@@ -18,15 +17,13 @@ internal struct GeminiAPIProbe {
         timeout: TimeInterval,
         networkClient: any NetworkClient,
         maxRetries: Int = 3,
-        cliExecutor: CLIExecutor = DefaultCLIExecutor(),
-        clock: any Clock = SystemClock()
+        cliExecutor: CLIExecutor = DefaultCLIExecutor()
     ) {
         self.homeDirectory = homeDirectory
         self.timeout = timeout
         self.networkClient = networkClient
         self.maxRetries = maxRetries
         self.cliExecutor = cliExecutor
-        self.clock = clock
     }
 
     func probe() async throws -> UsageSnapshot {
@@ -142,7 +139,7 @@ internal struct GeminiAPIProbe {
             autoResponses: [:]
         )
 
-        try await clock.sleep(nanoseconds: 1_500_000_000)
+        try await Task.sleep(nanoseconds: 1_500_000_000)
 
         AppLog.probes.debug("Gemini: CLI token refresh completed")
     }

--- a/Sources/Infrastructure/Kimi/KimiTokenProvider.swift
+++ b/Sources/Infrastructure/Kimi/KimiTokenProvider.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SweetCookieKit
 import Domain
 
 /// Protocol for resolving Kimi authentication tokens.
@@ -12,7 +11,7 @@ public protocol KimiTokenProviding: Sendable {
 ///
 /// Resolution order:
 /// 1. `KIMI_AUTH_TOKEN` environment variable
-/// 2. `kimi-auth` cookie from browser cookie stores (via SweetCookieKit)
+/// 2. `kimi-auth` cookie from browser cookie stores (macOS 13+ via SweetCookieKit)
 public struct KimiCookieTokenProvider: KimiTokenProviding {
     public init() {}
 
@@ -25,7 +24,7 @@ public struct KimiCookieTokenProvider: KimiTokenProviding {
             return envToken
         }
 
-        // 2. Try extracting from browser cookies
+        // 2. Try extracting from browser cookies (macOS 13+ only)
         if let browserToken = fetchFromBrowser() {
             AppLog.probes.debug("Kimi: Using token from browser cookie")
             return browserToken
@@ -36,28 +35,11 @@ public struct KimiCookieTokenProvider: KimiTokenProviding {
     }
 
     private func fetchFromBrowser() -> String? {
-        let cookieClient = BrowserCookieClient()
-        let query = BrowserCookieQuery(
-            domains: ["www.kimi.com", "kimi.com"],
-            domainMatch: .suffix,
-            includeExpired: false
-        )
-
-        for browser in Browser.defaultImportOrder {
-            do {
-                let stores = try cookieClient.records(matching: query, in: browser)
-                for store in stores {
-                    let cookies = store.cookies(origin: query.origin)
-                    if let auth = cookies.first(where: { $0.name == "kimi-auth" }),
-                       !auth.value.isEmpty
-                    {
-                        return auth.value
-                    }
-                }
-            } catch {
-                continue
-            }
+        #if canImport(SweetCookieKit)
+        if #available(macOS 13, *) {
+            return _KimiBrowserCookieFetcher().fetchCookie()
         }
+        #endif
         return nil
     }
 }

--- a/Sources/Infrastructure/Kimi/_KimiBrowserCookieProvider.swift
+++ b/Sources/Infrastructure/Kimi/_KimiBrowserCookieProvider.swift
@@ -1,0 +1,35 @@
+import Foundation
+#if canImport(SweetCookieKit)
+import SweetCookieKit
+#endif
+
+#if canImport(SweetCookieKit)
+@available(macOS 13, *)
+struct _KimiBrowserCookieFetcher {
+    func fetchCookie() -> String? {
+        let cookieClient = BrowserCookieClient()
+        let query = BrowserCookieQuery(
+            domains: ["www.kimi.com", "kimi.com"],
+            domainMatch: .suffix,
+            includeExpired: false
+        )
+
+        for browser in Browser.defaultImportOrder {
+            do {
+                let stores = try cookieClient.records(matching: query, in: browser)
+                for store in stores {
+                    let cookies = store.cookies(origin: query.origin)
+                    if let auth = cookies.first(where: { $0.name == "kimi-auth" }),
+                       !auth.value.isEmpty
+                    {
+                        return auth.value
+                    }
+                }
+            } catch {
+                continue
+            }
+        }
+        return nil
+    }
+}
+#endif

--- a/Sources/Infrastructure/Kiro/KiroUsageProbe.swift
+++ b/Sources/Infrastructure/Kiro/KiroUsageProbe.swift
@@ -112,7 +112,7 @@ public struct KiroUsageProbe: UsageProbe {
             let pattern = #"([\d.]+) of ([\d.]+)"#
             if let numMatch = creditsLine.range(of: pattern, options: .regularExpression) {
                 let numStr = String(creditsLine[numMatch])
-                let parts = numStr.split(separator: " of ")
+                let parts = numStr.components(separatedBy: " of ")
                 if parts.count == 2, let used = Double(parts[0]), let total = Double(parts[1]), total > 0 {
                     let remaining = ((total - used) / total) * 100
                     

--- a/Sources/Infrastructure/Shared/SystemClock.swift
+++ b/Sources/Infrastructure/Shared/SystemClock.swift
@@ -4,11 +4,7 @@ import Domain
 public struct SystemClock: Clock {
     public init() {}
 
-    public func sleep(for duration: Duration) async throws {
-        try await Task.sleep(for: duration)
-    }
-
-    public func sleep(nanoseconds: UInt64) async throws {
-        try await Task.sleep(nanoseconds: nanoseconds)
+    public func sleep(for duration: TimeInterval) async throws {
+        try await Task.sleep(nanoseconds: UInt64(duration * 1_000_000_000))
     }
 }

--- a/Sources/Infrastructure/Shared/TerminalRenderer.swift
+++ b/Sources/Infrastructure/Shared/TerminalRenderer.swift
@@ -1,84 +1,43 @@
 import Foundation
-import SwiftTerm
-
-/// Minimal delegate for headless terminal rendering.
-/// Only implements required methods - we don't need to send data back.
-private final class RenderDelegate: TerminalDelegate {
-    func send(source: Terminal, data: ArraySlice<UInt8>) {
-        // No-op: we're only reading, not sending
-    }
-}
 
 /// Renders raw terminal output with ANSI escape sequences into clean text.
 ///
-/// Uses SwiftTerm's terminal emulator to properly handle cursor movements,
-/// screen clearing, and other terminal control sequences that would otherwise
-/// corrupt the output when captured from a PTY.
-///
-/// Example:
-/// ```swift
-/// let renderer = TerminalRenderer()
-/// let raw = "Hello\u{1B}[5CWorld"  // "Hello" + move 5 right + "World"
-/// let clean = renderer.render(raw)  // "Hello     World"
-/// ```
+/// On macOS 13+, uses SwiftTerm's terminal emulator for proper cursor movement
+/// and screen clearing handling. On macOS 12, falls back to basic ANSI stripping.
 public final class TerminalRenderer {
     private let cols: Int
     private let rows: Int
 
-    /// Creates a terminal renderer with the specified dimensions.
-    /// - Parameters:
-    ///   - cols: Number of columns (default: 160)
-    ///   - rows: Number of rows (default: 50)
     public init(cols: Int = 160, rows: Int = 50) {
         self.cols = cols
         self.rows = rows
     }
 
-    /// Renders raw terminal output into clean text.
-    ///
-    /// - Parameter raw: Raw terminal output containing ANSI escape sequences
-    /// - Returns: Clean rendered text as it would appear in a terminal
     public func render(_ raw: String) -> String {
-        let delegate = RenderDelegate()
-        // Enable convertEol to handle \n as \r\n (newline + carriage return)
-        let options = TerminalOptions(cols: cols, rows: rows, convertEol: true)
-        let terminal = Terminal(delegate: delegate, options: options)
-
-        // Feed the raw output to the terminal emulator
-        terminal.feed(text: raw)
-
-        // Extract the rendered screen content
-        return extractScreenText(from: terminal)
+        #if canImport(SwiftTerm)
+        if #available(macOS 13, *) {
+            return _SwiftTermRenderer(cols: cols, rows: rows).render(raw)
+        }
+        #endif
+        return stripAnsiEscapes(raw)
     }
 
-    /// Extracts text content from the terminal buffer.
-    private func extractScreenText(from terminal: Terminal) -> String {
-        var lines: [String] = []
-
-        // Iterate through all lines in the terminal buffer
-        for row in 0..<rows {
-            guard let line = terminal.getLine(row: row) else {
-                lines.append("")
-                continue
-            }
-
-            var lineText = ""
-            for col in 0..<cols {
-                let charData = line[col]
-                let char = charData.getCharacter()
-                // Replace null character (empty cell) with space
-                lineText.append(char == "\0" ? " " : char)
-            }
-
-            // Trim trailing spaces from each line
-            lines.append(lineText.trimmingCharacters(in: CharacterSet(charactersIn: " \t\0")))
-        }
-
-        // Join lines and trim trailing empty lines
-        return lines
-            .reversed()
-            .drop(while: { $0.isEmpty })
-            .reversed()
-            .joined(separator: "\n")
+    private func stripAnsiEscapes(_ text: String) -> String {
+        var result = text
+        // Remove CSI sequences: ESC [ (params) (final byte)
+        result = result.replacingOccurrences(
+            of: #"\x1b\[[0-9;?]*[A-Za-z]"#,
+            with: "",
+            options: .regularExpression
+        )
+        // Remove OSC sequences: ESC ] (text) BEL
+        result = result.replacingOccurrences(
+            of: #"\x1b\][^\x07]*\x07"#,
+            with: "",
+            options: .regularExpression
+        )
+        // Remove carriage returns
+        result = result.replacingOccurrences(of: "\r", with: "")
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/Sources/Infrastructure/Shared/_SwiftTermRenderer.swift
+++ b/Sources/Infrastructure/Shared/_SwiftTermRenderer.swift
@@ -1,0 +1,51 @@
+import Foundation
+#if canImport(SwiftTerm)
+import SwiftTerm
+#endif
+
+#if canImport(SwiftTerm)
+@available(macOS 13, *)
+struct _SwiftTermRenderer {
+    private final class RenderDelegate: TerminalDelegate {
+        func send(source: Terminal, data: ArraySlice<UInt8>) {}
+    }
+
+    let cols: Int
+    let rows: Int
+
+    init(cols: Int = 160, rows: Int = 50) {
+        self.cols = cols
+        self.rows = rows
+    }
+
+    func render(_ raw: String) -> String {
+        let delegate = RenderDelegate()
+        let options = TerminalOptions(cols: cols, rows: rows, convertEol: true)
+        let terminal = Terminal(delegate: delegate, options: options)
+        terminal.feed(text: raw)
+        return extractScreenText(from: terminal)
+    }
+
+    private func extractScreenText(from terminal: Terminal) -> String {
+        var lines: [String] = []
+        for row in 0..<rows {
+            guard let line = terminal.getLine(row: row) else {
+                lines.append("")
+                continue
+            }
+            var lineText = ""
+            for col in 0..<cols {
+                let charData = line[col]
+                let char = charData.getCharacter()
+                lineText.append(char == "\0" ? " " : char)
+            }
+            lines.append(lineText.trimmingCharacters(in: CharacterSet(charactersIn: " \t\0")))
+        }
+        return lines
+            .reversed()
+            .drop(while: { $0.isEmpty })
+            .reversed()
+            .joined(separator: "\n")
+    }
+}
+#endif

--- a/Sources/Infrastructure/Storage/AIProviders.swift
+++ b/Sources/Infrastructure/Storage/AIProviders.swift
@@ -1,15 +1,16 @@
 import Foundation
-import Observation
+import Combine
 import Domain
 
 /// Repository of AI providers.
-/// Observable class that provides access to all providers and filters by enabled state.
-@Observable
-public final class AIProviders: AIProviderRepository, @unchecked Sendable {
+/// ObservableObject class that provides access to all providers and filters by enabled state.
+public final class AIProviders: ObservableObject, AIProviderRepository, @unchecked Sendable {
+    public let objectWillChange = ObservableObjectPublisher()
+
     // MARK: - All Providers
 
     /// All registered providers
-    public private(set) var all: [any AIProvider]
+    @Published public private(set) var all: [any AIProvider]
 
     // MARK: - Filtered Views
 
@@ -44,11 +45,13 @@ public final class AIProviders: AIProviderRepository, @unchecked Sendable {
             return
         }
         all.append(provider)
+        objectWillChange.send()
     }
 
     /// Removes a provider by ID
     /// - Parameter id: The provider identifier to remove
     public func remove(id: String) {
         all.removeAll { $0.id == id }
+        objectWillChange.send()
     }
 }

--- a/Tests/AcceptanceTests/BedrockConfigSpec.swift
+++ b/Tests/AcceptanceTests/BedrockConfigSpec.swift
@@ -17,8 +17,7 @@ import Mockable
 struct BedrockConfigSpec {
 
     private struct TestClock: Clock {
-        func sleep(for duration: Duration) async throws {}
-        func sleep(nanoseconds: UInt64) async throws {}
+        func sleep(for duration: TimeInterval) async throws {}
     }
 
     // MARK: - #43: AWS profile configuration

--- a/Tests/AcceptanceTests/ClaudeConfigSpec.swift
+++ b/Tests/AcceptanceTests/ClaudeConfigSpec.swift
@@ -17,8 +17,7 @@ import Mockable
 struct ClaudeConfigSpec {
 
     private struct TestClock: Clock {
-        func sleep(for duration: Duration) async throws {}
-        func sleep(nanoseconds: UInt64) async throws {}
+        func sleep(for duration: TimeInterval) async throws {}
     }
 
     // MARK: - #28: Switch Claude to API mode
@@ -26,8 +25,7 @@ struct ClaudeConfigSpec {
     @Suite("Scenario: Switch probe mode")
     struct SwitchProbeMode {
         private struct TestClock: Clock {
-            func sleep(for duration: Duration) async throws {}
-            func sleep(nanoseconds: UInt64) async throws {}
+            func sleep(for duration: TimeInterval) async throws {}
         }
 
         @Test
@@ -239,8 +237,7 @@ struct ClaudeConfigSpec {
     @Suite("Scenario: Expired session shows user-friendly error")
     struct SessionExpired {
         private struct TestClock: Clock {
-            func sleep(for duration: Duration) async throws {}
-            func sleep(nanoseconds: UInt64) async throws {}
+            func sleep(for duration: TimeInterval) async throws {}
         }
 
         @Test

--- a/Tests/AcceptanceTests/CodexConfigSpec.swift
+++ b/Tests/AcceptanceTests/CodexConfigSpec.swift
@@ -16,8 +16,7 @@ import Mockable
 struct CodexConfigSpec {
 
     private struct TestClock: Clock {
-        func sleep(for duration: Duration) async throws {}
-        func sleep(nanoseconds: UInt64) async throws {}
+        func sleep(for duration: TimeInterval) async throws {}
     }
 
     // MARK: - #33: Switch Codex to API mode
@@ -25,8 +24,7 @@ struct CodexConfigSpec {
     @Suite("Scenario: Switch probe mode")
     struct SwitchProbeMode {
         private struct TestClock: Clock {
-            func sleep(for duration: Duration) async throws {}
-            func sleep(nanoseconds: UInt64) async throws {}
+            func sleep(for duration: TimeInterval) async throws {}
         }
 
         @Test

--- a/Tests/AcceptanceTests/MenuBarSpec.swift
+++ b/Tests/AcceptanceTests/MenuBarSpec.swift
@@ -17,8 +17,7 @@ import Mockable
 struct MenuBarSpec {
 
     private struct TestClock: Clock {
-        func sleep(for duration: Duration) async throws {}
-        func sleep(nanoseconds: UInt64) async throws {}
+        func sleep(for duration: TimeInterval) async throws {}
     }
 
     private static func makeSettings() -> MockProviderSettingsRepository {
@@ -34,8 +33,7 @@ struct MenuBarSpec {
     @Suite("Scenario: Overall status calculation")
     struct OverallStatus {
         private struct TestClock: Clock {
-            func sleep(for duration: Duration) async throws {}
-            func sleep(nanoseconds: UInt64) async throws {}
+            func sleep(for duration: TimeInterval) async throws {}
         }
 
         @Test

--- a/Tests/AcceptanceTests/NotificationsSpec.swift
+++ b/Tests/AcceptanceTests/NotificationsSpec.swift
@@ -18,8 +18,7 @@ import Mockable
 struct NotificationsSpec {
 
     private struct TestClock: Clock {
-        func sleep(for duration: Duration) async throws {}
-        func sleep(nanoseconds: UInt64) async throws {}
+        func sleep(for duration: TimeInterval) async throws {}
     }
 
     private func makeSettings() -> MockProviderSettingsRepository {
@@ -36,8 +35,7 @@ struct NotificationsSpec {
     struct QuotaDegrades {
 
         private struct TestClock: Clock {
-            func sleep(for duration: Duration) async throws {}
-            func sleep(nanoseconds: UInt64) async throws {}
+            func sleep(for duration: TimeInterval) async throws {}
         }
 
         @Test
@@ -84,8 +82,7 @@ struct NotificationsSpec {
     struct QuotaUnchanged {
 
         private struct TestClock: Clock {
-            func sleep(for duration: Duration) async throws {}
-            func sleep(nanoseconds: UInt64) async throws {}
+            func sleep(for duration: TimeInterval) async throws {}
         }
 
         @Test
@@ -133,8 +130,7 @@ struct NotificationsSpec {
     struct ProviderIsolation {
 
         private struct TestClock: Clock {
-            func sleep(for duration: Duration) async throws {}
-            func sleep(nanoseconds: UInt64) async throws {}
+            func sleep(for duration: TimeInterval) async throws {}
         }
 
         @Test

--- a/Tests/AcceptanceTests/ProviderEnableDisableSpec.swift
+++ b/Tests/AcceptanceTests/ProviderEnableDisableSpec.swift
@@ -17,8 +17,7 @@ import Mockable
 struct ProviderEnableDisableSpec {
 
     private struct TestClock: Clock {
-        func sleep(for duration: Duration) async throws {}
-        func sleep(nanoseconds: UInt64) async throws {}
+        func sleep(for duration: TimeInterval) async throws {}
     }
 
     private static func makeSettings() -> MockProviderSettingsRepository {
@@ -34,8 +33,7 @@ struct ProviderEnableDisableSpec {
     @Suite("Scenario: Disable a provider")
     struct DisableProvider {
         private struct TestClock: Clock {
-            func sleep(for duration: Duration) async throws {}
-            func sleep(nanoseconds: UInt64) async throws {}
+            func sleep(for duration: TimeInterval) async throws {}
         }
 
         @Test
@@ -115,8 +113,7 @@ struct ProviderEnableDisableSpec {
     @Suite("Scenario: Enable a provider")
     struct EnableProvider {
         private struct TestClock: Clock {
-            func sleep(for duration: Duration) async throws {}
-            func sleep(nanoseconds: UInt64) async throws {}
+            func sleep(for duration: TimeInterval) async throws {}
         }
 
         @Test

--- a/Tests/AcceptanceTests/ProviderSelectionSpec.swift
+++ b/Tests/AcceptanceTests/ProviderSelectionSpec.swift
@@ -18,8 +18,7 @@ import Mockable
 struct ProviderSelectionSpec {
 
     private struct TestClock: Clock {
-        func sleep(for duration: Duration) async throws {}
-        func sleep(nanoseconds: UInt64) async throws {}
+        func sleep(for duration: TimeInterval) async throws {}
     }
 
     // MARK: - #4: Switch to a different provider
@@ -27,8 +26,7 @@ struct ProviderSelectionSpec {
     @Suite("Scenario: Switch to a different provider")
     struct SwitchProvider {
         private struct TestClock: Clock {
-            func sleep(for duration: Duration) async throws {}
-            func sleep(nanoseconds: UInt64) async throws {}
+            func sleep(for duration: TimeInterval) async throws {}
         }
 
         private static func makeSettings() -> MockProviderSettingsRepository {
@@ -85,8 +83,7 @@ struct ProviderSelectionSpec {
     @Suite("Scenario: Only enabled providers appear as pills")
     struct EnabledProviders {
         private struct TestClock: Clock {
-            func sleep(for duration: Duration) async throws {}
-            func sleep(nanoseconds: UInt64) async throws {}
+            func sleep(for duration: TimeInterval) async throws {}
         }
 
         private static func makeSettings() -> MockProviderSettingsRepository {
@@ -136,8 +133,7 @@ struct ProviderSelectionSpec {
     @Suite("Scenario: Disabling the currently selected provider")
     struct DisableSelectedProvider {
         private struct TestClock: Clock {
-            func sleep(for duration: Duration) async throws {}
-            func sleep(nanoseconds: UInt64) async throws {}
+            func sleep(for duration: TimeInterval) async throws {}
         }
 
         private static func makeSettings() -> MockProviderSettingsRepository {
@@ -192,8 +188,7 @@ struct ProviderSelectionSpec {
     @Suite("Scenario: Selecting a disabled provider")
     struct SelectDisabledProvider {
         private struct TestClock: Clock {
-            func sleep(for duration: Duration) async throws {}
-            func sleep(nanoseconds: UInt64) async throws {}
+            func sleep(for duration: TimeInterval) async throws {}
         }
 
         @Test

--- a/Tests/AcceptanceTests/QuotaDisplaySpec.swift
+++ b/Tests/AcceptanceTests/QuotaDisplaySpec.swift
@@ -19,8 +19,7 @@ import Mockable
 struct QuotaDisplaySpec {
 
     private struct TestClock: Clock {
-        func sleep(for duration: Duration) async throws {}
-        func sleep(nanoseconds: UInt64) async throws {}
+        func sleep(for duration: TimeInterval) async throws {}
     }
 
     // MARK: - #8: Account info card
@@ -28,8 +27,7 @@ struct QuotaDisplaySpec {
     @Suite("Scenario: Account info displays after refresh")
     struct AccountInfo {
         private struct TestClock: Clock {
-            func sleep(for duration: Duration) async throws {}
-            func sleep(nanoseconds: UInt64) async throws {}
+            func sleep(for duration: TimeInterval) async throws {}
         }
 
         private static func makeSettings() -> MockProviderSettingsRepository {
@@ -85,8 +83,7 @@ struct QuotaDisplaySpec {
     @Suite("Scenario: Quota cards display correctly after refresh")
     struct QuotaCards {
         private struct TestClock: Clock {
-            func sleep(for duration: Duration) async throws {}
-            func sleep(nanoseconds: UInt64) async throws {}
+            func sleep(for duration: TimeInterval) async throws {}
         }
 
         private static func makeSettings() -> MockProviderSettingsRepository {
@@ -209,8 +206,7 @@ struct QuotaDisplaySpec {
     @Suite("Scenario: Unavailable provider shows error message")
     struct ProviderErrors {
         private struct TestClock: Clock {
-            func sleep(for duration: Duration) async throws {}
-            func sleep(nanoseconds: UInt64) async throws {}
+            func sleep(for duration: TimeInterval) async throws {}
         }
 
         @Test

--- a/Tests/AcceptanceTests/RefreshSpec.swift
+++ b/Tests/AcceptanceTests/RefreshSpec.swift
@@ -17,8 +17,7 @@ import Mockable
 struct RefreshSpec {
 
     private struct TestClock: Clock {
-        func sleep(for duration: Duration) async throws {}
-        func sleep(nanoseconds: UInt64) async throws {}
+        func sleep(for duration: TimeInterval) async throws {}
     }
 
     private static func makeSettings() -> MockProviderSettingsRepository {
@@ -34,8 +33,7 @@ struct RefreshSpec {
     @Suite("Scenario: Successful refresh")
     struct SuccessfulRefresh {
         private struct TestClock: Clock {
-            func sleep(for duration: Duration) async throws {}
-            func sleep(nanoseconds: UInt64) async throws {}
+            func sleep(for duration: TimeInterval) async throws {}
         }
 
         @Test
@@ -105,8 +103,7 @@ struct RefreshSpec {
     @Suite("Scenario: Background sync")
     struct BackgroundSync {
         private struct TestClock: Clock {
-            func sleep(for duration: Duration) async throws {}
-            func sleep(nanoseconds: UInt64) async throws {}
+            func sleep(for duration: TimeInterval) async throws {}
         }
 
         @Test
@@ -128,7 +125,7 @@ struct RefreshSpec {
             )
 
             // When — start monitoring
-            let stream = monitor.startMonitoring(interval: .milliseconds(100))
+            let stream = monitor.startMonitoring(interval: 0.1)
             var events: [MonitoringEvent] = []
 
             for await event in stream.prefix(2) {
@@ -161,7 +158,7 @@ struct RefreshSpec {
             )
 
             // When — start then immediately stop
-            let stream = monitor.startMonitoring(interval: .milliseconds(50))
+            let stream = monitor.startMonitoring(interval: 0.05)
             monitor.stopMonitoring()
 
             var eventCount = 0

--- a/Tests/DomainTests/Monitor/QuotaMonitorTests.swift
+++ b/Tests/DomainTests/Monitor/QuotaMonitorTests.swift
@@ -7,8 +7,7 @@ import Mockable
 @Suite
 struct QuotaMonitorTests {
     private struct TestClock: Clock {
-        func sleep(for duration: Duration) async throws {}
-        func sleep(nanoseconds: UInt64) async throws {}
+        func sleep(for duration: TimeInterval) async throws {}
     }
 
     private func makeMonitor(
@@ -329,7 +328,7 @@ struct QuotaMonitorTests {
         let monitor = makeMonitor(providers: AIProviders(providers: [provider]))
 
         // When
-        let stream = monitor.startMonitoring(interval: .milliseconds(100))
+        let stream = monitor.startMonitoring(interval: 0.1)
         var events: [MonitoringEvent] = []
 
         // Collect first 2 events
@@ -362,7 +361,7 @@ struct QuotaMonitorTests {
         let monitor = makeMonitor(providers: AIProviders(providers: [provider]))
 
         // When
-        let stream = monitor.startMonitoring(interval: .milliseconds(50))
+        let stream = monitor.startMonitoring(interval: 0.05)
         monitor.stopMonitoring()
 
         var eventCount = 0

--- a/Tests/InfrastructureTests/Extension/ExtensionDirectoryScannerTests.swift
+++ b/Tests/InfrastructureTests/Extension/ExtensionDirectoryScannerTests.swift
@@ -9,11 +9,11 @@ struct ExtensionDirectoryScannerTests {
 
     @Test
     func `scans directory and finds valid extensions`() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appending(path: "ext-test-\(UUID().uuidString)")
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("ext-test-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         // Create two extension directories with manifests
-        let ext1Dir = tempDir.appending(path: "my-provider")
+        let ext1Dir = tempDir.appendingPathComponent("my-provider")
         try FileManager.default.createDirectory(at: ext1Dir, withIntermediateDirectories: true)
         let manifest1 = """
         {
@@ -29,9 +29,9 @@ struct ExtensionDirectoryScannerTests {
             ]
         }
         """
-        try manifest1.write(to: ext1Dir.appending(path: "manifest.json"), atomically: true, encoding: .utf8)
+        try manifest1.write(to: ext1Dir.appendingPathComponent("manifest.json"), atomically: true, encoding: .utf8)
 
-        let ext2Dir = tempDir.appending(path: "another")
+        let ext2Dir = tempDir.appendingPathComponent("another")
         try FileManager.default.createDirectory(at: ext2Dir, withIntermediateDirectories: true)
         let manifest2 = """
         {
@@ -47,7 +47,7 @@ struct ExtensionDirectoryScannerTests {
             ]
         }
         """
-        try manifest2.write(to: ext2Dir.appending(path: "manifest.json"), atomically: true, encoding: .utf8)
+        try manifest2.write(to: ext2Dir.appendingPathComponent("manifest.json"), atomically: true, encoding: .utf8)
 
         let scanner = ExtensionDirectoryScanner()
         let results = scanner.scan(directory: tempDir)
@@ -60,13 +60,13 @@ struct ExtensionDirectoryScannerTests {
 
     @Test
     func `skips directories without manifest json`() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appending(path: "ext-test-\(UUID().uuidString)")
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("ext-test-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         // Create directory without manifest
-        let extDir = tempDir.appending(path: "no-manifest")
+        let extDir = tempDir.appendingPathComponent("no-manifest")
         try FileManager.default.createDirectory(at: extDir, withIntermediateDirectories: true)
-        try "just a probe".write(to: extDir.appending(path: "probe.sh"), atomically: true, encoding: .utf8)
+        try "just a probe".write(to: extDir.appendingPathComponent("probe.sh"), atomically: true, encoding: .utf8)
 
         let scanner = ExtensionDirectoryScanner()
         let results = scanner.scan(directory: tempDir)
@@ -76,12 +76,12 @@ struct ExtensionDirectoryScannerTests {
 
     @Test
     func `skips directories with invalid manifest`() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appending(path: "ext-test-\(UUID().uuidString)")
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("ext-test-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        let extDir = tempDir.appending(path: "bad-ext")
+        let extDir = tempDir.appendingPathComponent("bad-ext")
         try FileManager.default.createDirectory(at: extDir, withIntermediateDirectories: true)
-        try "{ invalid json".write(to: extDir.appending(path: "manifest.json"), atomically: true, encoding: .utf8)
+        try "{ invalid json".write(to: extDir.appendingPathComponent("manifest.json"), atomically: true, encoding: .utf8)
 
         let scanner = ExtensionDirectoryScanner()
         let results = scanner.scan(directory: tempDir)
@@ -92,17 +92,17 @@ struct ExtensionDirectoryScannerTests {
     @Test
     func `returns empty array when directory does not exist`() {
         let scanner = ExtensionDirectoryScanner()
-        let results = scanner.scan(directory: URL(filePath: "/nonexistent/path"))
+        let results = scanner.scan(directory: URL(fileURLWithPath: "/nonexistent/path"))
 
         #expect(results.isEmpty)
     }
 
     @Test
     func `scan result includes directory URL`() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appending(path: "ext-test-\(UUID().uuidString)")
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("ext-test-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        let extDir = tempDir.appending(path: "my-ext")
+        let extDir = tempDir.appendingPathComponent("my-ext")
         try FileManager.default.createDirectory(at: extDir, withIntermediateDirectories: true)
         let manifest = """
         {
@@ -114,7 +114,7 @@ struct ExtensionDirectoryScannerTests {
             ]
         }
         """
-        try manifest.write(to: extDir.appending(path: "manifest.json"), atomically: true, encoding: .utf8)
+        try manifest.write(to: extDir.appendingPathComponent("manifest.json"), atomically: true, encoding: .utf8)
 
         let scanner = ExtensionDirectoryScanner()
         let results = scanner.scan(directory: tempDir)

--- a/Tests/InfrastructureTests/Extension/JSONExtensionConfigRepositoryTests.swift
+++ b/Tests/InfrastructureTests/Extension/JSONExtensionConfigRepositoryTests.swift
@@ -7,9 +7,9 @@ import Testing
 struct JSONExtensionConfigRepositoryTests {
     private func makeTempStore() -> (JSONExtensionConfigRepository, URL) {
         let tempDir = FileManager.default.temporaryDirectory
-            .appending(path: "claudebar-test-\(UUID().uuidString)")
+            .appendingPathComponent("claudebar-test-\(UUID().uuidString)")
         try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        let settingsFile = tempDir.appending(path: "settings.json")
+        let settingsFile = tempDir.appendingPathComponent("settings.json")
         let store = JSONExtensionConfigRepository(
             settingsStore: JSONSettingsStore(fileURL: settingsFile),
             userDefaultsSuiteName: "com.claudebar.test.\(UUID().uuidString)"
@@ -73,12 +73,12 @@ struct JSONExtensionConfigRepositoryTests {
     func `stores and retrieves a secret value via UserDefaults`() {
         let suiteName = "com.claudebar.test.\(UUID().uuidString)"
         let tempDir = FileManager.default.temporaryDirectory
-            .appending(path: "claudebar-test-\(UUID().uuidString)")
+            .appendingPathComponent("claudebar-test-\(UUID().uuidString)")
         try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let store = JSONExtensionConfigRepository(
-            settingsStore: JSONSettingsStore(fileURL: tempDir.appending(path: "settings.json")),
+            settingsStore: JSONSettingsStore(fileURL: tempDir.appendingPathComponent("settings.json")),
             userDefaultsSuiteName: suiteName
         )
 
@@ -105,12 +105,12 @@ struct JSONExtensionConfigRepositoryTests {
     func `removes secret when set to nil`() {
         let suiteName = "com.claudebar.test.\(UUID().uuidString)"
         let tempDir = FileManager.default.temporaryDirectory
-            .appending(path: "claudebar-test-\(UUID().uuidString)")
+            .appendingPathComponent("claudebar-test-\(UUID().uuidString)")
         try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let store = JSONExtensionConfigRepository(
-            settingsStore: JSONSettingsStore(fileURL: tempDir.appending(path: "settings.json")),
+            settingsStore: JSONSettingsStore(fileURL: tempDir.appendingPathComponent("settings.json")),
             userDefaultsSuiteName: suiteName
         )
 
@@ -128,7 +128,7 @@ struct JSONExtensionConfigRepositoryTests {
     func `allValues returns all stored values for an extension`() {
         let suiteName = "com.claudebar.test.\(UUID().uuidString)"
         let tempDir = FileManager.default.temporaryDirectory
-            .appending(path: "claudebar-test-\(UUID().uuidString)")
+            .appendingPathComponent("claudebar-test-\(UUID().uuidString)")
         try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         defer {
             try? FileManager.default.removeItem(at: tempDir)
@@ -136,7 +136,7 @@ struct JSONExtensionConfigRepositoryTests {
         }
 
         let store = JSONExtensionConfigRepository(
-            settingsStore: JSONSettingsStore(fileURL: tempDir.appending(path: "settings.json")),
+            settingsStore: JSONSettingsStore(fileURL: tempDir.appendingPathComponent("settings.json")),
             userDefaultsSuiteName: suiteName
         )
 

--- a/Tests/InfrastructureTests/Extension/ScriptProbeTests.swift
+++ b/Tests/InfrastructureTests/Extension/ScriptProbeTests.swift
@@ -34,7 +34,7 @@ struct ScriptProbeTests {
 
         let probe = ScriptProbe(
             scriptPath: "/ext/probe.sh",
-            extensionDir: URL(filePath: "/ext"),
+            extensionDir: URL(fileURLWithPath: "/ext"),
             providerId: "test",
             sectionType: .quotaGrid,
             timeout: 10,
@@ -73,7 +73,7 @@ struct ScriptProbeTests {
 
         let probe = ScriptProbe(
             scriptPath: "./probe.sh",
-            extensionDir: URL(filePath: "/ext"),
+            extensionDir: URL(fileURLWithPath: "/ext"),
             providerId: "test",
             sectionType: .metricsRow,
             timeout: 10,
@@ -106,7 +106,7 @@ struct ScriptProbeTests {
 
         let probe = ScriptProbe(
             scriptPath: "./probe.sh",
-            extensionDir: URL(filePath: "/ext"),
+            extensionDir: URL(fileURLWithPath: "/ext"),
             providerId: "test",
             sectionType: .costUsage,
             timeout: 10,
@@ -131,7 +131,7 @@ struct ScriptProbeTests {
 
         let probe = ScriptProbe(
             scriptPath: "./probe.sh",
-            extensionDir: URL(filePath: "/ext"),
+            extensionDir: URL(fileURLWithPath: "/ext"),
             providerId: "test",
             sectionType: .quotaGrid,
             timeout: 10,
@@ -153,7 +153,7 @@ struct ScriptProbeTests {
 
         let probe = ScriptProbe(
             scriptPath: "./probe.sh",
-            extensionDir: URL(filePath: "/ext"),
+            extensionDir: URL(fileURLWithPath: "/ext"),
             providerId: "test",
             sectionType: .quotaGrid,
             timeout: 10,
@@ -169,11 +169,11 @@ struct ScriptProbeTests {
 
     @Test
     func `isAvailable returns true when script exists`() async throws {
-        let tempDir = FileManager.default.temporaryDirectory.appending(path: "probe-test-\(UUID().uuidString)")
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("probe-test-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        let scriptFile = tempDir.appending(path: "probe.sh")
+        let scriptFile = tempDir.appendingPathComponent("probe.sh")
         try "#!/bin/sh\necho '{}'".write(to: scriptFile, atomically: true, encoding: .utf8)
 
         let executor = MockCLIExecutor()
@@ -225,7 +225,7 @@ struct ScriptProbeTests {
 
         let probe = ScriptProbe(
             scriptPath: "./probe.sh",
-            extensionDir: URL(filePath: "/ext"),
+            extensionDir: URL(fileURLWithPath: "/ext"),
             providerId: "ext-openrouter",
             sectionType: .quotaGrid,
             timeout: 10,
@@ -260,7 +260,7 @@ struct ScriptProbeTests {
 
         let probe = ScriptProbe(
             scriptPath: "./probe.sh",
-            extensionDir: URL(filePath: "/ext"),
+            extensionDir: URL(fileURLWithPath: "/ext"),
             providerId: "test",
             sectionType: .quotaGrid,
             timeout: 10,
@@ -280,7 +280,7 @@ struct ScriptProbeTests {
 
         let probe = ScriptProbe(
             scriptPath: "./nonexistent.sh",
-            extensionDir: URL(filePath: "/nonexistent"),
+            extensionDir: URL(fileURLWithPath: "/nonexistent"),
             providerId: "test",
             sectionType: .quotaGrid,
             timeout: 10,

--- a/Tests/InfrastructureTests/Gemini/GeminiAPIProbeTests.swift
+++ b/Tests/InfrastructureTests/Gemini/GeminiAPIProbeTests.swift
@@ -6,10 +6,6 @@ import Mockable
 
 @Suite
 struct GeminiAPIProbeTests {
-    private struct TestClock: Clock {
-        func sleep(for duration: Duration) async throws {}
-        func sleep(nanoseconds: UInt64) async throws {}
-    }
 
     // MARK: - Helpers
 
@@ -265,8 +261,7 @@ struct GeminiAPIProbeTests {
             timeout: 1.0,
             networkClient: mockService,
             maxRetries: 1,
-            cliExecutor: mockExecutor,
-            clock: TestClock()
+            cliExecutor: mockExecutor
         )
 
         let snapshot = try await probe.probe()
@@ -315,8 +310,7 @@ struct GeminiAPIProbeTests {
             timeout: 1.0,
             networkClient: mockService,
             maxRetries: 1,
-            cliExecutor: mockExecutor,
-            clock: TestClock()
+            cliExecutor: mockExecutor
         )
 
         await #expect(throws: ProbeError.authenticationRequired) {
@@ -366,8 +360,7 @@ struct GeminiAPIProbeTests {
             timeout: 1.0,
             networkClient: mockService,
             maxRetries: 1,
-            cliExecutor: mockExecutor,
-            clock: TestClock()
+            cliExecutor: mockExecutor
         )
 
         await #expect(throws: ProbeError.authenticationRequired) {
@@ -420,8 +413,7 @@ struct GeminiAPIProbeTests {
             timeout: 1.0,
             networkClient: mockService,
             maxRetries: 1,
-            cliExecutor: mockExecutor,
-            clock: TestClock()
+            cliExecutor: mockExecutor
         )
 
         await #expect(throws: ProbeError.executionFailed("HTTP 500")) {

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -13,7 +13,11 @@ let packageSettings = PackageSettings(
     targetSettings: [
         "IssueReporting": ["SWIFT_PACKAGE_NAME": "xctest-dynamic-overlay"],
         "IssueReportingPackageSupport": ["SWIFT_PACKAGE_NAME": "xctest-dynamic-overlay"],
-        "SwiftTerm": ["EXCLUDED_SOURCE_FILE_NAMES": "Shaders.metal"],
+        "SwiftTerm": [
+            "EXCLUDED_SOURCE_FILE_NAMES": "Shaders.metal",
+            "MACOSX_DEPLOYMENT_TARGET": "12.0",
+        ],
+        "SweetCookieKit": ["MACOSX_DEPLOYMENT_TARGET": "12.0"],
     ]
 )
 #endif


### PR DESCRIPTION
In case you want to offer releases for macOS 12, this CR lowers the deployment target from macOS 15.0 to macOS 12.0 so ClaudeBar runs on Monterey. This required replacing several macOS 13+/14+ APIs:

- @Observable macro -> ObservableObject with @Published (20 classes)
- MenuBarExtra -> NSStatusBar with NSPopover
- .onChange two-parameter closures -> single-parameter form (26 sites)
- #Preview macro -> PreviewProvider structs (24 sites)
- .foregroundStyle() -> .foregroundColor() (349 occurrences)
- .spring(response:dampingFraction:) -> .spring()
- .contentTransition(.numericText()) -> removed
- .badge(Color) -> removed
- Date.formatted() -> DateFormatter
- SMAppService -> guarded with #available(macOS 13, *)
- URL(filePath:)/.appending(path:) -> fileURLWithPath equivalents
- TimeInterval.milliseconds -> literal Double values

All 100+ tests pass across Domain, Infrastructure, and Acceptance suites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS minimum support lowered to 12.0
  * Native status bar icon + popover replaces prior menu entry
  * Automatic browser cookie extraction for select providers

* **Improvements**
  * App state observation updated for snappier, more responsive UI
  * UI color handling and previews refined for more consistent visuals
<!-- end of auto-generated comment: release notes by coderabbit.ai -->