### PR TITLE
fix(gemini): report real quota via loadCodeAssist + tier-aware dedupe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **Gemini quota now reports real usage instead of dummy 100%**: The probe used to discover a project via `cloudresourcemanager.googleapis.com/v1/projects`, which fails for personal-OAuth users (no GCP scope). Without a project, `cloudcode-pa retrieveUserQuota` returns a meaningless three-bucket "all 100%" response — the same symptom reported in #124 (quotas frozen at 100%) and the cause behind #122 (Gemini 3 models missing). `GeminiProjectRepository` now calls the same `cloudcode-pa loadCodeAssist` bootstrap that gemini-cli itself uses and surfaces the resulting `cloudaicompanionProject`, so the quota request returns accurate per-user numbers including `gemini-3-*-preview` buckets.
 
+### Changed
+- **Gemini quotas sort by usage**: Models with the lowest remaining fraction (most used) now appear first in the menu, with model ID as a stable tiebreaker. Previously sorted alphabetically, which buried the model you actually need to watch.
+
 ---
 
 ## [0.4.61] - 2026-05-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Gemini quotas sort by usage**: Models with the lowest remaining fraction (most used) now appear first in the menu, with model ID as a stable tiebreaker. Previously sorted alphabetically, which buried the model you actually need to watch.
+- **Gemini quotas collapse tier-aliased duplicates**: The Code Assist API exposes one tier-level quota under multiple model IDs (e.g. `gemini-2.5-pro`, `gemini-3-pro-preview`, and `gemini-3.1-pro-preview` all return the same Pro-tier bucket). The probe now collapses aliases that share both tier and `(remainingFraction, resetTime)` into a single row labeled with the newest version, so 7 effectively-duplicate rows become 3 distinct quotas (Pro / Flash / Flash-Lite).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Gemini quota now reports real usage instead of dummy 100%**: The probe used to discover a project via `cloudresourcemanager.googleapis.com/v1/projects`, which fails for personal-OAuth users (no GCP scope). Without a project, `cloudcode-pa retrieveUserQuota` returns a meaningless three-bucket "all 100%" response — the same symptom reported in #124 (quotas frozen at 100%) and the cause behind #122 (Gemini 3 models missing). `GeminiProjectRepository` now calls the same `cloudcode-pa loadCodeAssist` bootstrap that gemini-cli itself uses and surfaces the resulting `cloudaicompanionProject`, so the quota request returns accurate per-user numbers including `gemini-3-*-preview` buckets.
+
 ---
 
 ## [0.4.61] - 2026-05-08

--- a/Sources/Infrastructure/Gemini/GeminiAPIProbe.swift
+++ b/Sources/Infrastructure/Gemini/GeminiAPIProbe.swift
@@ -171,8 +171,16 @@ internal struct GeminiAPIProbe {
             }
         }
 
+        // Sort by remaining fraction ascending (most-used models first), with
+        // model ID as a stable tiebreaker so the order doesn't shuffle between
+        // probes when multiple models share a quota (e.g. several at 100%).
         let quotas: [UsageQuota] = modelQuotaMap
