### PR TITLE
Add optional menu bar quota percentage display

### DIFF
--- a/Sources/App/ClaudeBarApp.swift
+++ b/Sources/App/ClaudeBarApp.swift
@@ -142,6 +142,18 @@ struct ClaudeBarApp: App {
         return snapshot.overallStatus
     }
 
+    private var menuBarPercentageDisplay: MenuBarPercentageDisplay? {
+        guard settings.menuBarPercentageEnabled else { return nil }
+
+        return monitor.menuBarPercentageDisplay(
+            providerId: settings.menuBarPercentageProviderId,
+            quotaKey: settings.menuBarPercentageQuotaKey,
+            mode: settings.usageDisplayMode,
+            burnRateWarningEnabled: settings.burnRateWarningEnabled,
+            burnRateThreshold: settings.burnRateThreshold
+        )
+    }
+
     /// Current theme mode from settings
     private var currentThemeMode: ThemeMode {
         ThemeMode(rawValue: settings.themeMode) ?? .system
@@ -218,8 +230,13 @@ struct ClaudeBarApp: App {
             #endif
         } label: {
             // Show overall status + active session indicator in menu bar
-            StatusBarIcon(status: effectiveSelectedProviderStatus, activeSession: sessionMonitor.activeSession)
-                .appThemeProvider(themeModeId: settings.themeMode)
+            if let display = menuBarPercentageDisplay {
+                StatusBarPercentageLabel(display: display, activeSession: sessionMonitor.activeSession)
+                    .appThemeProvider(themeModeId: settings.themeMode)
+            } else {
+                StatusBarIcon(status: effectiveSelectedProviderStatus, activeSession: sessionMonitor.activeSession)
+                    .appThemeProvider(themeModeId: settings.themeMode)
+            }
         }
         .menuBarExtraStyle(.window)
     }
@@ -275,6 +292,61 @@ struct StatusBarIcon: View {
 
     private func sessionPhaseColor(_ phase: ClaudeSession.Phase) -> Color {
         phase.color
+    }
+}
+
+/// The menu bar percentage label for an opt-in provider/quota selection.
+struct StatusBarPercentageLabel: View {
+    let display: MenuBarPercentageDisplay
+    var activeSession: ClaudeSession? = nil
+
+    @Environment(\.appTheme) private var theme
+
+    var body: some View {
+        let statusColor = theme.statusColor(for: display.status)
+
+        HStack(spacing: 3) {
+            if let session = activeSession {
+                Image(systemName: "terminal.fill")
+                    .symbolRenderingMode(.palette)
+                    .foregroundStyle(sessionPhaseColor(session.phase))
+            }
+
+            Image(nsImage: StatusBarPercentageImageRenderer.image(
+                text: display.text,
+                color: statusColor
+            ))
+            .renderingMode(.original)
+            .accessibilityLabel(display.text)
+        }
+    }
+
+    private func sessionPhaseColor(_ phase: ClaudeSession.Phase) -> Color {
+        phase.color
+    }
+}
+
+/// Renders status text as an original-color image because macOS can ignore
+/// `Text.foregroundStyle` inside a `MenuBarExtra` label.
+private enum StatusBarPercentageImageRenderer {
+    @MainActor
+    static func image(text: String, color: Color) -> NSImage {
+        let font = NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .semibold)
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: NSColor(color),
+        ]
+        let attributedText = NSAttributedString(string: text, attributes: attributes)
+        let textSize = attributedText.size()
+        let imageSize = NSSize(width: ceil(textSize.width), height: ceil(textSize.height))
+        let image = NSImage(size: imageSize)
+        image.isTemplate = false
+
+        image.lockFocus()
+        attributedText.draw(at: .zero)
+        image.unlockFocus()
+
+        return image
     }
 }
 

--- a/Sources/App/ClaudeBarApp.swift
+++ b/Sources/App/ClaudeBarApp.swift
@@ -243,6 +243,10 @@ struct ClaudeBarApp: App {
 
 }
 
+private func sessionPhaseColor(_ phase: ClaudeSession.Phase) -> Color {
+    phase.color
+}
+
 /// The menu bar icon that reflects the overall quota status.
 /// When a Claude Code session is active, shows a terminal icon with phase color.
 /// Uses theme's `statusBarIconName` if set, otherwise shows status-based icons.
@@ -289,10 +293,6 @@ struct StatusBarIcon: View {
     private var iconColor: Color {
         theme.statusColor(for: status)
     }
-
-    private func sessionPhaseColor(_ phase: ClaudeSession.Phase) -> Color {
-        phase.color
-    }
 }
 
 /// The menu bar percentage label for an opt-in provider/quota selection.
@@ -321,9 +321,6 @@ struct StatusBarPercentageLabel: View {
         }
     }
 
-    private func sessionPhaseColor(_ phase: ClaudeSession.Phase) -> Color {
-        phase.color
-    }
 }
 
 /// Renders status text as an original-color image because macOS can ignore
@@ -339,12 +336,11 @@ private enum StatusBarPercentageImageRenderer {
         let attributedText = NSAttributedString(string: text, attributes: attributes)
         let textSize = attributedText.size()
         let imageSize = NSSize(width: ceil(textSize.width), height: ceil(textSize.height))
-        let image = NSImage(size: imageSize)
+        let image = NSImage(size: imageSize, flipped: false) { _ in
+            attributedText.draw(at: .zero)
+            return true
+        }
         image.isTemplate = false
-
-        image.lockFocus()
-        attributedText.draw(at: .zero)
-        image.unlockFocus()
 
         return image
     }

