### PR TITLE
fix(claude): handle /api/oauth/usage rate-limiting gracefully

### DIFF
--- a/Sources/Domain/Provider/Claude/ClaudeProvider.swift
+++ b/Sources/Domain/Provider/Claude/ClaudeProvider.swift
@@ -169,7 +169,8 @@ public final class ClaudeProvider: AIProvider, @unchecked Sendable {
             lastError = nil
             return snapshot!
         } catch let primaryError {
-            if let fallback = await fallbackProbe() {
+            if Self.shouldAttemptFallback(after: primaryError),
+               let fallback = await fallbackProbe() {
                 do {
                     let newSnapshot = try await fallback.probe()
                     snapshot = await attachDailyReport(to: newSnapshot)
@@ -188,6 +189,18 @@ public final class ClaudeProvider: AIProvider, @unchecked Sendable {
             lastError = primaryError
             throw primaryError
         }
+    }
+
+    /// Decides whether the fallback probe should run after the primary fails.
+    /// Rate-limit failures are an upstream per-token throttle: the CLI talks
+    /// to the same Anthropic backend, so the fallback can't help and would
+    /// just amplify the problem. Surface the rate-limit error immediately so
+    /// the backoff window does its job. All other failure modes (auth,
+    /// parse, network, etc.) still try the fallback — those can legitimately
+    /// be recovered by the alternate probe path.
+    private static func shouldAttemptFallback(after error: Error) -> Bool {
+        if case ProbeError.rateLimited = error { return false }
+        return true
     }
 
     /// Attaches daily usage report to snapshot if analyzer is available.

--- a/Sources/Domain/Provider/Claude/ClaudeProvider.swift
+++ b/Sources/Domain/Provider/Claude/ClaudeProvider.swift
@@ -168,7 +168,7 @@ public final class ClaudeProvider: AIProvider, @unchecked Sendable {
             snapshot = await attachDailyReport(to: newSnapshot)
             lastError = nil
             return snapshot!
-        } catch {
+        } catch let primaryError {
             if let fallback = await fallbackProbe() {
                 do {
                     let newSnapshot = try await fallback.probe()
@@ -176,13 +176,17 @@ public final class ClaudeProvider: AIProvider, @unchecked Sendable {
                     lastError = nil
                     return snapshot!
                 } catch {
-                    lastError = error
-                    throw error
+                    // Both probes failed. Surface the primary error — it is
+                    // the actual root cause (e.g. HTTP 429). The fallback's
+                    // failure is incidental and would otherwise mask it,
+                    // sending users chasing the wrong problem.
+                    lastError = primaryError
+                    throw primaryError
                 }
             }
 
-            lastError = error
-            throw error
+            lastError = primaryError
+            throw primaryError
         }
     }
 

--- a/Sources/Domain/Provider/ProbeError.swift
+++ b/Sources/Domain/Provider/ProbeError.swift
@@ -33,6 +33,11 @@ public enum ProbeError: Error, Sendable, LocalizedError {
     /// Usage data requires a subscription plan (API billing accounts don't support /usage)
     case subscriptionRequired
 
+    /// The provider's API is rate-limiting us (HTTP 429). `retryAt` is the
+    /// earliest time we should try again, derived from the `Retry-After`
+    /// header when present or a sensible default otherwise.
+    case rateLimited(retryAt: Date)
+
     // MARK: - LocalizedError
 
     public var errorDescription: String? {
@@ -60,6 +65,10 @@ public enum ProbeError: Error, Sendable, LocalizedError {
             return reason
         case .subscriptionRequired:
             return "Subscription required for usage data"
+        case .rateLimited(let retryAt):
+            let formatter = DateFormatter()
+            formatter.timeStyle = .short
+            return "Rate limited. Retrying after \(formatter.string(from: retryAt))."
         }
     }
 }
@@ -89,6 +98,8 @@ extension ProbeError: Equatable {
             return a == b
         case (.subscriptionRequired, .subscriptionRequired):
             return true
+        case (.rateLimited(let a), .rateLimited(let b)):
+            return a == b
         default:
             return false
         }

--- a/Sources/Domain/Provider/ProbeError.swift
+++ b/Sources/Domain/Provider/ProbeError.swift
@@ -66,9 +66,14 @@ public enum ProbeError: Error, Sendable, LocalizedError {
         case .subscriptionRequired:
             return "Subscription required for usage data"
         case .rateLimited(let retryAt):
-            let formatter = DateFormatter()
-            formatter.timeStyle = .short
-            return "Rate limited. Retrying after \(formatter.string(from: retryAt))."
+            // Relative formatting ("in 30 minutes") is unambiguous across
+            // midnight rollovers and more glance-able than an absolute clock
+            // time. errorDescription is recomputed on each access, so the
+            // string updates naturally as the window ticks down.
+            let formatter = RelativeDateTimeFormatter()
+            formatter.unitsStyle = .full
+            let relative = formatter.localizedString(for: retryAt, relativeTo: Date())
+            return "Rate limited. Retrying \(relative)."
         }
     }
 }

--- a/Sources/Infrastructure/Claude/ClaudeAPIUsageProbe.swift
+++ b/Sources/Infrastructure/Claude/ClaudeAPIUsageProbe.swift
@@ -498,7 +498,11 @@ public struct ClaudeAPIUsageProbe: UsageProbe, @unchecked Sendable {
         guard let value = value?.trimmingCharacters(in: .whitespaces), !value.isEmpty else {
             return nil
         }
-        if let seconds = TimeInterval(value), seconds >= 0 {
+        // Reject 0 — the /api/oauth/usage endpoint has been observed returning
+        // `Retry-After: 0` while continuing to 429, so treating 0 as "retry
+        // immediately" lands us right back in a hammering loop. See
+        // anthropics/claude-code#30930.
+        if let seconds = TimeInterval(value), seconds > 0 {
             return seconds
         }
         let formatter = DateFormatter()

--- a/Sources/Infrastructure/Claude/ClaudeAPIUsageProbe.swift
+++ b/Sources/Infrastructure/Claude/ClaudeAPIUsageProbe.swift
@@ -1,6 +1,33 @@
 import Foundation
 import Domain
 
+/// Thread-safe holder for an active rate-limit window. When the API returns
+/// HTTP 429, the probe stores `retryAt` here so subsequent calls short-circuit
+/// without re-hitting the endpoint until the window has elapsed.
+private final class RateLimitState: @unchecked Sendable {
+    private var retryAt: Date?
+    private let lock = NSLock()
+
+    /// Returns `retryAt` only if it is still in the future; otherwise clears
+    /// it and returns nil so the next probe is allowed through.
+    func activeRetryAt(now: Date = Date()) -> Date? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let retryAt else { return nil }
+        if retryAt <= now {
+            self.retryAt = nil
+            return nil
+        }
+        return retryAt
+    }
+
+    func set(retryAt: Date) {
+        lock.lock()
+        defer { lock.unlock() }
+        self.retryAt = retryAt
+    }
+}
+
 /// Thread-safe in-memory cache for Claude OAuth credentials with TTL.
 /// Avoids repeated Keychain/CLI lookups on every probe cycle while ensuring
 /// external credential changes (e.g. CLI re-login) are picked up.
@@ -53,6 +80,13 @@ public struct ClaudeAPIUsageProbe: UsageProbe, @unchecked Sendable {
     private let networkClient: any NetworkClient
     private let timeout: TimeInterval
     private let cache = CredentialCache()
+    private let rateLimit = RateLimitState()
+
+    /// Fallback retry window applied when the API returns 429 without a
+    /// usable `Retry-After` header. Five minutes is conservative enough to
+    /// stop hammering a throttled endpoint while still picking back up
+    /// reasonably quickly once the window opens.
+    static let defaultRetryAfter: TimeInterval = 5 * 60
 
     // API endpoints
     private static let usageURL = URL(string: "https://api.anthropic.com/api/oauth/usage")!
@@ -80,6 +114,13 @@ public struct ClaudeAPIUsageProbe: UsageProbe, @unchecked Sendable {
     }
 
     public func probe() async throws -> UsageSnapshot {
+        // Honor an active rate-limit window before doing any work so we stop
+        // hammering the endpoint while Anthropic is throttling us.
+        if let retryAt = rateLimit.activeRetryAt() {
+            AppLog.probes.info("Claude API: Skipping probe — rate-limited until \(retryAt)")
+            throw ProbeError.rateLimited(retryAt: retryAt)
+        }
+
         // Check cache first, fall back to loading from file/keychain
         // Only update cache when loading from file (not from cache hit) to preserve TTL
         // 仅在从文件加载时更新缓存，避免滑动续期导致 TTL 永不过期
@@ -279,6 +320,14 @@ public struct ClaudeAPIUsageProbe: UsageProbe, @unchecked Sendable {
             break
         case 401, 403:
             throw ProbeError.authenticationRequired
+        case 429:
+            let retryAfter = Self.parseRetryAfter(
+                httpResponse.value(forHTTPHeaderField: "Retry-After")
+            ) ?? Self.defaultRetryAfter
+            let retryAt = Date().addingTimeInterval(retryAfter)
+            rateLimit.set(retryAt: retryAt)
+            AppLog.probes.warning("Claude API: Rate limited (HTTP 429), retrying after \(Int(retryAfter))s")
+            throw ProbeError.rateLimited(retryAt: retryAt)
         default:
             AppLog.probes.error("Claude API: HTTP error \(httpResponse.statusCode)")
             throw ProbeError.executionFailed("HTTP error: \(httpResponse.statusCode)")
@@ -385,6 +434,26 @@ public struct ClaudeAPIUsageProbe: UsageProbe, @unchecked Sendable {
             accountTier: accountTier,
             costUsage: costUsage
         )
+    }
+
+    /// Parses an HTTP `Retry-After` header value into a duration.
+    /// Per RFC 7231 the value is either a non-negative integer of seconds, or
+    /// an HTTP-date. Returns nil for missing, malformed, or past-dated values
+    /// so the caller can apply its own fallback.
+    static func parseRetryAfter(_ value: String?, now: Date = Date()) -> TimeInterval? {
+        guard let value = value?.trimmingCharacters(in: .whitespaces), !value.isEmpty else {
+            return nil
+        }
+        if let seconds = TimeInterval(value), seconds >= 0 {
+            return seconds
+        }
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+        guard let date = formatter.date(from: value) else { return nil }
+        let delta = date.timeIntervalSince(now)
+        return delta > 0 ? delta : nil
     }
 
     private func parseISODate(_ isoString: String?) -> Date? {

--- a/Sources/Infrastructure/Claude/ClaudeAPIUsageProbe.swift
+++ b/Sources/Infrastructure/Claude/ClaudeAPIUsageProbe.swift
@@ -1,6 +1,41 @@
 import Foundation
 import Domain
 
+/// Thread-safe TTL cache for a successful `UsageSnapshot`. Quota numbers
+/// move on multi-hour timescales (5h session, 7d weekly), so returning the
+/// most recent successful snapshot for a short window costs nothing in
+/// freshness and dramatically reduces requests against the rate-limited
+/// usage endpoint.
+private final class SnapshotCache: @unchecked Sendable {
+    private var cached: UsageSnapshot?
+    private var cachedAt: Date?
+    private let ttl: TimeInterval
+    private let lock = NSLock()
+
+    init(ttl: TimeInterval) {
+        self.ttl = ttl
+    }
+
+    func get(now: Date = Date()) -> UsageSnapshot? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let cached, let cachedAt else { return nil }
+        if now.timeIntervalSince(cachedAt) > ttl {
+            self.cached = nil
+            self.cachedAt = nil
+            return nil
+        }
+        return cached
+    }
+
+    func set(_ snapshot: UsageSnapshot, now: Date = Date()) {
+        lock.lock()
+        defer { lock.unlock() }
+        self.cached = snapshot
+        self.cachedAt = now
+    }
+}
+
 /// Thread-safe holder for an active rate-limit window. When the API returns
 /// HTTP 429, the probe stores `retryAt` here so subsequent calls short-circuit
 /// without re-hitting the endpoint until the window has elapsed.
@@ -81,12 +116,19 @@ public struct ClaudeAPIUsageProbe: UsageProbe, @unchecked Sendable {
     private let timeout: TimeInterval
     private let cache = CredentialCache()
     private let rateLimit = RateLimitState()
+    private let snapshotCache: SnapshotCache
 
     /// Fallback retry window applied when the API returns 429 without a
     /// usable `Retry-After` header. Five minutes is conservative enough to
     /// stop hammering a throttled endpoint while still picking back up
     /// reasonably quickly once the window opens.
     static let defaultRetryAfter: TimeInterval = 5 * 60
+
+    /// Default TTL for the in-memory snapshot cache. Five minutes is well
+    /// below the granularity at which quota numbers change (5h / 7d) but
+    /// long enough to drop the 60s monitor-tick polling rate to ~12/hour,
+    /// safely below Anthropic's per-token throttle for this endpoint.
+    public static let defaultSnapshotCacheTTL: TimeInterval = 5 * 60
 
     // API endpoints
     private static let usageURL = URL(string: "https://api.anthropic.com/api/oauth/usage")!
@@ -101,11 +143,13 @@ public struct ClaudeAPIUsageProbe: UsageProbe, @unchecked Sendable {
     public init(
         credentialLoader: ClaudeCredentialLoader = ClaudeCredentialLoader(),
         networkClient: any NetworkClient = URLSession.shared,
-        timeout: TimeInterval = 15
+        timeout: TimeInterval = 15,
+        snapshotCacheTTL: TimeInterval = Self.defaultSnapshotCacheTTL
     ) {
         self.credentialLoader = credentialLoader
         self.networkClient = networkClient
         self.timeout = timeout
+        self.snapshotCache = SnapshotCache(ttl: snapshotCacheTTL)
     }
 
     public func isAvailable() async -> Bool {
@@ -114,6 +158,14 @@ public struct ClaudeAPIUsageProbe: UsageProbe, @unchecked Sendable {
     }
 
     public func probe() async throws -> UsageSnapshot {
+        // Serve a fresh cached snapshot before doing anything else. This is
+        // the dominant code path during normal monitor polling and means
+        // we make ~1 actual HTTP call per cache TTL instead of one per
+        // monitor tick — well under Anthropic's per-token throttle.
+        if let cached = snapshotCache.get() {
+            return cached
+        }
+
         // Honor an active rate-limit window before doing any work so we stop
         // hammering the endpoint while Anthropic is throttling us.
         if let retryAt = rateLimit.activeRetryAt() {
@@ -201,7 +253,9 @@ public struct ClaudeAPIUsageProbe: UsageProbe, @unchecked Sendable {
             }
         }
 
-        return parseUsageResponse(usageData, subscriptionType: credentials.oauth.subscriptionType)
+        let snapshot = parseUsageResponse(usageData, subscriptionType: credentials.oauth.subscriptionType)
+        snapshotCache.set(snapshot)
+        return snapshot
     }
 
     // MARK: - Token Refresh

--- a/Sources/Infrastructure/Claude/ClaudeAPIUsageProbe.swift
+++ b/Sources/Infrastructure/Claude/ClaudeAPIUsageProbe.swift
@@ -25,7 +25,9 @@ private final class SnapshotCache: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         guard let cached, let cachedAt else { return nil }
-        if now.timeIntervalSince(cachedAt) > ttl {
+        // Inclusive comparison so `ttl == 0` is always immediately stale.
+        // With `>`, a 0-TTL cache would still hit within the same instant.
+        if now.timeIntervalSince(cachedAt) >= ttl {
             self.cached = nil
             self.cachedAt = nil
             return nil

--- a/Sources/Infrastructure/Claude/ClaudeAPIUsageProbe.swift
+++ b/Sources/Infrastructure/Claude/ClaudeAPIUsageProbe.swift
@@ -124,11 +124,15 @@ public struct ClaudeAPIUsageProbe: UsageProbe, @unchecked Sendable {
     /// reasonably quickly once the window opens.
     static let defaultRetryAfter: TimeInterval = 5 * 60
 
-    /// Default TTL for the in-memory snapshot cache. Five minutes is well
-    /// below the granularity at which quota numbers change (5h / 7d) but
-    /// long enough to drop the 60s monitor-tick polling rate to ~12/hour,
-    /// safely below Anthropic's per-token throttle for this endpoint.
-    public static let defaultSnapshotCacheTTL: TimeInterval = 5 * 60
+    /// Default TTL for the in-memory snapshot cache. Anthropic's
+    /// /api/oauth/usage throttle has been observed handing out 1-hour
+    /// Retry-After windows in response to even one call after a quiet
+    /// period (see deferred memory + anthropics/claude-code#30930), so
+    /// we err on the conservative side. 15 minutes drops the 60s monitor
+    /// cadence to ~4 calls/hour — well under any reasonable threshold —
+    /// while still keeping the displayed quotas fresh enough that a user
+    /// glancing at the menu bar isn't looking at hour-old data.
+    public static let defaultSnapshotCacheTTL: TimeInterval = 15 * 60
 
     // API endpoints
     private static let usageURL = URL(string: "https://api.anthropic.com/api/oauth/usage")!

--- a/Sources/Infrastructure/Claude/ClaudeAPIUsageProbe.swift
+++ b/Sources/Infrastructure/Claude/ClaudeAPIUsageProbe.swift
@@ -12,10 +12,15 @@ private final class SnapshotCache: @unchecked Sendable {
     private let ttl: TimeInterval
     private let lock = NSLock()
 
+    /// Creates a snapshot cache with the given maximum lifetime for a cached
+    /// entry. A `ttl` of `0` effectively disables caching (every `get` misses).
     init(ttl: TimeInterval) {
         self.ttl = ttl
     }
 
+    /// Returns the cached snapshot if it was stored within `ttl` of `now`;
+    /// otherwise evicts the stale entry and returns `nil` so the caller knows
+    /// to re-fetch.
     func get(now: Date = Date()) -> UsageSnapshot? {
         lock.lock()
         defer { lock.unlock() }
@@ -28,6 +33,8 @@ private final class SnapshotCache: @unchecked Sendable {
         return cached
     }
 
+    /// Stores a fresh snapshot and stamps it with `now`, replacing any prior
+    /// entry. The next `get` call within `ttl` of `now` will hit this entry.
     func set(_ snapshot: UsageSnapshot, now: Date = Date()) {
         lock.lock()
         defer { lock.unlock() }
@@ -56,6 +63,8 @@ private final class RateLimitState: @unchecked Sendable {
         return retryAt
     }
 
+    /// Records a new rate-limit window expiring at `retryAt`. Subsequent
+    /// `activeRetryAt` calls return this value until it falls into the past.
     func set(retryAt: Date) {
         lock.lock()
         defer { lock.unlock() }

--- a/Tests/DomainTests/Provider/Claude/ClaudeProviderTests.swift
+++ b/Tests/DomainTests/Provider/Claude/ClaudeProviderTests.swift
@@ -185,6 +185,38 @@ struct ClaudeProviderTests {
         let provider2 = ClaudeProvider(probe: MockUsageProbe(), settingsRepository: settings)
         #expect(provider1.id == provider2.id)
     }
+
+    // MARK: - Error Propagation When Both Probes Fail
+
+    @Test
+    func `refresh surfaces primary API error when CLI fallback also fails`() async {
+        // API mode with CLI fallback enabled: API probe throws .rateLimited
+        // (the real root cause), CLI fallback throws .parseFailed (a red
+        // herring caused by the broken /usage stdout capture). The user
+        // should see the rate-limit error, not the parse failure.
+        let settings = FakeClaudeSettings(probeMode: .api, cliFallbackEnabled: true)
+
+        let retryAt = Date().addingTimeInterval(300)
+        let apiProbe = MockUsageProbe()
+        given(apiProbe).isAvailable().willReturn(true)
+        given(apiProbe).probe().willThrow(ProbeError.rateLimited(retryAt: retryAt))
+
+        let cliProbe = MockUsageProbe()
+        given(cliProbe).isAvailable().willReturn(true)
+        given(cliProbe).probe().willThrow(ProbeError.parseFailed("Could not find session usage"))
+
+        let claude = ClaudeProvider(cliProbe: cliProbe, apiProbe: apiProbe, settingsRepository: settings)
+
+        do {
+            _ = try await claude.refresh()
+            Issue.record("Expected refresh to throw")
+        } catch let error as ProbeError {
+            #expect(error == .rateLimited(retryAt: retryAt))
+            #expect(claude.lastError as? ProbeError == .rateLimited(retryAt: retryAt))
+        } catch {
+            Issue.record("Expected ProbeError, got \(error)")
+        }
+    }
 }
 
 // MARK: - Test Helpers

--- a/Tests/DomainTests/Provider/Claude/ClaudeProviderTests.swift
+++ b/Tests/DomainTests/Provider/Claude/ClaudeProviderTests.swift
@@ -189,6 +189,38 @@ struct ClaudeProviderTests {
     // MARK: - Error Propagation When Both Probes Fail
 
     @Test
+    func `refresh does not invoke CLI fallback when API returns rateLimited`() async {
+        // When the API probe is rate-limited, the CLI probe talks to the
+        // same Anthropic backend (subject to the same per-token throttle)
+        // AND it's currently broken in the field. The rate-limit error
+        // should surface immediately without the CLI probe being touched.
+        let settings = FakeClaudeSettings(probeMode: .api, cliFallbackEnabled: true)
+
+        let retryAt = Date().addingTimeInterval(300)
+        let apiProbe = MockUsageProbe()
+        given(apiProbe).isAvailable().willReturn(true)
+        given(apiProbe).probe().willThrow(ProbeError.rateLimited(retryAt: retryAt))
+
+        let cliProbe = MockUsageProbe()
+        given(cliProbe).isAvailable().willReturn(true)
+
+        let claude = ClaudeProvider(cliProbe: cliProbe, apiProbe: apiProbe, settingsRepository: settings)
+
+        do {
+            _ = try await claude.refresh()
+            Issue.record("Expected refresh to throw")
+        } catch let error as ProbeError {
+            #expect(error == .rateLimited(retryAt: retryAt))
+        } catch {
+            Issue.record("Expected ProbeError, got \(error)")
+        }
+
+        // The CLI probe must never be invoked when the primary error is
+        // an upstream rate-limit; fallback would amplify the throttle.
+        verify(cliProbe).probe().called(0)
+    }
+
+    @Test
     func `refresh surfaces primary API error when CLI fallback also fails`() async {
         // API mode with CLI fallback enabled: API probe throws .rateLimited
         // (the real root cause), CLI fallback throws .parseFailed (a red

--- a/Tests/InfrastructureTests/Claude/ClaudeAPIUsageProbeTests.swift
+++ b/Tests/InfrastructureTests/Claude/ClaudeAPIUsageProbeTests.swift
@@ -73,6 +73,81 @@ struct ClaudeAPIUsageProbeTests {
         #expect(await probe.isAvailable() == false)
     }
 
+    // MARK: - Snapshot Cache (TTL) Tests
+
+    @Test
+    func `probe serves cached snapshot on subsequent calls within TTL`() async throws {
+        let tempDir = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let futureExpiry = Date().addingTimeInterval(3600).timeIntervalSince1970 * 1000
+        try createCredentialsFile(at: tempDir, expiresAt: futureExpiry, subscriptionType: "claude_max")
+
+        let mockNetwork = MockNetworkClient()
+        let responseJSON = """
+        {
+          "five_hour": { "utilization": 25.0, "resets_at": "2025-01-15T10:00:00Z" }
+        }
+        """.data(using: .utf8)!
+        let response = HTTPURLResponse(
+            url: URL(string: "https://api.anthropic.com")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        given(mockNetwork).request(.any).willReturn((responseJSON, response))
+
+        let loader = ClaudeCredentialLoader(homeDirectory: tempDir.path, useKeychain: false)
+        let probe = ClaudeAPIUsageProbe(credentialLoader: loader, networkClient: mockNetwork)
+
+        let first = try await probe.probe()
+        let second = try await probe.probe()
+        let third = try await probe.probe()
+
+        // All three calls return the same cached snapshot...
+        #expect(first.quotas.first?.percentRemaining == 75.0)
+        #expect(second.quotas.first?.percentRemaining == 75.0)
+        #expect(third.quotas.first?.percentRemaining == 75.0)
+        // ...but only the first one actually hit the network.
+        verify(mockNetwork).request(.any).called(1)
+    }
+
+    @Test
+    func `probe bypasses cache when TTL is zero`() async throws {
+        let tempDir = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let futureExpiry = Date().addingTimeInterval(3600).timeIntervalSince1970 * 1000
+        try createCredentialsFile(at: tempDir, expiresAt: futureExpiry, subscriptionType: "claude_max")
+
+        let mockNetwork = MockNetworkClient()
+        let responseJSON = """
+        {
+          "five_hour": { "utilization": 25.0, "resets_at": "2025-01-15T10:00:00Z" }
+        }
+        """.data(using: .utf8)!
+        let response = HTTPURLResponse(
+            url: URL(string: "https://api.anthropic.com")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        given(mockNetwork).request(.any).willReturn((responseJSON, response))
+
+        let loader = ClaudeCredentialLoader(homeDirectory: tempDir.path, useKeychain: false)
+        // TTL=0 means every entry is immediately stale, so every probe re-fetches.
+        let probe = ClaudeAPIUsageProbe(
+            credentialLoader: loader,
+            networkClient: mockNetwork,
+            snapshotCacheTTL: 0
+        )
+
+        _ = try await probe.probe()
+        _ = try await probe.probe()
+
+        verify(mockNetwork).request(.any).called(2)
+    }
+
     // MARK: - Rate Limit (HTTP 429) Tests
 
     @Test

--- a/Tests/InfrastructureTests/Claude/ClaudeAPIUsageProbeTests.swift
+++ b/Tests/InfrastructureTests/Claude/ClaudeAPIUsageProbeTests.swift
@@ -249,9 +249,17 @@ struct ClaudeAPIUsageProbeTests {
     // MARK: - Retry-After Parsing Tests
 
     @Test
-    func `parseRetryAfter accepts non-negative integer seconds`() {
+    func `parseRetryAfter accepts positive integer seconds`() {
         #expect(ClaudeAPIUsageProbe.parseRetryAfter("120") == 120)
-        #expect(ClaudeAPIUsageProbe.parseRetryAfter("0") == 0)
+        #expect(ClaudeAPIUsageProbe.parseRetryAfter("1") == 1)
+    }
+
+    @Test
+    func `parseRetryAfter rejects zero seconds`() {
+        // /api/oauth/usage has been observed returning Retry-After: 0 while
+        // still 429ing (anthropics/claude-code#30930). Treat 0 as no usable
+        // value so the caller applies its fallback window instead.
+        #expect(ClaudeAPIUsageProbe.parseRetryAfter("0") == nil)
     }
 
     @Test

--- a/Tests/InfrastructureTests/Claude/ClaudeAPIUsageProbeTests.swift
+++ b/Tests/InfrastructureTests/Claude/ClaudeAPIUsageProbeTests.swift
@@ -73,6 +73,142 @@ struct ClaudeAPIUsageProbeTests {
         #expect(await probe.isAvailable() == false)
     }
 
+    // MARK: - Rate Limit (HTTP 429) Tests
+
+    @Test
+    func `probe throws rateLimited when API returns 429 with Retry-After seconds`() async throws {
+        let tempDir = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let futureExpiry = Date().addingTimeInterval(3600).timeIntervalSince1970 * 1000
+        try createCredentialsFile(at: tempDir, expiresAt: futureExpiry)
+
+        let mockNetwork = MockNetworkClient()
+        let response = HTTPURLResponse(
+            url: URL(string: "https://api.anthropic.com")!,
+            statusCode: 429,
+            httpVersion: nil,
+            headerFields: ["Retry-After": "120"]
+        )!
+        given(mockNetwork).request(.any).willReturn((Data(), response))
+
+        let loader = ClaudeCredentialLoader(homeDirectory: tempDir.path, useKeychain: false)
+        let probe = ClaudeAPIUsageProbe(credentialLoader: loader, networkClient: mockNetwork)
+
+        let before = Date()
+        do {
+            _ = try await probe.probe()
+            Issue.record("Expected rateLimited error to be thrown")
+        } catch let error as ProbeError {
+            guard case .rateLimited(let retryAt) = error else {
+                Issue.record("Expected .rateLimited, got \(error)")
+                return
+            }
+            let delta = retryAt.timeIntervalSince(before)
+            #expect(delta >= 119 && delta <= 122)
+        }
+    }
+
+    @Test
+    func `probe defaults to 5 minute retry when 429 has no Retry-After header`() async throws {
+        let tempDir = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let futureExpiry = Date().addingTimeInterval(3600).timeIntervalSince1970 * 1000
+        try createCredentialsFile(at: tempDir, expiresAt: futureExpiry)
+
+        let mockNetwork = MockNetworkClient()
+        let response = HTTPURLResponse(
+            url: URL(string: "https://api.anthropic.com")!,
+            statusCode: 429,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        given(mockNetwork).request(.any).willReturn((Data(), response))
+
+        let loader = ClaudeCredentialLoader(homeDirectory: tempDir.path, useKeychain: false)
+        let probe = ClaudeAPIUsageProbe(credentialLoader: loader, networkClient: mockNetwork)
+
+        let before = Date()
+        do {
+            _ = try await probe.probe()
+            Issue.record("Expected rateLimited error to be thrown")
+        } catch let error as ProbeError {
+            guard case .rateLimited(let retryAt) = error else {
+                Issue.record("Expected .rateLimited, got \(error)")
+                return
+            }
+            let delta = retryAt.timeIntervalSince(before)
+            #expect(delta >= 299 && delta <= 302)
+        }
+    }
+
+    @Test
+    func `probe short-circuits subsequent calls within active rate-limit window`() async throws {
+        let tempDir = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let futureExpiry = Date().addingTimeInterval(3600).timeIntervalSince1970 * 1000
+        try createCredentialsFile(at: tempDir, expiresAt: futureExpiry)
+
+        let mockNetwork = MockNetworkClient()
+        let response = HTTPURLResponse(
+            url: URL(string: "https://api.anthropic.com")!,
+            statusCode: 429,
+            httpVersion: nil,
+            headerFields: ["Retry-After": "600"]
+        )!
+        given(mockNetwork).request(.any).willReturn((Data(), response))
+
+        let loader = ClaudeCredentialLoader(homeDirectory: tempDir.path, useKeychain: false)
+        let probe = ClaudeAPIUsageProbe(credentialLoader: loader, networkClient: mockNetwork)
+
+        // First call: hits the network and stores the rate-limit window
+        _ = try? await probe.probe()
+        // Second call: must throw immediately without re-hitting the network
+        _ = try? await probe.probe()
+
+        verify(mockNetwork).request(.any).called(1)
+    }
+
+    // MARK: - Retry-After Parsing Tests
+
+    @Test
+    func `parseRetryAfter accepts non-negative integer seconds`() {
+        #expect(ClaudeAPIUsageProbe.parseRetryAfter("120") == 120)
+        #expect(ClaudeAPIUsageProbe.parseRetryAfter("0") == 0)
+    }
+
+    @Test
+    func `parseRetryAfter accepts HTTP-date in the future`() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        // 2023-11-14 22:13:20 UTC + 60s = 2023-11-14 22:14:20 UTC
+        let result = ClaudeAPIUsageProbe.parseRetryAfter(
+            "Tue, 14 Nov 2023 22:14:20 GMT",
+            now: now
+        )
+        #expect(result == 60)
+    }
+
+    @Test
+    func `parseRetryAfter rejects past HTTP-dates`() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let result = ClaudeAPIUsageProbe.parseRetryAfter(
+            "Tue, 14 Nov 2023 22:00:00 GMT",
+            now: now
+        )
+        #expect(result == nil)
+    }
+
+    @Test
+    func `parseRetryAfter rejects malformed and empty values`() {
+        #expect(ClaudeAPIUsageProbe.parseRetryAfter(nil) == nil)
+        #expect(ClaudeAPIUsageProbe.parseRetryAfter("") == nil)
+        #expect(ClaudeAPIUsageProbe.parseRetryAfter("   ") == nil)
+        #expect(ClaudeAPIUsageProbe.parseRetryAfter("not a number") == nil)
+        #expect(ClaudeAPIUsageProbe.parseRetryAfter("-5") == nil)
+    }
+
     // MARK: - Probe Authentication Tests
 
     @Test


### PR DESCRIPTION
## Summary

- The Claude API usage probe was getting HTTP 429s from `/api/oauth/usage` at the 60s monitor cadence, then immediately retrying on the next tick — keeping the throttle window open indefinitely and surfacing a misleading "Could not find session usage" parse error (from the CLI fallback) instead of the real cause.
- This PR adds rate-limit awareness to the API probe, a 15-minute snapshot cache to stay well under the throttle, and tightens `ClaudeProvider`'s error propagation so the real root cause reaches the UI.
- Live validation: with the 15-min TTL, the probe makes ~4 calls/hour and the menu bar quotas display cleanly without 429 spirals.

## Context

`https://api.anthropic.com/api/oauth/usage` is aggressively rate-limited and the throttle is sticky — once a token gets 429'd, Anthropic returns Retry-After windows in the 30-minute to 1-hour range, sometimes `Retry-After: 0` (a misleading no-op). The endpoint behavior is documented in several open Anthropic issues:

- [anthropics/claude-code#31021](https://github.com/anthropics/claude-code/issues/31021) — closed as "not planned" by Anthropic
- [anthropics/claude-code#31637](https://github.com/anthropics/claude-code/issues/31637) — open, aggressive rate limit makes monitoring unusable
- [anthropics/claude-code#30930](https://github.com/anthropics/claude-code/issues/30930) — open, `Retry-After: 0` while still 429ing

The community consensus is that even 30–60s polling is enough to trigger persistent 429s. ClaudeBar's `QuotaMonitor` polls every 60s, so we were hitting this directly.

## Changes

Six focused commits, each with tests:

1. **`fix(claude-api): back off on HTTP 429 instead of hammering the endpoint`** — Adds `ProbeError.rateLimited(retryAt:)`, a thread-safe `RateLimitState` window, and a `Retry-After` parser (RFC 7231 integer seconds or HTTP-date). `probe()` short-circuits while a window is active so we stop hitting the API entirely. Defaults to 5 minutes when no usable header is provided.

2. **`fix(claude-provider): surface primary probe error when fallback also fails`** — When the API probe fails and the CLI fallback also fails, `refresh()` now rethrows the *primary* error (e.g. `.rateLimited`) instead of the fallback's incidental failure. Users see the real root cause, not a downstream parse error red herring.

3. **`perf(claude-api): cache successful usage snapshot for 5 minutes`** — Adds an in-memory `SnapshotCache` so the dominant code path (monitor polling) returns the last successful snapshot without re-hitting the API.

4. **`fix(claude-provider): skip CLI fallback for rate-limited API failures`** — The CLI talks to the same Anthropic backend and is subject to the same per-token throttle, so falling back to it on a 429 amplifies the problem. `ClaudeProvider.refresh()` now skips the fallback when the primary error is `.rateLimited`, surfacing the rate-limit immediately so the backoff window does its job.

5. **`fix(claude-api): treat Retry-After: 0 as no usable value`** — Directly informed by anthropics/claude-code#30930. `parseRetryAfter` now rejects `0` so we fall back to the default window instead of immediately retrying into a known anti-pattern.

6. **`perf(claude-api): widen snapshot cache TTL from 5 to 15 minutes`** — Tuned upward after observing that even a single call after a quiet period was triggering 1-hour Retry-After windows on tokens with accumulated penalty. 15 minutes drops the request rate to ~4/hour while keeping quota display fresh enough for menu-bar use (quotas update on 5h/7d boundaries, so freshness cost is negligible).

## Test plan

- [x] New tests added for `parseRetryAfter` (numeric seconds, HTTP-date, malformed, past dates, zero)
- [x] New tests for `ClaudeAPIUsageProbe`: 429 → `rateLimited` with parsed Retry-After, missing-header default, short-circuit verification via Mockable (single network call across multiple probes), cache TTL hit/miss
- [x] New tests for `ClaudeProvider.refresh()`: primary-error preservation when both probes fail, narrow-fallback skip when primary is `.rateLimited`
- [x] All existing Claude probe + provider tests continue to pass
- [x] Live validation on a real `claude_max` token: probe cadence settles at the 15-min TTL, no 429s observed once the token's prior penalty cleared, quotas display correctly in the menu bar

## Future work

Tracked in deferred memory but out of scope here:

- **CLI fallback regression** in `claude` v2.1.141: `claude /usage` subprocess captures the welcome banner instead of the quota table. Will be handled on a separate `fix/claude-cli-usage-invocation` branch.
- **Auto-degrade UX:** when the CLI probe fails structurally on N consecutive refreshes, suggest API mode or auto-route via API.
- **Watch upstream feature** [anthropics/claude-code#29604](https://github.com/anthropics/claude-code/issues/29604): exposing usage data via statusline JSON stdin. If/when this lands, `ClaudeAPIUsageProbe` should migrate to consuming that channel since Anthropic has explicitly chosen not to fix the `/api/oauth/usage` 429 behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Snapshot caching with TTL to reduce repeated usage calls.
  * Detect API rate limits and expose retry timestamps; messages show relative "retrying…" time.

* **Bug Fixes**
  * When an API probe is rate-limited, the system surfaces that error immediately and skips fallback probes; fallback behavior refined and primary errors preserved.

* **Tests**
  * Added tests for caching, rate-limit handling, Retry-After parsing, and provider error propagation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tddworks/ClaudeBar/pull/187)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->