-            .sorted { $0.key < $1.key }
+            .sorted { lhs, rhs in
+                if lhs.value.fraction != rhs.value.fraction {
+                    return lhs.value.fraction < rhs.value.fraction
+                }
+                return lhs.key < rhs.key
+            }
             .map { modelId, data in
                 let resetsAt = data.resetTime.flatMap { parseResetTime($0) }
                 return UsageQuota(

--- a/Sources/Infrastructure/Gemini/GeminiAPIProbe.swift
+++ b/Sources/Infrastructure/Gemini/GeminiAPIProbe.swift
@@ -171,21 +171,30 @@ internal struct GeminiAPIProbe {
             }
         }
 
+        // Collapse aliases that share a quota bucket. The Code Assist API
+        // exposes one tier-level quota under multiple model IDs (e.g. the Pro
+        // tier appears as gemini-2.5-pro, gemini-3-pro-preview, and
+        // gemini-3.1-pro-preview, all moving in lockstep). When the tier and
+        // (fraction, resetTime) match, keep only the newest-versioned model
+        // as the survivor — the menu otherwise shows the same quota three
+        // times in a row. Models with no recognizable tier stay distinct.
+        let dedupedEntries = Self.dedupeAliases(modelQuotaMap)
+
         // Sort by remaining fraction ascending (most-used models first), with
         // model ID as a stable tiebreaker so the order doesn't shuffle between
         // probes when multiple models share a quota (e.g. several at 100%).
-        let quotas: [UsageQuota] = modelQuotaMap
+        let quotas: [UsageQuota] = dedupedEntries
             .sorted { lhs, rhs in
-                if lhs.value.fraction != rhs.value.fraction {
-                    return lhs.value.fraction < rhs.value.fraction
+                if lhs.fraction != rhs.fraction {
+                    return lhs.fraction < rhs.fraction
                 }
-                return lhs.key < rhs.key
+                return lhs.modelId < rhs.modelId
             }
-            .map { modelId, data in
-                let resetsAt = data.resetTime.flatMap { parseResetTime($0) }
+            .map { entry in
+                let resetsAt = entry.resetTime.flatMap { parseResetTime($0) }
                 return UsageQuota(
-                    percentRemaining: data.fraction * 100,
-                    quotaType: .modelSpecific(modelId),
+                    percentRemaining: entry.fraction * 100,
+                    quotaType: .modelSpecific(entry.displayLabel),
                     providerId: "gemini",
                     resetsAt: resetsAt,
                     resetText: formatResetText(resetsAt)
@@ -280,5 +289,97 @@ internal struct GeminiAPIProbe {
 
     private struct QuotaResponse: Decodable {
         let buckets: [QuotaBucket]?
+    }
+
+    // MARK: - Tier-aware Alias Dedupe
+
+    fileprivate struct DedupedEntry {
+        /// The model ID that won the survivor selection (kept for stable
+        /// sort tiebreaks and parity with single-row entries).
+        let modelId: String
+        /// What gets shown to the user. For tiered entries this is the
+        /// tier label ("Pro" / "Flash" / "Flash Lite") matching gemini-cli's
+        /// own /model UI; for unrecognized models it's the modelId.
+        let displayLabel: String
+        let fraction: Double
+        let resetTime: String?
+    }
+
+    /// Human-readable tier label matching gemini-cli's `/model` view.
+    fileprivate static func tierDisplayLabel(_ tier: String) -> String {
+        switch tier {
+        case "pro": return "Pro"
+        case "flash": return "Flash"
+        case "flash-lite": return "Flash Lite"
+        default: return tier
+        }
+    }
+
+    /// Detects which tier a Gemini model ID belongs to. The Code Assist quota
+    /// system gates on tier (Pro / Flash / Flash-Lite) but exposes the same
+    /// bucket under every model alias the user is allowed to call. Returns nil
+    /// for models with no recognizable tier — those keep their own row.
+    /// Note: Flash-Lite must be checked before Flash (the substring "flash"
+    /// appears in both).
+    fileprivate static func tier(for modelId: String) -> String? {
+        let lower = modelId.lowercased()
+        if lower.contains("flash-lite") { return "flash-lite" }
+        if lower.contains("flash") { return "flash" }
+        if lower.contains("pro") { return "pro" }
+        return nil
+    }
+
+    /// Extracts a comparable version score from a Gemini model ID. The version
+    /// segment is the first dotted-number group after the "gemini-" prefix —
+    /// e.g. "gemini-3.1-pro-preview" → 3.1, "gemini-2.5-flash" → 2.5.
+    fileprivate static func versionScore(_ modelId: String) -> Double {
+        let stripped = modelId.lowercased()
+            .replacingOccurrences(of: "gemini-", with: "")
+        guard let head = stripped.split(separator: "-").first else { return 0 }
+        let nums = head.split(separator: ".").compactMap { Double($0) }
+        guard let major = nums.first else { return 0 }
+        let minor = nums.count > 1 ? nums[1] : 0
+        return major + minor / 100.0
+    }
+
+    /// Decides which alias label survives when two share a tier+bucket. The
+    /// stable model the user actually invokes day-to-day wins over preview
+    /// IDs that share the same quota; among models of the same preview-ness
+    /// the highest version wins. Falls back to model ID for stability.
+    fileprivate static func isPreferredOver(_ candidate: String, _ existing: String) -> Bool {
+        let candidatePreview = candidate.lowercased().contains("preview")
+        let existingPreview = existing.lowercased().contains("preview")
+        if candidatePreview != existingPreview { return !candidatePreview }
+        let candidateScore = versionScore(candidate)
+        let existingScore = versionScore(existing)
+        if candidateScore != existingScore { return candidateScore > existingScore }
+        return candidate < existing
+    }
+
+    fileprivate static func dedupeAliases(
+        _ modelQuotaMap: [String: (fraction: Double, resetTime: String?)]
+    ) -> [DedupedEntry] {
+        struct BucketKey: Hashable {
+            let group: String     // "tier:pro" or "model:<id>"
+            let fraction: Double
+            let resetTime: String?
+        }
+
+        var survivors: [BucketKey: DedupedEntry] = [:]
+        for (modelId, data) in modelQuotaMap {
+            let detectedTier = tier(for: modelId)
+            let group = detectedTier.map { "tier:\($0)" } ?? "model:\(modelId)"
+            let key = BucketKey(group: group, fraction: data.fraction, resetTime: data.resetTime)
+            let displayLabel = detectedTier.map(tierDisplayLabel) ?? modelId
+
+            if let existing = survivors[key] {
+                if isPreferredOver(modelId, existing.modelId) {
+                    survivors[key] = DedupedEntry(modelId: modelId, displayLabel: displayLabel, fraction: data.fraction, resetTime: data.resetTime)
+                }
+            } else {
+                survivors[key] = DedupedEntry(modelId: modelId, displayLabel: displayLabel, fraction: data.fraction, resetTime: data.resetTime)
+            }
+        }
+        return Array(survivors.values)
     }
 }

--- a/Sources/Infrastructure/Gemini/GeminiProjectRepository.swift
+++ b/Sources/Infrastructure/Gemini/GeminiProjectRepository.swift
@@ -8,7 +8,14 @@ internal struct GeminiProjectRepository {
     private let networkClient: any NetworkClient
     private let timeout: TimeInterval
     private let maxRetries: Int
-    private static let projectsEndpoint = "https://cloudresourcemanager.googleapis.com/v1/projects"
+
+    /// gemini-cli's bootstrap endpoint. Returns the user's `cloudaicompanionProject`
+    /// (the project ID required for accurate per-user quota on the personal-OAuth
+    /// "Gemini Code Assist" tier). The previous implementation called
+    /// `cloudresourcemanager.googleapis.com/v1/projects` which fails for users
+    /// without a GCP account, leaving the quota request projectless and the API
+    /// returning dummy 100% buckets.
+    private static let loadCodeAssistEndpoint = "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist"
 
     init(
         networkClient: any NetworkClient,
@@ -27,16 +34,21 @@ internal struct GeminiProjectRepository {
         return projects.bestProjectForQuota
     }
 
-    /// Fetches all available Gemini projects with retry logic.
-    /// On cold start, network may not be immediately responsive.
+    /// Resolves the user's Gemini Code Assist project via the loadCodeAssist
+    /// bootstrap call and wraps it in a single-element `GeminiProjects` so the
+    /// rest of the probe pipeline (which expects a collection) keeps working.
+    /// Includes retry logic for cold-start network delays.
     func fetchProjects(accessToken: String) async -> GeminiProjects? {
-        guard let url = URL(string: Self.projectsEndpoint) else {
-            logger.error("Invalid projects endpoint URL")
+        guard let url = URL(string: Self.loadCodeAssistEndpoint) else {
+            logger.error("Invalid loadCodeAssist endpoint URL")
             return nil
         }
 
         var request = URLRequest(url: url)
+        request.httpMethod = "POST"
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = Data(#"{"metadata":{"pluginType":"GEMINI"}}"#.utf8)
         request.timeoutInterval = timeout
 
         // Retry with exponential backoff for cold-start network delays
@@ -58,12 +70,14 @@ internal struct GeminiProjectRepository {
                 }
 
                 if httpResponse.statusCode == 200 {
-                    if let projects = try? JSONDecoder().decode(GeminiProjects.self, from: data) {
-                        logger.debug("Gemini project discovery: found \(projects.projects.count) projects")
-                        return projects
-                    } else {
-                        logger.warning("Gemini project discovery: failed to decode response")
+                    if let decoded = try? JSONDecoder().decode(LoadCodeAssistResponse.self, from: data),
+                       let projectId = decoded.cloudaicompanionProject, !projectId.isEmpty {
+                        logger.debug("Gemini project discovery: resolved project '\(projectId, privacy: .public)'")
+                        let project = GeminiProject(projectId: projectId, labels: nil)
+                        return GeminiProjects(projects: [project])
                     }
+                    logger.warning("Gemini project discovery: response missing cloudaicompanionProject")
+                    return GeminiProjects(projects: [])
                 } else if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
                     // Auth errors won't be fixed by retrying
                     logger.error("Gemini project discovery: auth error \(httpResponse.statusCode)")
@@ -84,5 +98,9 @@ internal struct GeminiProjectRepository {
             logger.error("Gemini project discovery failed after \(self.maxRetries) attempts: \(lastError.localizedDescription)")
         }
         return nil
+    }
+
+    private struct LoadCodeAssistResponse: Decodable {
+        let cloudaicompanionProject: String?
     }
 }

--- a/Tests/InfrastructureTests/Gemini/GeminiAPIProbeTests.swift
+++ b/Tests/InfrastructureTests/Gemini/GeminiAPIProbeTests.swift
@@ -116,7 +116,65 @@ struct GeminiAPIProbeTests {
             })
             .called(1)
     }
-    
+
+    @Test
+    func `probe sorts quotas by remaining fraction ascending`() async throws {
+        // Ensures the most-used models bubble to the top so a glance at the
+        // menu surfaces what's actually under pressure. Tiebreaker is model ID.
+        let homeDir = try makeTemporaryHomeDirectory()
+        try createCredentialsFile(in: homeDir)
+        let mockService = MockNetworkClient()
+
+        let projectsResponse = """
+        { "cloudaicompanionProject": "alien-superstate-rq4hk" }
+        """.data(using: .utf8)!
+
+        // API returns models in alphabetical order; the probe must reorder by usage.
+        let quotaResponse = """
+        {
+            "buckets": [
+                { "modelId": "gemini-2.5-flash",      "remainingFraction": 0.99,  "resetTime": "2026-05-11T14:56:33Z" },
+                { "modelId": "gemini-2.5-flash-lite", "remainingFraction": 1.0,   "resetTime": "2026-05-11T14:56:33Z" },
+                { "modelId": "gemini-2.5-pro",        "remainingFraction": 0.05,  "resetTime": "2026-05-10T17:28:41Z" },
+                { "modelId": "gemini-3-pro-preview",  "remainingFraction": 0.4,   "resetTime": "2026-05-10T17:28:41Z" },
+                { "modelId": "gemini-other",          "remainingFraction": 1.0,   "resetTime": "2026-05-11T14:56:33Z" }
+            ]
+        }
+        """.data(using: .utf8)!
+
+        given(mockService)
+            .request(.any)
+            .willProduce { request in
+                let url = request.url?.absoluteString ?? ""
+                if url.contains("loadCodeAssist") {
+                    return (projectsResponse, HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+                } else {
+                    return (quotaResponse, HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+                }
+            }
+
+        let probe = GeminiAPIProbe(
+            homeDirectory: homeDir.path,
+            timeout: 1.0,
+            networkClient: mockService,
+            maxRetries: 1
+        )
+
+        let snapshot = try await probe.probe()
+
+        let modelIds: [String] = snapshot.quotas.compactMap {
+            if case let .modelSpecific(id) = $0.quotaType { return id }
+            return nil
+        }
+        #expect(modelIds == [
+            "gemini-2.5-pro",          // 5%
+            "gemini-3-pro-preview",    // 40%
+            "gemini-2.5-flash",        // 99%
+            "gemini-2.5-flash-lite",   // 100% (tiebreaker: alphabetical)
+            "gemini-other"             // 100%
+        ])
+    }
+
     @Test
     func `probe parses reset time into Date and human readable text`() async throws {
         let homeDir = try makeTemporaryHomeDirectory()

--- a/Tests/InfrastructureTests/Gemini/GeminiAPIProbeTests.swift
+++ b/Tests/InfrastructureTests/Gemini/GeminiAPIProbeTests.swift
@@ -129,15 +129,15 @@ struct GeminiAPIProbeTests {
         { "cloudaicompanionProject": "alien-superstate-rq4hk" }
         """.data(using: .utf8)!
 
-        // API returns models in alphabetical order; the probe must reorder by usage.
+        // Distinct tiers, distinct fractions — covers the sort path without
+        // tripping the alias-dedupe path (which collapses tier-mates).
         let quotaResponse = """
         {
             "buckets": [
-                { "modelId": "gemini-2.5-flash",      "remainingFraction": 0.99,  "resetTime": "2026-05-11T14:56:33Z" },
-                { "modelId": "gemini-2.5-flash-lite", "remainingFraction": 1.0,   "resetTime": "2026-05-11T14:56:33Z" },
-                { "modelId": "gemini-2.5-pro",        "remainingFraction": 0.05,  "resetTime": "2026-05-10T17:28:41Z" },
-                { "modelId": "gemini-3-pro-preview",  "remainingFraction": 0.4,   "resetTime": "2026-05-10T17:28:41Z" },
-                { "modelId": "gemini-other",          "remainingFraction": 1.0,   "resetTime": "2026-05-11T14:56:33Z" }
+                { "modelId": "gemini-2.5-pro",        "remainingFraction": 0.05, "resetTime": "2026-05-10T17:28:41Z" },
+                { "modelId": "gemini-2.5-flash",      "remainingFraction": 0.4,  "resetTime": "2026-05-10T17:29:03Z" },
+                { "modelId": "gemini-2.5-flash-lite", "remainingFraction": 0.99, "resetTime": "2026-05-11T14:56:33Z" },
+                { "modelId": "gemini-other",          "remainingFraction": 1.0,  "resetTime": "2026-05-11T14:56:33Z" }
             ]
         }
         """.data(using: .utf8)!
@@ -162,17 +162,131 @@ struct GeminiAPIProbeTests {
 
         let snapshot = try await probe.probe()
 
-        let modelIds: [String] = snapshot.quotas.compactMap {
-            if case let .modelSpecific(id) = $0.quotaType { return id }
+        let labels: [String] = snapshot.quotas.compactMap {
+            if case let .modelSpecific(label) = $0.quotaType { return label }
             return nil
         }
-        #expect(modelIds == [
-            "gemini-2.5-pro",          // 5%
-            "gemini-3-pro-preview",    // 40%
-            "gemini-2.5-flash",        // 99%
-            "gemini-2.5-flash-lite",   // 100% (tiebreaker: alphabetical)
-            "gemini-other"             // 100%
+        // Tiered models get tier labels (matching gemini-cli's /model UI);
+        // unrecognized models keep their raw ID.
+        #expect(labels == [
+            "Pro",          // 5%
+            "Flash",        // 40%
+            "Flash Lite",   // 99%
+            "gemini-other"  // 100%
         ])
+    }
+
+    @Test
+    func `probe collapses tier-aliased model IDs into one row per tier`() async throws {
+        // The Code Assist API reports one tier-level bucket under every model
+        // alias the user can call (e.g. all three Pro IDs share the Pro
+        // bucket and move in lockstep). Without dedupe, the menu shows the
+        // same quota three times. Survivor is the newest-versioned alias.
+        let homeDir = try makeTemporaryHomeDirectory()
+        try createCredentialsFile(in: homeDir)
+        let mockService = MockNetworkClient()
+
+        let projectsResponse = """
+        { "cloudaicompanionProject": "alien-superstate-rq4hk" }
+        """.data(using: .utf8)!
+
+        let quotaResponse = """
+        {
+            "buckets": [
+                { "modelId": "gemini-2.5-pro",                "remainingFraction": 0.88, "resetTime": "2026-05-10T17:28:41Z" },
+                { "modelId": "gemini-3-pro-preview",          "remainingFraction": 0.88, "resetTime": "2026-05-10T17:28:41Z" },
+                { "modelId": "gemini-3.1-pro-preview",        "remainingFraction": 0.88, "resetTime": "2026-05-10T17:28:41Z" },
+                { "modelId": "gemini-2.5-flash",              "remainingFraction": 0.96, "resetTime": "2026-05-10T17:29:03Z" },
+                { "modelId": "gemini-3-flash-preview",        "remainingFraction": 0.96, "resetTime": "2026-05-10T17:29:03Z" },
+                { "modelId": "gemini-2.5-flash-lite",         "remainingFraction": 1.0,  "resetTime": "2026-05-11T14:56:55Z" },
+                { "modelId": "gemini-3.1-flash-lite-preview", "remainingFraction": 1.0,  "resetTime": "2026-05-11T14:56:55Z" }
+            ]
+        }
+        """.data(using: .utf8)!
+
+        given(mockService)
+            .request(.any)
+            .willProduce { request in
+                let url = request.url?.absoluteString ?? ""
+                if url.contains("loadCodeAssist") {
+                    return (projectsResponse, HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+                } else {
+                    return (quotaResponse, HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+                }
+            }
+
+        let probe = GeminiAPIProbe(
+            homeDirectory: homeDir.path,
+            timeout: 1.0,
+            networkClient: mockService,
+            maxRetries: 1
+        )
+
+        let snapshot = try await probe.probe()
+
+        #expect(snapshot.quotas.count == 3)
+
+        let labels: [String] = snapshot.quotas.compactMap {
+            if case let .modelSpecific(label) = $0.quotaType { return label }
+            return nil
+        }
+        // Tier labels match gemini-cli's /model view — independent of which
+        // version alias survived the dedupe, the quota represents the tier.
+        #expect(labels == [
+            "Pro",         // 88% — most used
+            "Flash",       // 96%
+            "Flash Lite"   // 100%
+        ])
+    }
+
+    @Test
+    func `probe falls back to newest preview when only previews are available`() async throws {
+        // If a tier exposes only preview aliases (e.g. on accounts where the
+        // stable model has been retired), the highest-versioned preview wins.
+        let homeDir = try makeTemporaryHomeDirectory()
+        try createCredentialsFile(in: homeDir)
+        let mockService = MockNetworkClient()
+
+        let projectsResponse = """
+        { "cloudaicompanionProject": "alien-superstate-rq4hk" }
+        """.data(using: .utf8)!
+
+        let quotaResponse = """
+        {
+            "buckets": [
+                { "modelId": "gemini-3-pro-preview",   "remainingFraction": 0.5, "resetTime": "2026-05-10T17:28:41Z" },
+                { "modelId": "gemini-3.1-pro-preview", "remainingFraction": 0.5, "resetTime": "2026-05-10T17:28:41Z" }
+            ]
+        }
+        """.data(using: .utf8)!
+
+        given(mockService)
+            .request(.any)
+            .willProduce { request in
+                let url = request.url?.absoluteString ?? ""
+                if url.contains("loadCodeAssist") {
+                    return (projectsResponse, HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+                } else {
+                    return (quotaResponse, HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+                }
+            }
+
+        let probe = GeminiAPIProbe(
+            homeDirectory: homeDir.path,
+            timeout: 1.0,
+            networkClient: mockService,
+            maxRetries: 1
+        )
+
+        let snapshot = try await probe.probe()
+
+        #expect(snapshot.quotas.count == 1)
+        if case let .modelSpecific(label) = snapshot.quotas.first?.quotaType {
+            // Even with only previews available, the row is labeled by tier.
+            #expect(label == "Pro")
+        } else {
+            Issue.record("expected modelSpecific quota")
+        }
     }
 
     @Test

--- a/Tests/InfrastructureTests/Gemini/GeminiAPIProbeTests.swift
+++ b/Tests/InfrastructureTests/Gemini/GeminiAPIProbeTests.swift
@@ -57,13 +57,12 @@ struct GeminiAPIProbeTests {
         try createCredentialsFile(in: homeDir)
         let mockService = MockNetworkClient()
 
-        // Setup mocks
+        // Setup mocks: loadCodeAssist returns the cloudaicompanionProject, then
+        // retrieveUserQuota returns model buckets. This mirrors how gemini-cli
+        // bootstraps a session, which is the path ClaudeBar must follow to get
+        // accurate per-user quota for personal-OAuth users.
         let projectsResponse = """
-        {
-            "projects": [
-                { "projectId": "gen-lang-client-123456" }
-            ]
-        }
+        { "cloudaicompanionProject": "alien-superstate-rq4hk" }
         """.data(using: .utf8)!
 
         let quotaResponse = """
@@ -82,7 +81,7 @@ struct GeminiAPIProbeTests {
             .request(.any)
             .willProduce { request in
                 let url = request.url?.absoluteString ?? ""
-                if url.contains("projects") {
+                if url.contains("loadCodeAssist") {
                     return (projectsResponse, HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
                 } else {
                     return (quotaResponse, HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
@@ -95,24 +94,22 @@ struct GeminiAPIProbeTests {
             networkClient: mockService,
             maxRetries: 1
         )
-        
+
         let snapshot = try await probe.probe()
-        
+
         // Verify quota
         #expect(snapshot.quotas.count == 1)
         #expect(snapshot.quotas.first?.percentRemaining == 80.0)
-        
-        // Verify project ID was included in quota request
+
+        // Verify the discovered project ID was included in the quota request
+        // (the bug this test pins down: without it, the API returns dummy 100%)
         verify(mockService)
             .request(.matching { request in
                 guard let url = request.url?.absoluteString else { return false }
-                
-                // Check if this is the quota request
                 if url.contains("retrieveUserQuota") {
-                    // Check body for project ID
                     if let body = request.httpBody,
                        let bodyStr = String(data: body, encoding: .utf8) {
-                        return bodyStr.contains("gen-lang-client-123456")
+                        return bodyStr.contains("alien-superstate-rq4hk")
                     }
                 }
                 return false
@@ -127,11 +124,7 @@ struct GeminiAPIProbeTests {
         let mockService = MockNetworkClient()
 
         let projectsResponse = """
-        {
-            "projects": [
-                { "projectId": "gen-lang-client-123456" }
-            ]
-        }
+        { "cloudaicompanionProject": "gen-lang-client-123456" }
         """.data(using: .utf8)!
 
         // Use a reset time 2 hours in the future
@@ -156,7 +149,7 @@ struct GeminiAPIProbeTests {
             .request(.any)
             .willProduce { request in
                 let url = request.url?.absoluteString ?? ""
-                if url.contains("projects") {
+                if url.contains("loadCodeAssist") {
                     return (projectsResponse, HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
                 } else {
                     return (quotaResponse, HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
@@ -216,11 +209,7 @@ struct GeminiAPIProbeTests {
         let mockExecutor = MockCLIExecutor()
 
         let projectsResponse = """
-        {
-            "projects": [
-                { "projectId": "gen-lang-client-123456" }
-            ]
-        }
+        { "cloudaicompanionProject": "gen-lang-client-123456" }
         """.data(using: .utf8)!
 
         let quotaResponse = """
@@ -291,11 +280,7 @@ struct GeminiAPIProbeTests {
         let mockExecutor = MockCLIExecutor()
 
         let projectsResponse = """
-        {
-            "projects": [
-                { "projectId": "gen-lang-client-123456" }
-            ]
-        }
+        { "cloudaicompanionProject": "gen-lang-client-123456" }
         """.data(using: .utf8)!
 
         given(mockService)
@@ -332,11 +317,7 @@ struct GeminiAPIProbeTests {
         let mockExecutor = MockCLIExecutor()
 
         let projectsResponse = """
-        {
-            "projects": [
-                { "projectId": "gen-lang-client-123456" }
-            ]
-        }
+        { "cloudaicompanionProject": "gen-lang-client-123456" }
         """.data(using: .utf8)!
 
         var quotaCalls = 0
@@ -383,11 +364,7 @@ struct GeminiAPIProbeTests {
         let mockExecutor = MockCLIExecutor()
 
         let projectsResponse = """
-        {
-            "projects": [
-                { "projectId": "gen-lang-client-123456" }
-            ]
-        }
+        { "cloudaicompanionProject": "gen-lang-client-123456" }
         """.data(using: .utf8)!
 
         var quotaCalls = 0

--- a/Tests/InfrastructureTests/Gemini/GeminiProjectRepositoryTests.swift
+++ b/Tests/InfrastructureTests/Gemini/GeminiProjectRepositoryTests.swift
@@ -5,73 +5,117 @@ import Mockable
 
 @Suite
 struct GeminiProjectRepositoryTests {
-    
+
     @Test
     func `fetchProjects returns nil when network fails`() async throws {
         let mockService = MockNetworkClient()
         given(mockService)
             .request(.any)
             .willProduce { _ in throw URLError(.notConnectedToInternet) }
-        
+
         let repository = GeminiProjectRepository(
             networkClient: mockService,
             timeout: 1.0
         )
-        
+
         let projects = await repository.fetchProjects(accessToken: "token")
         #expect(projects == nil)
     }
-    
+
     @Test
-    func `fetchProjects parses projects and returns collection`() async throws {
+    func `fetchProjects resolves project from loadCodeAssist response`() async throws {
         let mockService = MockNetworkClient()
         let json = """
         {
-            "projects": [
-                { "projectId": "gen-lang-client-123", "labels": {} },
-                { "projectId": "other-project", "labels": {"generative-language": "true"} }
-            ]
+            "currentTier": { "id": "standard-tier" },
+            "cloudaicompanionProject": "alien-superstate-rq4hk"
         }
         """.data(using: .utf8)!
-        
+
         given(mockService)
             .request(.any)
             .willReturn((json, HTTPURLResponse(url: URL(string: "http://x")!, statusCode: 200, httpVersion: nil, headerFields: nil)!))
-        
+
         let repository = GeminiProjectRepository(
             networkClient: mockService,
             timeout: 1.0
         )
-        
+
         let projects = await repository.fetchProjects(accessToken: "token")
-        
+
         #expect(projects != nil)
-        #expect(projects?.projects.count == 2)
+        #expect(projects?.projects.count == 1)
+        #expect(projects?.projects.first?.projectId == "alien-superstate-rq4hk")
     }
-    
+
     @Test
-    func `fetchBestProject returns correct project`() async throws {
+    func `fetchProjects calls loadCodeAssist endpoint with bearer token`() async throws {
         let mockService = MockNetworkClient()
         let json = """
-        {
-            "projects": [
-                { "projectId": "other-project", "labels": {"generative-language": "true"} },
-                { "projectId": "gen-lang-client-123", "labels": {} }
-            ]
-        }
+        { "cloudaicompanionProject": "alien-superstate-rq4hk" }
         """.data(using: .utf8)!
-        
+
         given(mockService)
             .request(.any)
             .willReturn((json, HTTPURLResponse(url: URL(string: "http://x")!, statusCode: 200, httpVersion: nil, headerFields: nil)!))
-        
+
         let repository = GeminiProjectRepository(
             networkClient: mockService,
             timeout: 1.0
         )
-        
+
+        _ = await repository.fetchProjects(accessToken: "test-token")
+
+        verify(mockService)
+            .request(.matching { request in
+                let url = request.url?.absoluteString ?? ""
+                guard url.contains("loadCodeAssist") else { return false }
+                guard request.value(forHTTPHeaderField: "Authorization") == "Bearer test-token" else { return false }
+                guard let body = request.httpBody, let bodyStr = String(data: body, encoding: .utf8) else { return false }
+                return bodyStr.contains("\"pluginType\":\"GEMINI\"")
+            })
+            .called(1)
+    }
+
+    @Test
+    func `fetchProjects returns empty when cloudaicompanionProject is missing`() async throws {
+        let mockService = MockNetworkClient()
+        let json = """
+        { "currentTier": { "id": "standard-tier" } }
+        """.data(using: .utf8)!
+
+        given(mockService)
+            .request(.any)
+            .willReturn((json, HTTPURLResponse(url: URL(string: "http://x")!, statusCode: 200, httpVersion: nil, headerFields: nil)!))
+
+        let repository = GeminiProjectRepository(
+            networkClient: mockService,
+            timeout: 1.0
+        )
+
+        let projects = await repository.fetchProjects(accessToken: "token")
+
+        #expect(projects?.projects.isEmpty == true)
+    }
+
+    @Test
+    func `fetchBestProject returns the resolved project`() async throws {
+        let mockService = MockNetworkClient()
+        let json = """
+        { "cloudaicompanionProject": "alien-superstate-rq4hk" }
+        """.data(using: .utf8)!
+
+        given(mockService)
+            .request(.any)
+            .willReturn((json, HTTPURLResponse(url: URL(string: "http://x")!, statusCode: 200, httpVersion: nil, headerFields: nil)!))
+
+        let repository = GeminiProjectRepository(
+            networkClient: mockService,
+            timeout: 1.0
+        )
+
         let project = await repository.fetchBestProject(accessToken: "token")
-        
-        #expect(project?.projectId == "gen-lang-client-123")
+
+        #expect(project?.projectId == "alien-superstate-rq4hk")
     }
 }

--- a/Tests/InfrastructureTests/Gemini/GeminiUsageProbeTests.swift
+++ b/Tests/InfrastructureTests/Gemini/GeminiUsageProbeTests.swift
@@ -37,9 +37,9 @@ struct GeminiUsageProbeTests {
         
         // Setup API mocks
         let projectsResponse = """
-        { "projects": [{ "projectId": "gen-lang-client-123" }] }
+        { "cloudaicompanionProject": "gen-lang-client-123" }
         """.data(using: .utf8)!
-        
+
         let quotaResponse = """
         {
             "buckets": [{
@@ -49,12 +49,12 @@ struct GeminiUsageProbeTests {
             }]
         }
         """.data(using: .utf8)!
-        
+
         given(mockService)
             .request(.any)
             .willProduce { request in
                 let url = request.url?.absoluteString ?? ""
-                if url.contains("projects") {
+                if url.contains("loadCodeAssist") {
                     return (projectsResponse, HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
                 } else {
                     return (quotaResponse, HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)


### PR DESCRIPTION
## Summary

The Gemini probe was reporting dummy 100%-remaining quota for everyone (see #124) and not surfacing Gemini 3 models for tier-eligible users (see #122). Root cause: `GeminiProjectRepository` discovered the project via `cloudresourcemanager.googleapis.com/v1/projects`, which fails for personal-OAuth users (no GCP scope). Without a project, `cloudcode-pa retrieveUserQuota` returns three meaningless 100% buckets.

Switching to the same `cloudcode-pa loadCodeAssist` bootstrap that gemini-cli itself uses surfaces the user's `cloudaicompanionProject`. With the right project, the quota request returns accurate per-user numbers including `gemini-3-*-preview` models for opted-in accounts.

## What changed (3 commits)

1. **`fix(gemini): use loadCodeAssist bootstrap for project discovery`** — replace `cloudresourcemanager` call with `cloudcode-pa loadCodeAssist`. This is the actual bug fix.
2. **`fix(gemini): sort quotas by usage so the most-used models surface first`** — order by `remainingFraction` ascending with model ID as a stable tiebreaker. Previously alphabetical, which buried whichever model was under pressure.
3. **`fix(gemini): collapse tier-aliased model IDs and label rows by tier`** — Code Assist exposes one tier-level bucket (Pro / Flash / Flash Lite) under multiple model ID aliases that move in lockstep. Collapse entries that share `(tier, fraction, resetTime)` into a single row labeled with the tier name, matching gemini-cli's own `/model` UI.

## Before / After

End-to-end verified against a Google One AI Pro account:

| Tier | Before | After | gemini /stats |
|---|---|---|---|
| Pro | 100% | 86% | 13% used ✓ |
| Flash | 100% | 96% | 4% used ✓ |
| Flash Lite | 100% | 100% | 0% used ✓ |
| Gemini-3-\*-preview | missing | bucketed into the tier rows | n/a |

## Test plan

- [x] `xcodebuild test -only-testing:InfrastructureTests` — all suites pass, including 3 new tests in `GeminiAPIProbeTests`:
  - `probe sorts quotas by remaining fraction ascending`
  - `probe collapses tier-aliased model IDs into one row per tier`
  - `probe falls back to newest preview when only previews are available`
- [x] Existing `GeminiAPIProbeTests` / `GeminiProjectRepositoryTests` / `GeminiUsageProbeTests` mocks updated for the new endpoint and response shape.
- [x] Manual: built locally, ran patched bundle, observed correct per-tier quotas in the menu.

## Notes

- The free-tier path is unaffected functionally — same number of rows, just relabeled from `gemini-2.5-pro` to `Pro` etc.
- Models that don't match a known tier (e.g. `gemini-embedding-*`, hypothetical future names) keep their raw model ID as the label and don't get deduped.
- If the API ever returns different `remainingFraction` values for same-tier aliases, the dedupe key `(tier, fraction, resetTime)` keeps them as separate rows rather than merging them. The current API treats them as one bucket.

Closes #124. Likely also closes #122 (Gemini 3 models now reported under their respective tier rows).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved accuracy of Gemini quota reporting.

* **Changed**
  * Gemini quota listings now sort by remaining usage (lowest fraction first).
  * Duplicate tier-aliased quota rows automatically collapse into consolidated tier buckets for cleaner display.
  * Updated Gemini Code Assist project discovery mechanism.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tddworks/ClaudeBar/pull/183)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->