### PR TITLE
docs(claude.md): list available test targets next to tuist test example

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ tuist build
 # Run all tests
 tuist test
 
-# Run a specific test target
+# Run a specific test target (DomainTests, InfrastructureTests, AcceptanceTests)
 tuist test DomainTests
 
 # Run tests with coverage


### PR DESCRIPTION
## Summary

- Adds a one-line clarification to `CLAUDE.md` listing the available test targets (`DomainTests`, `InfrastructureTests`, `AcceptanceTests`) next to the `tuist test DomainTests` example, so contributors don't have to grep `Project.swift` to find target names.

## Test plan

- [ ] Read the updated section in CLAUDE.md — purely a doc change, no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified test execution command documentation to explain how to run specific test targets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tddworks/ClaudeBar/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->