--- a/Sources/App/Settings/AppSettings.swift
+++ b/Sources/App/Settings/AppSettings.swift
@@ -35,10 +35,31 @@ public final class AppSettings {
 
     // MARK: - Display Settings
 
-    /// Whether to show quota as "remaining" or "used"
+    /// Whether to show quota as remaining, used, or pace-aware.
     public var usageDisplayMode: UsageDisplayMode {
         didSet {
             repository.setUsageDisplayMode(usageDisplayMode.rawValue)
+        }
+    }
+
+    /// Whether the menu bar label should show a selected quota percentage instead of the icon.
+    public var menuBarPercentageEnabled: Bool {
+        didSet {
+            repository.setMenuBarPercentageEnabled(menuBarPercentageEnabled)
+        }
+    }
+
+    /// Provider used for the menu bar percentage label.
+    public var menuBarPercentageProviderId: String {
+        didSet {
+            repository.setMenuBarPercentageProviderId(menuBarPercentageProviderId)
+        }
+    }
+
+    /// Quota key used for the menu bar percentage label.
+    public var menuBarPercentageQuotaKey: String {
+        didSet {
+            repository.setMenuBarPercentageQuotaKey(menuBarPercentageQuotaKey)
         }
     }
 
@@ -155,6 +176,9 @@ public final class AppSettings {
         self.overviewModeEnabled = repository.overviewModeEnabled()
         self.backgroundSyncEnabled = repository.backgroundSyncEnabled()
         self.backgroundSyncInterval = repository.backgroundSyncInterval()
+        self.menuBarPercentageEnabled = repository.menuBarPercentageEnabled()
+        self.menuBarPercentageProviderId = repository.menuBarPercentageProviderId()
+        self.menuBarPercentageQuotaKey = repository.menuBarPercentageQuotaKey()
 
         if let mode = UsageDisplayMode(rawValue: repository.usageDisplayMode()) {
             self.usageDisplayMode = mode

--- a/Sources/App/Views/MenuContentView.swift
+++ b/Sources/App/Views/MenuContentView.swift
@@ -147,6 +147,9 @@ struct MenuContentView: View {
             Task {
                 await refresh(providerId: newProviderId)
             }
+            if settings.backgroundSyncEnabled && settings.menuBarPercentageEnabled {
+                restartBackgroundSync()
+            }
         }
         .onChange(of: settings.backgroundSyncEnabled) { _, enabled in
             // React to background sync toggle
@@ -162,6 +165,16 @@ struct MenuContentView: View {
                 restartBackgroundSync()
             }
         }
+        .onChange(of: settings.menuBarPercentageEnabled) { _, _ in
+            if settings.backgroundSyncEnabled {
+                restartBackgroundSync()
+            }
+        }
+        .onChange(of: settings.menuBarPercentageProviderId) { _, _ in
+            if settings.backgroundSyncEnabled && settings.menuBarPercentageEnabled {
+                restartBackgroundSync()
+            }
+        }
     }
 
     // MARK: - Background Sync Control
@@ -170,11 +183,19 @@ struct MenuContentView: View {
         let interval = Duration.seconds(settings.backgroundSyncInterval)
         AppLog.monitor.info("Starting background sync (interval: \(settings.backgroundSyncInterval)s)")
         Task {
-            let stream = monitor.startMonitoring(interval: interval)
+            let stream = monitor.startMonitoring(interval: interval, providerIds: backgroundSyncProviderIds)
             for await _ in stream {
                 // Events handled internally by QuotaMonitor
             }
         }
+    }
+
+    private var backgroundSyncProviderIds: [String]? {
+        guard settings.menuBarPercentageEnabled else { return nil }
+        return [
+            selectedProviderId,
+            settings.menuBarPercentageProviderId,
+        ]
     }
 
     private func stopBackgroundSync() {

--- a/Sources/App/Views/SettingsView.swift
+++ b/Sources/App/Views/SettingsView.swift
@@ -1440,51 +1440,34 @@ struct MenuBarProviderChoiceButton: View {
     let isSelected: Bool
     let action: () -> Void
 
-    @Environment(\.appTheme) private var theme
-    @State private var isHovering = false
-
     var body: some View {
-        Button(action: action) {
-            HStack(spacing: 6) {
-                Image(systemName: ProviderVisualIdentityLookup.symbolIcon(for: providerId))
-                    .font(.system(size: 10, weight: .bold))
-
-                Text(providerName)
-                    .font(.system(size: 11, weight: .semibold, design: theme.fontDesign))
-                    .lineLimit(1)
-            }
-            .foregroundStyle(isSelected ? selectedForeground : theme.textSecondary)
-            .padding(.horizontal, 10)
-            .padding(.vertical, 8)
-            .background(buttonBackground)
-        }
-        .buttonStyle(.plain)
-        .onHover { isHovering = $0 }
-    }
-
-    private var selectedForeground: Color {
-        theme.id == "cli" ? theme.textPrimary : .white
-    }
-
-    private var buttonBackground: some View {
-        ZStack {
-            if isSelected {
-                RoundedRectangle(cornerRadius: theme.pillCornerRadius)
-                    .fill(theme.accentGradient)
-                    .shadow(color: theme.accentPrimary.opacity(0.25), radius: 5, y: 2)
-            } else {
-                RoundedRectangle(cornerRadius: theme.pillCornerRadius)
-                    .fill(isHovering ? theme.hoverOverlay : theme.glassBackground)
-            }
-
-            RoundedRectangle(cornerRadius: theme.pillCornerRadius)
-                .stroke(isSelected ? theme.accentPrimary.opacity(0.5) : theme.glassBorder, lineWidth: 1)
-        }
+        MenuBarChoiceButton(
+            iconName: ProviderVisualIdentityLookup.symbolIcon(for: providerId),
+            label: providerName,
+            isSelected: isSelected,
+            action: action
+        )
     }
 }
 
 struct MenuBarQuotaChoiceButton: View {
     let title: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        MenuBarChoiceButton(
+            iconName: "gauge.with.needle.fill",
+            label: title,
+            isSelected: isSelected,
+            action: action
+        )
+    }
+}
+
+struct MenuBarChoiceButton: View {
+    let iconName: String
+    let label: String
     let isSelected: Bool
     let action: () -> Void
 
@@ -1494,10 +1477,10 @@ struct MenuBarQuotaChoiceButton: View {
     var body: some View {
         Button(action: action) {
             HStack(spacing: 6) {
-                Image(systemName: "gauge.with.needle.fill")
+                Image(systemName: iconName)
                     .font(.system(size: 10, weight: .bold))
 
-                Text(title)
+                Text(label)
                     .font(.system(size: 11, weight: .semibold, design: theme.fontDesign))
                     .lineLimit(1)
             }

--- a/Sources/App/Views/SettingsView.swift
+++ b/Sources/App/Views/SettingsView.swift
@@ -236,6 +236,10 @@ struct SettingsContentView: View {
         VStack(alignment: .leading, spacing: 12) {
             displayModeHeader
             displayModeToggle
+            menuBarPercentageToggle
+            if settings.menuBarPercentageEnabled {
+                menuBarPercentageControls
+            }
             dailyUsageCardsToggle
         }
         .padding(14)
@@ -266,7 +270,7 @@ struct SettingsContentView: View {
                     .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
                     .foregroundStyle(theme.textPrimary)
 
-                Text("Show remaining or used percentage")
+                Text("Show remaining, used, or pace")
                     .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
                     .foregroundStyle(theme.textTertiary)
             }
@@ -287,6 +291,130 @@ struct SettingsContentView: View {
                     }
                 }
             }
+        }
+    }
+
+    private var menuBarPercentageProviders: [any AIProvider] {
+        monitor.enabledProviders
+    }
+
+    private var selectedMenuBarPercentageProvider: (any AIProvider)? {
+        menuBarPercentageProviders.first { $0.id == settings.menuBarPercentageProviderId }
+            ?? monitor.selectedProvider
+            ?? menuBarPercentageProviders.first
+    }
+
+    private var menuBarPercentageQuotaOptions: [UsageQuota] {
+        selectedMenuBarPercentageProvider?.snapshot?.quotas ?? []
+    }
+
+    private var menuBarPercentageToggle: some View {
+        HStack {
+            Text("Menu Bar Percentage")
+                .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
+                .foregroundStyle(theme.textSecondary)
+
+            Spacer()
+
+            Toggle("", isOn: Binding(
+                get: { settings.menuBarPercentageEnabled },
+                set: { enabled in
+                    settings.menuBarPercentageEnabled = enabled
+                    if enabled {
+                        normalizeMenuBarPercentageSelection()
+                    }
+                }
+            ))
+            .toggleStyle(.switch)
+            .tint(theme.accentPrimary)
+            .scaleEffect(0.8)
+            .labelsHidden()
+        }
+    }
+
+    private var menuBarPercentageControls: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("PROVIDER")
+                    .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
+                    .foregroundStyle(theme.textSecondary)
+                    .tracking(0.5)
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ForEach(menuBarPercentageProviders, id: \.id) { provider in
+                            MenuBarProviderChoiceButton(
+                                providerId: provider.id,
+                                providerName: provider.name,
+                                isSelected: settings.menuBarPercentageProviderId == provider.id
+                            ) {
+                                settings.menuBarPercentageProviderId = provider.id
+                                selectFirstMenuBarPercentageQuotaIfNeeded(force: true)
+                            }
+                        }
+                    }
+                }
+                .disabled(menuBarPercentageProviders.isEmpty)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("QUOTA")
+                    .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
+                    .foregroundStyle(theme.textSecondary)
+                    .tracking(0.5)
+
+                if menuBarPercentageQuotaOptions.isEmpty {
+                    Text("No quota data")
+                        .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
+                        .foregroundStyle(theme.textTertiary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 7)
+                        .background(
+                            RoundedRectangle(cornerRadius: theme.pillCornerRadius)
+                                .fill(theme.glassBackground)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: theme.pillCornerRadius)
+                                        .stroke(theme.glassBorder, lineWidth: 1)
+                                )
+                        )
+                } else {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 8) {
+                            ForEach(menuBarPercentageQuotaOptions, id: \.quotaType.quotaKey) { quota in
+                                MenuBarQuotaChoiceButton(
+                                    title: quota.quotaType.displayName,
+                                    isSelected: settings.menuBarPercentageQuotaKey == quota.quotaType.quotaKey
+                                ) {
+                                    settings.menuBarPercentageQuotaKey = quota.quotaType.quotaKey
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .onAppear {
+            normalizeMenuBarPercentageSelection()
+        }
+    }
+
+    private func normalizeMenuBarPercentageSelection() {
+        if let provider = selectedMenuBarPercentageProvider,
+           settings.menuBarPercentageProviderId != provider.id {
+            settings.menuBarPercentageProviderId = provider.id
+        }
+        selectFirstMenuBarPercentageQuotaIfNeeded(force: false)
+    }
+
+    private func selectFirstMenuBarPercentageQuotaIfNeeded(force: Bool) {
+        guard let firstQuota = menuBarPercentageQuotaOptions.first else { return }
+        let currentQuotaExists = menuBarPercentageQuotaOptions.contains {
+            $0.quotaType.quotaKey == settings.menuBarPercentageQuotaKey
+        }
+
+        if force || !currentQuotaExists {
+            settings.menuBarPercentageQuotaKey = firstQuota.quotaType.quotaKey
         }
     }
 
@@ -1301,6 +1429,105 @@ struct DisplayModeButton: View {
                 RoundedRectangle(cornerRadius: 8)
                     .stroke(isSelected ? theme.accentPrimary.opacity(0.5) : theme.glassBorder, lineWidth: 1)
             )
+    }
+}
+
+// MARK: - Menu Bar Percentage Choice Buttons
+
+struct MenuBarProviderChoiceButton: View {
+    let providerId: String
+    let providerName: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    @Environment(\.appTheme) private var theme
+    @State private var isHovering = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                Image(systemName: ProviderVisualIdentityLookup.symbolIcon(for: providerId))
+                    .font(.system(size: 10, weight: .bold))
+
+                Text(providerName)
+                    .font(.system(size: 11, weight: .semibold, design: theme.fontDesign))
+                    .lineLimit(1)
+            }
+            .foregroundStyle(isSelected ? selectedForeground : theme.textSecondary)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .background(buttonBackground)
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovering = $0 }
+    }
+
+    private var selectedForeground: Color {
+        theme.id == "cli" ? theme.textPrimary : .white
+    }
+
+    private var buttonBackground: some View {
+        ZStack {
+            if isSelected {
+                RoundedRectangle(cornerRadius: theme.pillCornerRadius)
+                    .fill(theme.accentGradient)
+                    .shadow(color: theme.accentPrimary.opacity(0.25), radius: 5, y: 2)
+            } else {
+                RoundedRectangle(cornerRadius: theme.pillCornerRadius)
+                    .fill(isHovering ? theme.hoverOverlay : theme.glassBackground)
+            }
+
+            RoundedRectangle(cornerRadius: theme.pillCornerRadius)
+                .stroke(isSelected ? theme.accentPrimary.opacity(0.5) : theme.glassBorder, lineWidth: 1)
+        }
+    }
+}
+
+struct MenuBarQuotaChoiceButton: View {
+    let title: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    @Environment(\.appTheme) private var theme
+    @State private var isHovering = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                Image(systemName: "gauge.with.needle.fill")
+                    .font(.system(size: 10, weight: .bold))
+
+                Text(title)
+                    .font(.system(size: 11, weight: .semibold, design: theme.fontDesign))
+                    .lineLimit(1)
+            }
+            .foregroundStyle(isSelected ? selectedForeground : theme.textSecondary)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .background(buttonBackground)
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovering = $0 }
+    }
+
+    private var selectedForeground: Color {
+        theme.id == "cli" ? theme.textPrimary : .white
+    }
+
+    private var buttonBackground: some View {
+        ZStack {
+            if isSelected {
+                RoundedRectangle(cornerRadius: theme.pillCornerRadius)
+                    .fill(theme.accentGradient)
+                    .shadow(color: theme.accentPrimary.opacity(0.25), radius: 5, y: 2)
+            } else {
+                RoundedRectangle(cornerRadius: theme.pillCornerRadius)
+                    .fill(isHovering ? theme.hoverOverlay : theme.glassBackground)
+            }
+
+            RoundedRectangle(cornerRadius: theme.pillCornerRadius)
+                .stroke(isSelected ? theme.accentPrimary.opacity(0.5) : theme.glassBorder, lineWidth: 1)
+        }
     }
 }
 

