### PR TITLE
fix(zai): distinguish session/weekly/monthly TOKENS_LIMIT entries by `unit`

### DIFF
--- a/Sources/Infrastructure/Zai/ZaiUsageProbe.swift
+++ b/Sources/Infrastructure/Zai/ZaiUsageProbe.swift
@@ -300,11 +300,29 @@ public struct ZaiUsageProbe: UsageProbe {
             let quotaType: QuotaType
             let percentageUsed = limit.percentage
 
-            switch limit.type {
-            case "TOKENS_LIMIT":
-                quotaType = .session
-            case "TIME_LIMIT":
+            // Z.ai returns multiple TOKENS_LIMIT entries distinguished only by `unit`.
+            // Observed mapping (z.ai GLM Coding Plan, May 2026):
+            //   TIME_LIMIT  unit=5 -> MCP/Tools usage
+            //   TOKENS_LIMIT unit=3 -> rolling 5-hour session quota
+            //   TOKENS_LIMIT unit=6 -> rolling 7-day weekly quota
+            //   TOKENS_LIMIT unit=7 -> monthly quota (rare, plan-tier dependent)
+            // Without `unit`, both TOKENS_LIMIT entries collapsed into `.session`,
+            // silently dropping the weekly quota — the cap users care about most.
+            switch (limit.type, limit.unit) {
+            case ("TIME_LIMIT", _):
                 quotaType = .timeLimit("MCP")
+            case ("TOKENS_LIMIT", 3):
+                quotaType = .session
+            case ("TOKENS_LIMIT", 6):
+                quotaType = .weekly
+            case ("TOKENS_LIMIT", 7):
+                quotaType = .modelSpecific("Monthly")
+            case ("TOKENS_LIMIT", nil):
+                // Backward-compat: legacy responses with no `unit` field default to session.
+                quotaType = .session
+            case ("TOKENS_LIMIT", let unit?):
+                // Unknown unit — preserve via modelSpecific so it isn't dropped/collapsed.
+                quotaType = .modelSpecific("Tokens (unit \(unit))")
             default:
                 // Skip unknown limit types
                 continue
@@ -379,6 +397,7 @@ private struct QuotaLimitData: Decodable {
 
 private struct QuotaLimit: Decodable {
     let type: String
+    let unit: Int?
     let percentage: Double
     let nextResetTime: FlexibleDate?
 }

--- a/Tests/InfrastructureTests/Zai/ZaiUsageProbeParsingTests.swift
+++ b/Tests/InfrastructureTests/Zai/ZaiUsageProbeParsingTests.swift
@@ -221,6 +221,110 @@ struct ZaiUsageProbeParsingTests {
         }
     }
 
+    // MARK: - TOKENS_LIMIT unit-distinguishing Tests
+    //
+    // Z.ai's GLM Coding Plan API returns multiple TOKENS_LIMIT entries
+    // distinguished only by the `unit` field. Without parsing `unit`,
+    // both entries collapse into the same QuotaType and one (typically the
+    // weekly cap — the most user-visible one) gets silently dropped.
+    //
+    // Observed unit mapping (May 2026):
+    //   TIME_LIMIT  unit=5  -> MCP / tools usage
+    //   TOKENS_LIMIT unit=3 -> rolling 5-hour session quota
+    //   TOKENS_LIMIT unit=6 -> rolling 7-day weekly quota
+    //   TOKENS_LIMIT unit=7 -> monthly quota (plan-tier dependent)
+
+    static let sampleQuotaLimitResponseRealZai = """
+    {
+      "data": {
+        "limits": [
+          { "type": "TIME_LIMIT", "unit": 5, "percentage": 1, "nextResetTime": 1778591596997 },
+          { "type": "TOKENS_LIMIT", "unit": 3, "percentage": 13, "nextResetTime": 1778100911330 },
+          { "type": "TOKENS_LIMIT", "unit": 6, "percentage": 46, "nextResetTime": 1778418796990 }
+        ]
+      }
+    }
+    """
+
+    @Test
+    func `parses real z.ai response with all three quota tiers (session/weekly/MCP)`() throws {
+        let data = Data(Self.sampleQuotaLimitResponseRealZai.utf8)
+        let snapshot = try ZaiUsageProbe.parseQuotaLimitResponse(data, providerId: "zai")
+
+        #expect(snapshot.quotas.count == 3)
+        #expect(snapshot.quotas.contains { $0.quotaType == .session })
+        #expect(snapshot.quotas.contains { $0.quotaType == .weekly })
+        #expect(snapshot.quotas.contains { $0.quotaType == .timeLimit("MCP") })
+    }
+
+    @Test
+    func `maps TOKENS_LIMIT unit=3 to session`() throws {
+        let json = """
+        { "data": { "limits": [
+          { "type": "TOKENS_LIMIT", "unit": 3, "percentage": 13 }
+        ] } }
+        """
+        let snapshot = try ZaiUsageProbe.parseQuotaLimitResponse(Data(json.utf8), providerId: "zai")
+        #expect(snapshot.quotas.count == 1)
+        #expect(snapshot.quotas.first?.quotaType == .session)
+        #expect(snapshot.quotas.first?.percentRemaining == 87.0)
+    }
+
+    @Test
+    func `maps TOKENS_LIMIT unit=6 to weekly`() throws {
+        let json = """
+        { "data": { "limits": [
+          { "type": "TOKENS_LIMIT", "unit": 6, "percentage": 46 }
+        ] } }
+        """
+        let snapshot = try ZaiUsageProbe.parseQuotaLimitResponse(Data(json.utf8), providerId: "zai")
+        #expect(snapshot.quotas.count == 1)
+        #expect(snapshot.quotas.first?.quotaType == .weekly)
+        #expect(snapshot.quotas.first?.percentRemaining == 54.0)
+    }
+
+    @Test
+    func `does not collapse session and weekly into same quota`() throws {
+        // Regression test: prior implementation mapped both TOKENS_LIMIT entries
+        // to .session, so the second one (weekly) was effectively hidden.
+        let data = Data(Self.sampleQuotaLimitResponseRealZai.utf8)
+        let snapshot = try ZaiUsageProbe.parseQuotaLimitResponse(data, providerId: "zai")
+
+        let sessionQuotas = snapshot.quotas.filter { $0.quotaType == .session }
+        let weeklyQuotas = snapshot.quotas.filter { $0.quotaType == .weekly }
+        #expect(sessionQuotas.count == 1)
+        #expect(weeklyQuotas.count == 1)
+        #expect(sessionQuotas.first?.percentRemaining != weeklyQuotas.first?.percentRemaining)
+    }
+
+    @Test
+    func `legacy TOKENS_LIMIT response without unit still maps to session (backward-compat)`() throws {
+        // Existing tests use payloads without `unit` — preserve original behavior.
+        let json = """
+        { "data": { "limits": [
+          { "type": "TOKENS_LIMIT", "percentage": 65 }
+        ] } }
+        """
+        let snapshot = try ZaiUsageProbe.parseQuotaLimitResponse(Data(json.utf8), providerId: "zai")
+        #expect(snapshot.quotas.first?.quotaType == .session)
+    }
+
+    @Test
+    func `unknown TOKENS_LIMIT unit is preserved via modelSpecific (no silent drop)`() throws {
+        let json = """
+        { "data": { "limits": [
+          { "type": "TOKENS_LIMIT", "unit": 99, "percentage": 25 }
+        ] } }
+        """
+        let snapshot = try ZaiUsageProbe.parseQuotaLimitResponse(Data(json.utf8), providerId: "zai")
+        #expect(snapshot.quotas.count == 1)
+        if case .modelSpecific(let label) = snapshot.quotas.first?.quotaType {
+            #expect(label.contains("99"))
+        } else {
+            Issue.record("Expected .modelSpecific quota type for unknown unit, got \(String(describing: snapshot.quotas.first?.quotaType))")
+        }
+    }
+
     @Test
     func `clamps percentage to valid range`() throws {
         // Given - edge case where percentage might be negative or > 100


### PR DESCRIPTION
## Summary

Z.ai's GLM Coding Plan API returns multiple `TOKENS_LIMIT` entries that share the same `type` string and are distinguished only by an integer `unit` field. The previous parser mapped every `TOKENS_LIMIT` → `.session`, so the **second entry — the weekly token quota — silently collapsed with the 5-hour session quota.**

The weekly cap is arguably the most important number for users on the GLM Coding Plan; the bug made ClaudeBar's Z.ai tab useless for tracking it.

## Repro

Live API response from `GET https://api.z.ai/api/monitor/usage/quota/limit`:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced quota limit detection to support multiple quota types and units, enabling more accurate usage information tracking.

* **Tests**
  * Added comprehensive test coverage for quota parsing, including backward compatibility and edge case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->