### PR TITLE
fix(antigravity): match brew release binary name

### DIFF
--- a/Sources/Infrastructure/Antigravity/AntigravityUsageProbe.swift
+++ b/Sources/Infrastructure/Antigravity/AntigravityUsageProbe.swift
@@ -10,7 +10,7 @@ public struct AntigravityUsageProbe: UsageProbe {
     private let timeout: TimeInterval
 
     // Match both Intel and ARM binaries
-    private static let processNames = ["language_server_macos", "language_server_macos_arm"]
+    private static let processNames = ["language_server_macos", "language_server_macos_arm", "language_server"]
 
     public init(
         cliExecutor: (any CLIExecutor)? = nil,
@@ -97,7 +97,7 @@ public struct AntigravityUsageProbe: UsageProbe {
         // Use pgrep for more reliable process detection (avoids PTY buffering issues)
         let result = try cliExecutor.execute(
             binary: "/usr/bin/pgrep",
-            args: ["-lf", "language_server_macos"],
+            args: ["-lf", "language_server"],
             input: nil,
             timeout: timeout,
             workingDirectory: nil,

--- a/scripts/antigravity-debug.sh
+++ b/scripts/antigravity-debug.sh
@@ -9,7 +9,7 @@ echo
 
 # Step 1: Find Antigravity process
 echo "Step 1: Finding Antigravity process..."
-PROCESS_LINE=$(pgrep -lf language_server_macos | grep -E "(antigravity|--app_data_dir.*antigravity)" | head -1)
+PROCESS_LINE=$(pgrep -lf "language_server" | grep -E "(antigravity|--app_data_dir.*antigravity)" | head -1)
 
 if [ -z "$PROCESS_LINE" ]; then
     echo "ERROR: Antigravity process not found. Is the app running?"


### PR DESCRIPTION
Brew installs the binary as `language_server`, not `language_server_macos`. The pgrep pattern and processNames filter both hardcoded `language_server_macos`, so the probe never found the brew-installed process.

Changes:
- `processNames`: add `"language_server"`
- `pgrep` args: `language_server_macos` → `language_server`
- debug script: same fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated process detection to support additional Antigravity binary naming conventions, enhancing compatibility and availability checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tddworks/ClaudeBar/pull/193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->