### PR TITLE
Support Antigravity language_server process name

### DIFF
--- a/Sources/Infrastructure/Antigravity/AntigravityUsageProbe.swift
+++ b/Sources/Infrastructure/Antigravity/AntigravityUsageProbe.swift
@@ -9,8 +9,8 @@ public struct AntigravityUsageProbe: UsageProbe {
     private let networkClient: any NetworkClient
     private let timeout: TimeInterval
 
-    // Match both Intel and ARM binaries
-    private static let processNames = ["language_server_macos", "language_server_macos_arm"]
+    // Match current and older Antigravity language server binary names.
+    private static let processNames = ["language_server", "language_server_macos", "language_server_macos_arm"]
 
     public init(
         cliExecutor: (any CLIExecutor)? = nil,
@@ -97,7 +97,7 @@ public struct AntigravityUsageProbe: UsageProbe {
         // Use pgrep for more reliable process detection (avoids PTY buffering issues)
         let result = try cliExecutor.execute(
             binary: "/usr/bin/pgrep",
-            args: ["-lf", "language_server_macos"],
+            args: ["-lf", "language_server"],
             input: nil,
             timeout: timeout,
             workingDirectory: nil,
@@ -441,4 +441,3 @@ private struct QuotaInfo: Decodable {
     let remainingFraction: Double?
     let resetTime: String?
 }
-

--- a/Tests/InfrastructureTests/Antigravity/AntigravityUsageProbeTests.swift
+++ b/Tests/InfrastructureTests/Antigravity/AntigravityUsageProbeTests.swift
@@ -18,6 +18,10 @@ struct AntigravityUsageProbeTests {
     26416 /Applications/Antigravity.app/Contents/Resources/app/extensions/antigravity/bin/language_server_macos_arm --csrf_token 9f808dbe-cb96-4829 --extension_server_port 58445 --app_data_dir antigravity
     """
 
+    static let samplePsOutputWithCurrentAntigravity = """
+    5588 /Applications/Antigravity.app/Contents/Resources/bin/language_server --standalone --override_ide_name antigravity --subclient_type hub --override_ide_version 2.0.6 --override_user_agent_name antigravity --https_server_port 0 --csrf_token 21ee9ede-f085-4e96-9588-849208669d00 --app_data_dir antigravity --api_server_url https://generativelanguage.googleapis.com --cloud_code_endpoint https://daily-cloudcode-pa.googleapis.com --enable_sidecars
+    """
+
     static let samplePsOutputNoAntigravity = """
     12345 /path/to/some_other_binary --flag value
     67890 /another/process
@@ -95,6 +99,20 @@ struct AntigravityUsageProbeTests {
     }
 
     @Test
+    func `isAvailable returns true when current language_server binary detected with CSRF token`() async {
+        // Given
+        let mockExecutor = MockCLIExecutor()
+        given(mockExecutor)
+            .execute(binary: .any, args: .any, input: .any, timeout: .any, workingDirectory: .any, autoResponses: .any)
+            .willReturn(CLIResult(output: Self.samplePsOutputWithCurrentAntigravity, exitCode: 0))
+
+        let probe = AntigravityUsageProbe(cliExecutor: mockExecutor)
+
+        // When & Then
+        #expect(await probe.isAvailable() == true)
+    }
+
+    @Test
     func `isAvailable returns false when process running but CSRF token missing`() async {
         // Given
         let mockExecutor = MockCLIExecutor()
@@ -152,12 +170,14 @@ struct AntigravityUsageProbeTests {
         let antigravityLine = "/path/to/language_server_macos --app_data_dir antigravity"
         // ARM binary
         let antigravityARMLine = "/Applications/Antigravity.app/Contents/Resources/app/extensions/antigravity/bin/language_server_macos_arm --csrf_token abc --app_data_dir antigravity"
+        let currentAntigravityLine = "/Applications/Antigravity.app/Contents/Resources/bin/language_server --csrf_token abc --app_data_dir antigravity"
         let otherLine = "/path/to/some_other_binary"
         let antigravityPathLine = "/Users/test/.antigravity/language_server_macos"
 
         // When & Then
         #expect(AntigravityUsageProbe.isAntigravityProcess(antigravityLine) == true)
         #expect(AntigravityUsageProbe.isAntigravityProcess(antigravityARMLine) == true)
+        #expect(AntigravityUsageProbe.isAntigravityProcess(currentAntigravityLine) == true)
         #expect(AntigravityUsageProbe.isAntigravityProcess(otherLine) == false)
         #expect(AntigravityUsageProbe.isAntigravityProcess(antigravityPathLine) == true)
     }

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.8.1"),
         .package(url: "https://github.com/Kolos65/Mockable.git", from: "0.5.0"),
         .package(url: "https://github.com/migueldeicaza/SwiftTerm.git", exact: "1.12.0"),
-        .package(url: "https://github.com/awslabs/aws-sdk-swift", from: "1.6.43"),
+        .package(url: "https://github.com/awslabs/aws-sdk-swift", exact: "1.6.99"),
         .package(url: "https://github.com/steipete/SweetCookieKit.git", from: "0.3.0"),
     ]
 )


### PR DESCRIPTION
This PR updates the Antigravity usage probe to look for the 'language_server' process name (which the latest Antigravity/Codeium binary runs as) in addition to older names like 'language_server_macos'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Antigravity process detection to recognize an additional binary variant, improving compatibility.

* **Tests**
  * Added test coverage for the newly supported Antigravity binary detection scenario.

* **Chores**
  * Updated AWS SDK dependency to version 1.6.99.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tddworks/ClaudeBar/pull/196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->