--- a/Sources/Domain/Monitor/QuotaMonitor.swift
+++ b/Sources/Domain/Monitor/QuotaMonitor.swift
@@ -104,6 +104,22 @@ public final class QuotaMonitor: @unchecked Sendable {
         await refreshProvider(provider)
     }
 
+    /// Refreshes the given providers once, preserving order and removing duplicates.
+    public func refresh(providerIds: [String]) async {
+        var seen = Set<String>()
+        let uniqueProviderIds = providerIds.filter { providerId in
+            seen.insert(providerId).inserted
+        }
+
+        await withTaskGroup(of: Void.self) { group in
+            for providerId in uniqueProviderIds {
+                group.addTask {
+                    await self.refresh(providerId: providerId)
+                }
+            }
+        }
+    }
+
     /// Refreshes all enabled providers except the specified one.
     public func refreshOthers(except providerId: String) async {
         let otherProviders = providers.enabled.filter { $0.id != providerId }
@@ -149,6 +165,34 @@ public final class QuotaMonitor: @unchecked Sendable {
         providers.enabled
             .compactMap(\.snapshot?.lowestQuota)
             .min()
+    }
+
+    /// Returns the selected quota for a provider from enabled provider snapshots.
+    public func quota(providerId: String, quotaKey: String) -> UsageQuota? {
+        providers.enabled
+            .first { $0.id == providerId }?
+            .snapshot?
+            .quota(forKey: quotaKey)
+    }
+
+    /// Returns the menu bar percentage display for a provider/quota selection.
+    public func menuBarPercentageDisplay(
+        providerId: String,
+        quotaKey: String,
+        mode: UsageDisplayMode,
+        burnRateWarningEnabled: Bool = false,
+        burnRateThreshold: Double = 1.5
+    ) -> MenuBarPercentageDisplay? {
+        guard let quota = quota(providerId: providerId, quotaKey: quotaKey) else {
+            return nil
+        }
+
+        return MenuBarPercentageDisplay(
+            quota: quota,
+            mode: mode,
+            burnRateWarningEnabled: burnRateWarningEnabled,
+            burnRateThreshold: burnRateThreshold
+        )
     }
 
     /// Returns the overall status across enabled providers (worst status wins)
@@ -210,9 +254,13 @@ public final class QuotaMonitor: @unchecked Sendable {
     }
 
     /// Starts continuous monitoring at the specified interval.
-    /// Only refreshes the currently selected provider each cycle to minimize energy usage.
+    /// By default, refreshes the currently selected provider each cycle to minimize energy usage.
+    /// When provider IDs are supplied, refreshes that de-duplicated provider set each cycle.
     /// Returns an AsyncStream of monitoring events.
-    public func startMonitoring(interval: Duration = .seconds(60)) -> AsyncStream<MonitoringEvent> {
+    public func startMonitoring(
+        interval: Duration = .seconds(60),
+        providerIds: [String]? = nil
+    ) -> AsyncStream<MonitoringEvent> {
         // Stop any existing monitoring
         monitoringTask?.cancel()
 
@@ -221,7 +269,11 @@ public final class QuotaMonitor: @unchecked Sendable {
         return AsyncStream { continuation in
             let task = Task {
                 while !Task.isCancelled {
-                    await self.refreshSelected()
+                    if let providerIds {
+                        await self.refresh(providerIds: providerIds)
+                    } else {
+                        await self.refreshSelected()
+                    }
                     continuation.yield(.refreshed)
 
                     do {

--- a/Sources/Domain/Provider/MenuBarPercentageDisplay.swift
+++ b/Sources/Domain/Provider/MenuBarPercentageDisplay.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Formatted quota value for the menu bar percentage label.
+public struct MenuBarPercentageDisplay: Sendable, Equatable {
+    public let text: String
+    public let status: QuotaStatus
+    public let quota: UsageQuota
+
+    public init(
+        quota: UsageQuota,
+        mode: UsageDisplayMode,
+        burnRateWarningEnabled: Bool = false,
+        burnRateThreshold: Double = 1.5
+    ) {
+        self.quota = quota
+        self.text = "\(Int(quota.displayPercent(mode: mode)))%"
+        self.status = burnRateWarningEnabled
+            ? quota.paceAwareStatus(burnRateThreshold: burnRateThreshold)
+            : quota.status
+    }
+}

--- a/Sources/Domain/Provider/QuotaType.swift
+++ b/Sources/Domain/Provider/QuotaType.swift
@@ -26,6 +26,42 @@ public enum QuotaType: Sendable, Equatable, Hashable {
         }
     }
 
+    /// Stable key used for persisted quota selection.
+    public var quotaKey: String {
+        switch self {
+        case .session:
+            "session"
+        case .weekly:
+            "weekly"
+        case .modelSpecific(let modelName):
+            "model:\(modelName)"
+        case .timeLimit(let name):
+            "time:\(name)"
+        }
+    }
+
+    /// Creates a quota type from a persisted quota key.
+    public init?(quotaKey: String) {
+        switch quotaKey {
+        case "session":
+            self = .session
+        case "weekly":
+            self = .weekly
+        default:
+            if quotaKey.hasPrefix("model:") {
+                let name = String(quotaKey.dropFirst("model:".count))
+                guard !name.isEmpty else { return nil }
+                self = .modelSpecific(name)
+            } else if quotaKey.hasPrefix("time:") {
+                let name = String(quotaKey.dropFirst("time:".count))
+                guard !name.isEmpty else { return nil }
+                self = .timeLimit(name)
+            } else {
+                return nil
+            }
+        }
+    }
+
     /// The duration of the quota window
     public var duration: QuotaDuration {
         switch self {

--- a/Sources/Domain/Provider/UsageSnapshot.swift
+++ b/Sources/Domain/Provider/UsageSnapshot.swift
@@ -67,6 +67,12 @@ public struct UsageSnapshot: Sendable, Equatable {
         quotas.first { $0.quotaType == type }
     }
 
+    /// Finds a quota by its persisted quota key.
+    public func quota(forKey key: String) -> UsageQuota? {
+        guard let quotaType = QuotaType(quotaKey: key) else { return nil }
+        return quota(for: quotaType)
+    }
+
     /// The session quota if available
     public var sessionQuota: UsageQuota? {
         quota(for: .session)

--- a/Sources/Domain/Settings/AppSettingsRepository.swift
+++ b/Sources/Domain/Settings/AppSettingsRepository.swift
@@ -21,6 +21,15 @@ public protocol AppSettingsRepository: Sendable {
     func usageDisplayMode() -> String
     func setUsageDisplayMode(_ mode: String)
 
+    func menuBarPercentageEnabled() -> Bool
+    func setMenuBarPercentageEnabled(_ enabled: Bool)
+
+    func menuBarPercentageProviderId() -> String
+    func setMenuBarPercentageProviderId(_ providerId: String)
+
+    func menuBarPercentageQuotaKey() -> String
+    func setMenuBarPercentageQuotaKey(_ quotaKey: String)
+
     func showDailyUsageCards() -> Bool
     func setShowDailyUsageCards(_ show: Bool)
 

--- a/Sources/Infrastructure/Storage/JSONSettingsRepository.swift
+++ b/Sources/Infrastructure/Storage/JSONSettingsRepository.swift
@@ -57,6 +57,30 @@ public final class JSONSettingsRepository:
         store.write(value: mode, key: "app.usageDisplayMode")
     }
 
+    public func menuBarPercentageEnabled() -> Bool {
+        store.read(key: "app.menuBarPercentageEnabled") ?? false
+    }
+
+    public func setMenuBarPercentageEnabled(_ enabled: Bool) {
+        store.write(value: enabled, key: "app.menuBarPercentageEnabled")
+    }
+
+    public func menuBarPercentageProviderId() -> String {
+        store.read(key: "app.menuBarPercentageProviderId") ?? "claude"
+    }
+
+    public func setMenuBarPercentageProviderId(_ providerId: String) {
+        store.write(value: providerId, key: "app.menuBarPercentageProviderId")
+    }
+
+    public func menuBarPercentageQuotaKey() -> String {
+        store.read(key: "app.menuBarPercentageQuotaKey") ?? "session"
+    }
+
+    public func setMenuBarPercentageQuotaKey(_ quotaKey: String) {
+        store.write(value: quotaKey, key: "app.menuBarPercentageQuotaKey")
+    }
+
     public func showDailyUsageCards() -> Bool {
         store.read(key: "app.showDailyUsageCards") ?? true
     }

--- a/Tests/DomainTests/Monitor/QuotaMonitorTests.swift
+++ b/Tests/DomainTests/Monitor/QuotaMonitorTests.swift
@@ -13,6 +13,8 @@ struct QuotaMonitorTests {
 
     private struct SuspendingClock: Clock {
         func sleep(for duration: Duration) async throws {
+            // Keep the monitoring loop suspended after its first tick; stopMonitoring()
+            // cancels the task and interrupts this long sleep before the test waits.
             try await Task.sleep(nanoseconds: 60_000_000_000)
         }
 

--- a/Tests/DomainTests/Monitor/QuotaMonitorTests.swift
+++ b/Tests/DomainTests/Monitor/QuotaMonitorTests.swift
@@ -11,11 +11,69 @@ struct QuotaMonitorTests {
         func sleep(nanoseconds: UInt64) async throws {}
     }
 
+    private struct SuspendingClock: Clock {
+        func sleep(for duration: Duration) async throws {
+            try await Task.sleep(nanoseconds: 60_000_000_000)
+        }
+
+        func sleep(nanoseconds: UInt64) async throws {
+            try await Task.sleep(nanoseconds: nanoseconds)
+        }
+    }
+
+    private actor RefreshCounter {
+        private var value = 0
+
+        func increment() -> Int {
+            value += 1
+            return value
+        }
+
+        func count() -> Int {
+            value
+        }
+    }
+
+    private final class CountingUsageProbe: UsageProbe, @unchecked Sendable {
+        let providerId: String
+        let counter = RefreshCounter()
+
+        init(providerId: String) {
+            self.providerId = providerId
+        }
+
+        func probe() async throws -> UsageSnapshot {
+            let count = await counter.increment()
+            return UsageSnapshot(
+                providerId: providerId,
+                quotas: [
+                    UsageQuota(
+                        percentRemaining: Double(100 - count),
+                        quotaType: .session,
+                        providerId: providerId
+                    ),
+                ],
+                capturedAt: Date()
+            )
+        }
+
+        func isAvailable() async -> Bool {
+            true
+        }
+    }
+
     private func makeMonitor(
         providers: any AIProviderRepository,
         alerter: (any QuotaAlerter)? = nil
     ) -> QuotaMonitor {
         QuotaMonitor(providers: providers, alerter: alerter, clock: TestClock())
+    }
+
+    private func makeSuspendingMonitor(
+        providers: any AIProviderRepository,
+        alerter: (any QuotaAlerter)? = nil
+    ) -> QuotaMonitor {
+        QuotaMonitor(providers: providers, alerter: alerter, clock: SuspendingClock())
     }
 
 
@@ -54,6 +112,54 @@ struct QuotaMonitorTests {
         #expect(provider.snapshot != nil)
         #expect(provider.snapshot?.quotas.count == 2)
         #expect(provider.snapshot?.quota(for: .session)?.percentRemaining == 65)
+    }
+
+    @Test
+    func `menu bar percentage display uses selected quota and display mode`() async {
+        // Given
+        let settings = makeSettingsRepository()
+        let probe = MockUsageProbe()
+        given(probe).isAvailable().willReturn(true)
+        given(probe).probe().willReturn(UsageSnapshot(
+            providerId: "claude",
+            quotas: [
+                UsageQuota(percentRemaining: 75, quotaType: .session, providerId: "claude"),
+                UsageQuota(percentRemaining: 35, quotaType: .weekly, providerId: "claude"),
+            ],
+            capturedAt: Date()
+        ))
+        let provider = ClaudeProvider(probe: probe, settingsRepository: settings)
+        let monitor = makeMonitor(providers: AIProviders(providers: [provider]))
+
+        // When
+        await monitor.refresh(providerId: "claude")
+        let display = monitor.menuBarPercentageDisplay(
+            providerId: "claude",
+            quotaKey: "weekly",
+            mode: .used
+        )
+
+        // Then
+        #expect(display?.text == "65%")
+        #expect(display?.status == .warning)
+    }
+
+    @Test
+    func `menu bar percentage display falls back when quota data is missing`() {
+        // Given
+        let settings = makeSettingsRepository()
+        let provider = ClaudeProvider(probe: MockUsageProbe(), settingsRepository: settings)
+        let monitor = makeMonitor(providers: AIProviders(providers: [provider]))
+
+        // When
+        let display = monitor.menuBarPercentageDisplay(
+            providerId: "claude",
+            quotaKey: "session",
+            mode: .remaining
+        )
+
+        // Then
+        #expect(display == nil)
     }
 
     @Test
@@ -345,6 +451,72 @@ struct QuotaMonitorTests {
             if case .refreshed = event { return true }
             return false
         })
+    }
+
+    @Test
+    func `background monitoring refreshes configured menu bar provider in percentage mode`() async {
+        // Given
+        let settings = makeSettingsRepository()
+        let claudeProbe = CountingUsageProbe(providerId: "claude")
+        let codexProbe = CountingUsageProbe(providerId: "codex")
+        let claudeProvider = ClaudeProvider(probe: claudeProbe, settingsRepository: settings)
+        let codexProvider = CodexProvider(probe: codexProbe, settingsRepository: settings)
+        let monitor = makeSuspendingMonitor(providers: AIProviders(providers: [claudeProvider, codexProvider]))
+
+        // When - App layer passes selected + configured menu bar provider ids in percentage mode.
+        let stream = monitor.startMonitoring(
+            interval: .seconds(60),
+            providerIds: ["claude", "codex"]
+        )
+        for await _ in stream.prefix(1) {}
+        monitor.stopMonitoring()
+
+        // Then
+        #expect(await claudeProbe.counter.count() == 1)
+        #expect(await codexProbe.counter.count() == 1)
+        #expect(claudeProvider.snapshot != nil)
+        #expect(codexProvider.snapshot != nil)
+    }
+
+    @Test
+    func `background monitoring does not duplicate refreshes when selected and menu bar provider match`() async {
+        // Given
+        let settings = makeSettingsRepository()
+        let probe = CountingUsageProbe(providerId: "claude")
+        let provider = ClaudeProvider(probe: probe, settingsRepository: settings)
+        let monitor = makeSuspendingMonitor(providers: AIProviders(providers: [provider]))
+
+        // When
+        let stream = monitor.startMonitoring(
+            interval: .seconds(60),
+            providerIds: ["claude", "claude"]
+        )
+        for await _ in stream.prefix(1) {}
+        monitor.stopMonitoring()
+
+        // Then
+        #expect(await probe.counter.count() == 1)
+    }
+
+    @Test
+    func `background monitoring without provider ids preserves selected provider refresh behaviour`() async {
+        // Given
+        let settings = makeSettingsRepository()
+        let claudeProbe = CountingUsageProbe(providerId: "claude")
+        let codexProbe = CountingUsageProbe(providerId: "codex")
+        let claudeProvider = ClaudeProvider(probe: claudeProbe, settingsRepository: settings)
+        let codexProvider = CodexProvider(probe: codexProbe, settingsRepository: settings)
+        let monitor = makeSuspendingMonitor(providers: AIProviders(providers: [claudeProvider, codexProvider]))
+        monitor.selectProvider(id: "codex")
+
+        // When - icon mode uses the default selected-provider monitoring path.
+        let stream = monitor.startMonitoring(interval: .seconds(60))
+        for await _ in stream.prefix(1) {}
+        monitor.stopMonitoring()
+
+        // Then
+        #expect(await claudeProbe.counter.count() == 0)
+        #expect(await codexProbe.counter.count() == 1)
     }
 
     @Test

--- a/Tests/DomainTests/Provider/UsageSnapshotTests.swift
+++ b/Tests/DomainTests/Provider/UsageSnapshotTests.swift
@@ -82,6 +82,36 @@ struct UsageSnapshotTests {
         #expect(found == nil)
     }
 
+    @Test
+    func `quota types round trip persisted quota keys`() {
+        #expect(QuotaType(quotaKey: QuotaType.session.quotaKey) == .session)
+        #expect(QuotaType(quotaKey: QuotaType.weekly.quotaKey) == .weekly)
+        #expect(QuotaType(quotaKey: QuotaType.modelSpecific("opus").quotaKey) == .modelSpecific("opus"))
+        #expect(QuotaType(quotaKey: QuotaType.timeLimit("mcp").quotaKey) == .timeLimit("mcp"))
+        #expect(QuotaType(quotaKey: "model:") == nil)
+        #expect(QuotaType(quotaKey: "unknown") == nil)
+    }
+
+    @Test
+    func `snapshot can find dynamic quota by persisted key`() {
+        // Given
+        let opusQuota = UsageQuota(percentRemaining: 80, quotaType: .modelSpecific("opus"), providerId: "claude")
+        let mcpQuota = UsageQuota(percentRemaining: 40, quotaType: .timeLimit("mcp"), providerId: "claude")
+        let snapshot = UsageSnapshot(
+            providerId: "claude",
+            quotas: [opusQuota, mcpQuota],
+            capturedAt: Date()
+        )
+
+        // When
+        let foundModel = snapshot.quota(forKey: "model:opus")
+        let foundTimeLimit = snapshot.quota(forKey: "time:mcp")
+
+        // Then
+        #expect(foundModel?.percentRemaining == 80)
+        #expect(foundTimeLimit?.percentRemaining == 40)
+    }
+
     // MARK: - Overall Status
 
     @Test

--- a/Tests/InfrastructureTests/Settings/JSONSettingsRepositoryAppTests.swift
+++ b/Tests/InfrastructureTests/Settings/JSONSettingsRepositoryAppTests.swift
@@ -76,6 +76,37 @@ struct JSONSettingsRepositoryAppTests {
     }
 
     @Test
+    func `menuBarPercentageEnabled defaults to false`() {
+        let (repo, dir) = makeRepository()
+        defer { cleanup(dir) }
+
+        #expect(repo.menuBarPercentageEnabled() == false)
+    }
+
+    @Test
+    func `menuBarPercentageSelection defaults to claude session`() {
+        let (repo, dir) = makeRepository()
+        defer { cleanup(dir) }
+
+        #expect(repo.menuBarPercentageProviderId() == "claude")
+        #expect(repo.menuBarPercentageQuotaKey() == "session")
+    }
+
+    @Test
+    func `setMenuBarPercentageSettings persists values`() {
+        let (repo, dir) = makeRepository()
+        defer { cleanup(dir) }
+
+        repo.setMenuBarPercentageEnabled(true)
+        repo.setMenuBarPercentageProviderId("codex")
+        repo.setMenuBarPercentageQuotaKey("weekly")
+
+        #expect(repo.menuBarPercentageEnabled() == true)
+        #expect(repo.menuBarPercentageProviderId() == "codex")
+        #expect(repo.menuBarPercentageQuotaKey() == "weekly")
+    }
+
+    @Test
     func `showDailyUsageCards defaults to true`() {
         let (repo, dir) = makeRepository()
         defer { cleanup(dir) }
@@ -198,11 +229,17 @@ struct JSONSettingsRepositoryAppTests {
         repo1.setThemeMode("cli")
         repo1.setShowDailyUsageCards(false)
         repo1.setOverviewModeEnabled(true)
+        repo1.setMenuBarPercentageEnabled(true)
+        repo1.setMenuBarPercentageProviderId("codex")
+        repo1.setMenuBarPercentageQuotaKey("model:gpt-5")
 
         // New repo, same store
         let repo2 = JSONSettingsRepository(store: store)
         #expect(repo2.themeMode() == "cli")
         #expect(repo2.showDailyUsageCards() == false)
         #expect(repo2.overviewModeEnabled() == true)
+        #expect(repo2.menuBarPercentageEnabled() == true)
+        #expect(repo2.menuBarPercentageProviderId() == "codex")
+        #expect(repo2.menuBarPercentageQuotaKey() == "model:gpt-5")
     }
 }


### PR DESCRIPTION
## Summary
- Adds an opt-in menu bar percentage mode while preserving the existing icon default
- Persists selected menu bar provider and quota key in JSON settings
- Reuses `UsageDisplayMode`, `UsageQuota.displayPercent(mode:)`, and existing status colours
- Adds a status-coloured marker for reliable menu bar colour indication
- Replaces default provider/quota pickers with compact themed pill controls
- Updates background sync so percentage mode refreshes the configured menu bar provider as well as the selected provider
- Falls back to the existing menu bar icon when selected quota data is unavailable

## Tests
- `git diff --check` passed
- `xcrun swiftc -parse` passed for changed files
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer tuist generate` passed
- Local Xcode build passed
- `tuist test Domain` fails before compiling with existing Xcode generated-project error: `Unexpected duplicate tasks`

## Manual testing
- Verified default icon mode still works
- Verified percentage mode displays the selected provider/quota percentage
- Verified Remaining/Used/Pace updates the displayed value
- Verified missing quota data falls back to the existing icon
- Verified provider/quota selectors match the app styling
- Verified background sync refreshes the configured menu bar provider in percentage mode

Closes #179

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Display provider API quota usage percentage directly in the menu bar with status-aware color coding
  - New "Menu Bar Percentage" settings toggle to enable/disable the feature
  - Select which provider and specific quota type (session, weekly, model, etc.) to monitor
  - Enhanced background synchronization keeps menu bar quota information current without manual refresh

<!-- end of auto-generated comment: release notes by coderabbit.ai -->