### PR TITLE
Add Ollama Cloud / Pro provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **[Ollama Cloud / Pro](https://ollama.com) quota tracking**: New `OllamaProvider` monitors Ollama's paid subscription with two probe modes:
+  - **API mode** (default): Bearer-token authentication against `https://ollama.com/api/tags`. Resolves the key from a user-configured env-var name, then `OLLAMA_API_KEY` / `OLLAMA_KEY`, then a value stored in Settings.
+  - **Web mode**: Cookie-based scraping of the `ollama.com/settings` page via SweetCookieKit (already a project dependency). Recognises `__Secure-next-auth.session-token` plus chunked variants and the older `session` / `ollama_session` cookie names; parses session and weekly usage percentages along with reset times out of the rendered HTML.
+  - Settings UI: `OllamaConfigCard` with a probe-mode picker, secure API-key field with show/hide toggle, env-var name override, lookup-order legend, and a "Save & Test" button.
+  - Endpoints, cookie names, and parsing markers were derived from the working Ollama support in [steipete/CodexBar](https://github.com/steipete/CodexBar/tree/main/Sources/CodexBarCore/Providers/Ollama) (MIT).
+  - Defaults to disabled. Ollama does not currently publish a public JSON usage endpoint, so the API probe returns a connectivity-only snapshot until one exists; the Web probe returns full session and weekly quotas today. A TODO comment in `OllamaUsageProbe.swift` flags the URL/parser change needed when an API endpoint ships.
+
+
 ---
 
 ## [0.4.63] - 2026-05-15

--- a/Sources/App/ClaudeBarApp.swift
+++ b/Sources/App/ClaudeBarApp.swift
@@ -102,6 +102,11 @@ struct ClaudeBarApp: App {
                 probe: OpenCodeUsageProbe(),
                 settingsRepository: settingsRepository
             ),
+            OllamaProvider(
+                apiProbe: OllamaUsageProbe(settingsRepository: settingsRepository),
+                webProbe: OllamaWebUsageProbe(),
+                settingsRepository: settingsRepository
+            ),
         ])
         AppLog.providers.info("Created \(repository.all.count) providers")
 

--- a/Sources/App/Settings/AppSettings.swift
+++ b/Sources/App/Settings/AppSettings.swift
@@ -239,6 +239,7 @@ public final class AppSettings {
     public var bedrock: BedrockSettingsRepository { repository }
     public var minimax: MiniMaxSettingsRepository { repository }
     public var alibaba: AlibabaSettingsRepository { repository }
+    public var ollama: OllamaSettingsRepository { repository }
     public var hook: HookSettingsRepository { repository }
 
     /// Extension config repository for dynamic extension provider settings.

--- a/Sources/App/Views/ProviderIcons.swift
+++ b/Sources/App/Views/ProviderIcons.swift
@@ -96,6 +96,7 @@ struct ProviderIconView: View {
         case "copilot": return "chevron.left.forwardslash.chevron.right"
         case "minimax": return "waveform"
         case "opencode-go": return "square.stack.3d.up.fill"
+        case "ollama": return "cloud.fill"
         default: return "questionmark"
         }
     }

--- a/Sources/App/Views/ProviderVisualIdentity.swift
+++ b/Sources/App/Views/ProviderVisualIdentity.swift
@@ -380,6 +380,34 @@ extension MistralProvider: ProviderVisualIdentity {
     }
 }
 
+// MARK: - OllamaProvider Visual Identity
+
+extension OllamaProvider: ProviderVisualIdentity {
+    public var symbolIcon: String { "cloud.fill" }
+
+    public var iconAssetName: String { "OllamaIcon" }
+
+    public func themeColor(for scheme: ColorScheme) -> Color {
+        // Neutral graphite/black matching Ollama's wordmark
+        scheme == .dark
+            ? Color(red: 0.65, green: 0.65, blue: 0.68)
+            : Color(red: 0.30, green: 0.30, blue: 0.33)
+    }
+
+    public func themeGradient(for scheme: ColorScheme) -> LinearGradient {
+        LinearGradient(
+            colors: [
+                themeColor(for: scheme),
+                scheme == .dark
+                    ? Color(red: 0.45, green: 0.45, blue: 0.48)
+                    : Color(red: 0.18, green: 0.18, blue: 0.20)
+            ],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+}
+
 // MARK: - OpenCodeProvider Visual Identity
 
 extension OpenCodeProvider: ProviderVisualIdentity {
@@ -508,6 +536,10 @@ enum ProviderVisualIdentityLookup {
             return scheme == .dark
                 ? Color(red: 0.52, green: 0.36, blue: 1.0)
                 : Color(red: 0.42, green: 0.28, blue: 1.0)
+        case "ollama":
+            return scheme == .dark
+                ? Color(red: 0.65, green: 0.65, blue: 0.68)
+                : Color(red: 0.30, green: 0.30, blue: 0.33)
         default:
             return BaseTheme.purpleVibrant
         }
@@ -575,6 +607,10 @@ enum ProviderVisualIdentityLookup {
             secondaryColor = scheme == .dark
                 ? Color(red: 0.36, green: 0.20, blue: 0.90)
                 : Color(red: 0.30, green: 0.15, blue: 0.80)
+        case "ollama":
+            secondaryColor = scheme == .dark
+                ? Color(red: 0.45, green: 0.45, blue: 0.48)
+                : Color(red: 0.18, green: 0.18, blue: 0.20)
         default:
             return LinearGradient(
                 colors: [BaseTheme.coralAccent, BaseTheme.pinkHot],
@@ -607,6 +643,7 @@ enum ProviderVisualIdentityLookup {
         case "cursor": return "CursorIcon"
         case "mistral": return "MistralIcon"
         case "opencode-go": return "OpenCodeIcon"
+        case "ollama": return "OllamaIcon"
         default: return "QuestionIcon"
         }
     }
@@ -628,6 +665,7 @@ enum ProviderVisualIdentityLookup {
         case "cursor": return "Cursor"
         case "mistral": return "Mistral"
         case "opencode-go": return "OpenCode Go"
+        case "ollama": return "Ollama"
         default: return providerId.capitalized
         }
     }
@@ -649,6 +687,7 @@ enum ProviderVisualIdentityLookup {
         case "cursor": return "cursorarrow.rays"
         case "mistral": return "cat.fill"
         case "opencode-go": return "square.stack.3d.up.fill"
+        case "ollama": return "cloud.fill"
         default: return "questionmark.circle.fill"
         }
     }

--- a/Sources/App/Views/Settings/OllamaConfigCard.swift
+++ b/Sources/App/Views/Settings/OllamaConfigCard.swift
@@ -1,0 +1,376 @@
+import SwiftUI
+import Domain
+import Infrastructure
+
+/// Ollama provider configuration card for `SettingsContentView`.
+///
+/// Lets the user pick a probe mode (API or Web), paste an API key,
+/// override the env var name consulted for the key, test the connection,
+/// and remove a saved key.
+struct OllamaConfigCard: View {
+    let monitor: QuotaMonitor
+
+    @State private var settings = AppSettings.shared
+    @Environment(\.appTheme) private var theme
+
+    @State private var ollamaConfigExpanded: Bool = false
+    @State private var ollamaProbeMode: OllamaProbeMode = .api
+    @State private var ollamaApiKeyInput: String = ""
+    @State private var ollamaAuthEnvVarInput: String = ""
+    @State private var showOllamaApiKey: Bool = false
+    @State private var isTestingOllama: Bool = false
+    @State private var ollamaTestResult: String?
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $ollamaConfigExpanded) {
+            Divider()
+                .background(theme.glassBorder)
+                .padding(.vertical, 12)
+
+            ollamaConfigForm
+        } label: {
+            ollamaConfigHeader
+                .contentShape(.rect)
+                .onTapGesture {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        ollamaConfigExpanded.toggle()
+                    }
+                }
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 14)
+                .fill(theme.cardGradient)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14)
+                        .stroke(
+                            LinearGradient(
+                                colors: [
+                                    theme.glassBorder, theme.glassBorder.opacity(0.5)
+                                ],
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            ),
+                            lineWidth: 1
+                        )
+                )
+        )
+        .onAppear {
+            ollamaProbeMode = settings.ollama.ollamaProbeMode()
+            ollamaAuthEnvVarInput = settings.ollama.ollamaAuthEnvVar()
+        }
+    }
+
+    // MARK: - Header
+
+    private var ollamaConfigHeader: some View {
+        HStack(spacing: 10) {
+            ZStack {
+                Circle()
+                    .fill(
+                        LinearGradient(
+                            colors: [
+                                Color(red: 0.36, green: 0.36, blue: 0.40),
+                                Color(red: 0.20, green: 0.20, blue: 0.24)
+                            ],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                    .frame(width: 32, height: 32)
+
+                Image(systemName: "cloud.fill")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundStyle(.white)
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Ollama Configuration")
+                    .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
+                    .foregroundStyle(theme.textPrimary)
+
+                Text("Ollama Cloud / Pro quota tracking")
+                    .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
+                    .foregroundStyle(theme.textTertiary)
+            }
+
+            Spacer()
+        }
+    }
+
+    // MARK: - Form
+
+    private var ollamaConfigForm: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            probeModePicker
+            modeDescriptions
+            apiKeyField
+            envVarField
+            lookupOrder
+            testButton
+
+            if let result = ollamaTestResult {
+                Text(result)
+                    .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
+                    .foregroundStyle(result.contains("Success") ? theme.statusHealthy : theme.statusCritical)
+            }
+
+            helpLink
+            deleteKeyButton
+        }
+    }
+
+    private var probeModePicker: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("PROBE MODE")
+                .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
+                .foregroundStyle(theme.textSecondary)
+                .tracking(0.5)
+
+            Picker("", selection: $ollamaProbeMode) {
+                ForEach(OllamaProbeMode.allCases, id: \.self) { mode in
+                    Text(mode.displayName).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+            .onChange(of: ollamaProbeMode) { _, newValue in
+                settings.ollama.setOllamaProbeMode(newValue)
+                Task {
+                    await monitor.refresh(providerId: "ollama")
+                }
+            }
+        }
+    }
+
+    private var modeDescriptions: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "network")
+                    .font(.system(size: 10))
+                    .foregroundStyle(ollamaProbeMode == .api ? theme.accentPrimary : theme.textTertiary)
+                    .frame(width: 16)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("API Mode")
+                        .font(.system(size: 10, weight: .semibold, design: theme.fontDesign))
+                        .foregroundStyle(ollamaProbeMode == .api ? theme.textPrimary : theme.textSecondary)
+
+                    Text("Uses an Ollama API key (Bearer token). Most reliable.")
+                        .font(.system(size: 9, weight: .medium, design: theme.fontDesign))
+                        .foregroundStyle(theme.textTertiary)
+                }
+            }
+
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "globe")
+                    .font(.system(size: 10))
+                    .foregroundStyle(ollamaProbeMode == .web ? theme.accentPrimary : theme.textTertiary)
+                    .frame(width: 16)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Web Mode")
+                        .font(.system(size: 10, weight: .semibold, design: theme.fontDesign))
+                        .foregroundStyle(ollamaProbeMode == .web ? theme.textPrimary : theme.textSecondary)
+
+                    Text("Reads ollama.com session cookies from your browser.")
+                        .font(.system(size: 9, weight: .medium, design: theme.fontDesign))
+                        .foregroundStyle(theme.textTertiary)
+                }
+            }
+        }
+    }
+
+    private var apiKeyField: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text("API KEY")
+                    .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
+                    .foregroundStyle(theme.textSecondary)
+                    .tracking(0.5)
+
+                Spacer()
+
+                if settings.ollama.hasOllamaApiKey() {
+                    HStack(spacing: 3) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 9))
+                        Text("Configured")
+                            .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
+                    }
+                    .foregroundStyle(theme.statusHealthy)
+                }
+            }
+
+            HStack(spacing: 6) {
+                Group {
+                    if showOllamaApiKey {
+                        TextField("", text: $ollamaApiKeyInput, prompt: Text("sk-...").foregroundStyle(theme.textTertiary))
+                    } else {
+                        SecureField("", text: $ollamaApiKeyInput, prompt: Text("sk-...").foregroundStyle(theme.textTertiary))
+                    }
+                }
+                .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
+                .foregroundStyle(theme.textPrimary)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(theme.glassBackground)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(theme.glassBorder, lineWidth: 1)
+                        )
+                )
+
+                Button {
+                    showOllamaApiKey.toggle()
+                } label: {
+                    Image(systemName: showOllamaApiKey ? "eye.slash.fill" : "eye.fill")
+                        .font(.system(size: 11))
+                        .foregroundStyle(theme.textSecondary)
+                        .frame(width: 28, height: 28)
+                        .background(Circle().fill(theme.glassBackground))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private var envVarField: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("API KEY ENV VAR (ALTERNATIVE)")
+                .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
+                .foregroundStyle(theme.textSecondary)
+                .tracking(0.5)
+
+            TextField("", text: $ollamaAuthEnvVarInput, prompt: Text("OLLAMA_API_KEY").foregroundStyle(theme.textTertiary))
+                .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
+                .foregroundStyle(theme.textPrimary)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(theme.glassBackground)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(theme.glassBorder, lineWidth: 1)
+                        )
+                )
+                .onChange(of: ollamaAuthEnvVarInput) { _, newValue in
+                    settings.ollama.setOllamaAuthEnvVar(newValue)
+                }
+        }
+    }
+
+    private var lookupOrder: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("API KEY LOOKUP ORDER")
+                .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
+                .foregroundStyle(theme.textSecondary)
+                .tracking(0.5)
+
+            Text("1. Custom env var above (if set)")
+                .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
+                .foregroundStyle(theme.textTertiary)
+            Text("2. OLLAMA_API_KEY / OLLAMA_KEY environment variables")
+                .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
+                .foregroundStyle(theme.textTertiary)
+            Text("3. API key entered above")
+                .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
+                .foregroundStyle(theme.textTertiary)
+        }
+    }
+
+    @ViewBuilder
+    private var testButton: some View {
+        if isTestingOllama {
+            HStack {
+                ProgressView()
+                    .scaleEffect(0.7)
+                Text("Testing connection...")
+                    .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
+                    .foregroundStyle(theme.textSecondary)
+            }
+        } else {
+            Button {
+                Task { await testOllamaConnection() }
+            } label: {
+                Text("Save & Test Connection")
+                    .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(theme.accentPrimary)
+                    )
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private var helpLink: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Get your API key from the Ollama dashboard")
+                .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
+                .foregroundStyle(theme.textTertiary)
+
+            Link(destination: URL(string: "https://ollama.com/settings/keys")!) {
+                HStack(spacing: 3) {
+                    Text("Open Ollama API Keys")
+                        .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
+                    Image(systemName: "arrow.up.right")
+                        .font(.system(size: 7, weight: .bold))
+                }
+                .foregroundStyle(theme.accentPrimary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var deleteKeyButton: some View {
+        if settings.ollama.hasOllamaApiKey() {
+            Button {
+                settings.ollama.deleteOllamaApiKey()
+                ollamaApiKeyInput = ""
+                ollamaTestResult = nil
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "trash.fill")
+                        .font(.system(size: 9))
+                    Text("Remove API Key")
+                        .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
+                }
+                .foregroundStyle(theme.statusCritical)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    // MARK: - Actions
+
+    private func testOllamaConnection() async {
+        isTestingOllama = true
+        ollamaTestResult = nil
+
+        settings.ollama.setOllamaAuthEnvVar(ollamaAuthEnvVarInput)
+        if !ollamaApiKeyInput.isEmpty {
+            AppLog.credentials.info("Saving Ollama API key for connection test")
+            settings.ollama.saveOllamaApiKey(ollamaApiKeyInput)
+            ollamaApiKeyInput = ""
+        }
+
+        AppLog.credentials.info("Testing Ollama connection via provider refresh")
+        await monitor.refresh(providerId: "ollama")
+
+        if let error = monitor.provider(for: "ollama")?.lastError {
+            AppLog.credentials.error("Ollama connection test failed: \(error.localizedDescription)")
+            ollamaTestResult = "Failed: \(error.localizedDescription)"
+        } else {
+            AppLog.credentials.info("Ollama connection test succeeded")
+            ollamaTestResult = "Success: Connection verified"
+        }
+
+        isTestingOllama = false
+    }
+}

--- a/Sources/App/Views/Settings/OllamaConfigCard.swift
+++ b/Sources/App/Views/Settings/OllamaConfigCard.swift
@@ -364,7 +364,13 @@ struct OllamaConfigCard: View {
         await monitor.refresh(providerId: "ollama")
 
         if let error = monitor.provider(for: "ollama")?.lastError {
-            AppLog.credentials.error("Ollama connection test failed: \(error.localizedDescription)")
+            // Keep the credential log static — `error.localizedDescription` can
+            // contain bearer-token fragments or session cookie context that
+            // shouldn't land in os_log (CodeRabbit review on PR #197).
+            // The user-facing string in the UI still shows the message so the
+            // human running the test sees what happened; the system log does
+            // not.
+            AppLog.credentials.error("Ollama connection test failed")
             ollamaTestResult = "Failed: \(error.localizedDescription)"
         } else {
             AppLog.credentials.info("Ollama connection test succeeded")

--- a/Sources/App/Views/SettingsView.swift
+++ b/Sources/App/Views/SettingsView.swift
@@ -35,6 +35,7 @@ struct SettingsContentView: View {
         static let kimi = "kimi"
         static let minimax = "minimax"
         static let alibaba = "alibaba"
+        static let ollama = "ollama"
     }
 
     private var isCopilotEnabled: Bool {
@@ -67,6 +68,10 @@ struct SettingsContentView: View {
 
     private var isAlibabaEnabled: Bool {
         monitor.provider(for: ProviderID.alibaba)?.isEnabled ?? false
+    }
+
+    private var isOllamaEnabled: Bool {
+        monitor.provider(for: ProviderID.ollama)?.isEnabled ?? false
     }
 
     /// Extension providers that are enabled and have config fields declared in their manifest.
@@ -130,6 +135,10 @@ struct SettingsContentView: View {
                     }
                     if isBedrockEnabled {
                         BedrockConfigCard(monitor: monitor)
+                            .transition(.opacity.combined(with: .move(edge: .top)))
+                    }
+                    if isOllamaEnabled {
+                        OllamaConfigCard(monitor: monitor)
                             .transition(.opacity.combined(with: .move(edge: .top)))
                     }
                     ForEach(enabledExtensionProvidersWithConfig, id: \.id) { extProvider in

--- a/Sources/Domain/Provider/Ollama/OllamaProbeMode.swift
+++ b/Sources/Domain/Provider/Ollama/OllamaProbeMode.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// The mode used by `OllamaProvider` to fetch usage data.
+///
+/// Ollama Pro / Ollama Cloud is a paid subscription with two supported
+/// authentication flavors:
+///
+/// - **API**: a long-lived `OLLAMA_API_KEY` (or one entered in Settings)
+///   sent as a `Bearer` token. This is the most reliable path and the
+///   default for new installs.
+/// - **Web**: a browser session cookie (`__Secure-next-auth.session-token`
+///   and friends) read from the user's browser via SweetCookieKit. Useful
+///   when the user only logs in via the website and does not have an API
+///   key handy.
+///
+/// Users can switch between modes in the Settings UI.
+public enum OllamaProbeMode: String, Sendable, Equatable, CaseIterable {
+    /// Calls the Ollama API directly with a Bearer token.
+    /// Requires either an `OLLAMA_API_KEY` environment variable or an
+    /// API key entered in Settings.
+    case api
+
+    /// Scrapes the authenticated `ollama.com/settings` HTML using the
+    /// session cookie from the user's browser.
+    case web
+
+    /// Human-readable display name for the mode.
+    public var displayName: String {
+        switch self {
+        case .api:
+            return "API"
+        case .web:
+            return "Web"
+        }
+    }
+
+    /// Short description of what this mode does.
+    public var description: String {
+        switch self {
+        case .api:
+            return "Uses an Ollama API key (Bearer token)"
+        case .web:
+            return "Uses the ollama.com session cookie from your browser"
+        }
+    }
+}

--- a/Sources/Domain/Provider/Ollama/OllamaProvider.swift
+++ b/Sources/Domain/Provider/Ollama/OllamaProvider.swift
@@ -1,0 +1,153 @@
+import Foundation
+import Observation
+
+/// Ollama AI provider - a rich domain model.
+///
+/// Tracks usage for Ollama Pro / Ollama Cloud (the paid subscription at
+/// ollama.com — distinct from the open-source local-only Ollama runtime).
+/// Observable class with its own state (isSyncing, snapshot, error).
+///
+/// Supports dual probe modes: `api` (Bearer token, default) and `web`
+/// (browser session cookie). The active mode is persisted via
+/// `OllamaSettingsRepository`.
+@Observable
+public final class OllamaProvider: AIProvider, @unchecked Sendable {
+    // MARK: - Identity (Protocol Requirement)
+
+    public let id: String = "ollama"
+    public let name: String = "Ollama"
+    public let cliCommand: String = "ollama"
+
+    public var dashboardURL: URL? {
+        URL(string: "https://ollama.com/settings")
+    }
+
+    public var statusPageURL: URL? {
+        nil
+    }
+
+    /// Whether the provider is enabled (persisted via settingsRepository).
+    public var isEnabled: Bool {
+        didSet {
+            settingsRepository.setEnabled(isEnabled, forProvider: id)
+        }
+    }
+
+    // MARK: - State (Observable)
+
+    /// Whether the provider is currently syncing data.
+    public private(set) var isSyncing: Bool = false
+
+    /// The current usage snapshot (nil if never refreshed or unavailable).
+    public private(set) var snapshot: UsageSnapshot?
+
+    /// The last error that occurred during refresh.
+    public private(set) var lastError: Error?
+
+    // MARK: - Probe Mode
+
+    /// The current probe mode (API or Web).
+    public var probeMode: OllamaProbeMode {
+        get {
+            if let ollamaSettings = settingsRepository as? OllamaSettingsRepository {
+                return ollamaSettings.ollamaProbeMode()
+            }
+            return .api
+        }
+        set {
+            if let ollamaSettings = settingsRepository as? OllamaSettingsRepository {
+                ollamaSettings.setOllamaProbeMode(newValue)
+            }
+        }
+    }
+
+    // MARK: - Internal
+
+    /// The API probe (Bearer token to ollama.com API).
+    private let apiProbe: any UsageProbe
+
+    /// The Web probe (session-cookie scraping of ollama.com/settings).
+    /// Optional so the provider works in environments where cookie reading
+    /// is unsupported.
+    private let webProbe: (any UsageProbe)?
+
+    /// The settings repository for persisting provider settings.
+    private let settingsRepository: any ProviderSettingsRepository
+
+    /// Returns the probe matching the current mode, falling back to the
+    /// other probe when the requested one is unavailable.
+    private var activeProbe: any UsageProbe {
+        switch probeMode {
+        case .api:
+            return apiProbe
+        case .web:
+            return webProbe ?? apiProbe
+        }
+    }
+
+    // MARK: - Initialization
+
+    /// Creates an Ollama provider with a single API probe (no web fallback).
+    /// - Parameters:
+    ///   - probe: The probe to use for fetching usage data
+    ///   - settingsRepository: The repository for persisting settings
+    public init(probe: any UsageProbe, settingsRepository: any ProviderSettingsRepository) {
+        self.apiProbe = probe
+        self.webProbe = nil
+        self.settingsRepository = settingsRepository
+        self.isEnabled = settingsRepository.isEnabled(
+            forProvider: "ollama",
+            defaultValue: false
+        )
+    }
+
+    /// Creates an Ollama provider with both API and Web probes.
+    /// - Parameters:
+    ///   - apiProbe: The probe for fetching usage via the Ollama HTTP API (Bearer token)
+    ///   - webProbe: The probe for fetching usage via the ollama.com/settings HTML scrape
+    ///   - settingsRepository: The repository for persisting settings (must be an
+    ///     `OllamaSettingsRepository` for mode switching to persist)
+    public init(
+        apiProbe: any UsageProbe,
+        webProbe: any UsageProbe,
+        settingsRepository: any OllamaSettingsRepository
+    ) {
+        self.apiProbe = apiProbe
+        self.webProbe = webProbe
+        self.settingsRepository = settingsRepository
+        self.isEnabled = settingsRepository.isEnabled(
+            forProvider: "ollama",
+            defaultValue: false
+        )
+    }
+
+    // MARK: - AIProvider Protocol
+
+    public func isAvailable() async -> Bool {
+        await activeProbe.isAvailable()
+    }
+
+    /// Refreshes the usage data and updates the snapshot.
+    /// Uses the active probe based on the current probe mode.
+    /// Sets `isSyncing` during refresh and captures any errors.
+    @discardableResult
+    public func refresh() async throws -> UsageSnapshot {
+        isSyncing = true
+        defer { isSyncing = false }
+
+        do {
+            let newSnapshot = try await activeProbe.probe()
+            snapshot = newSnapshot
+            lastError = nil
+            return newSnapshot
+        } catch {
+            lastError = error
+            throw error
+        }
+    }
+
+    /// Whether Web mode is available (a web probe was provided).
+    public var supportsWebMode: Bool {
+        webProbe != nil
+    }
+}

--- a/Sources/Domain/Provider/ProviderSettingsRepository.swift
+++ b/Sources/Domain/Provider/ProviderSettingsRepository.swift
@@ -203,6 +203,39 @@ public protocol KimiSettingsRepository: ProviderSettingsRepository {
     func setKimiProbeMode(_ mode: KimiProbeMode)
 }
 
+/// Ollama-specific settings repository, extending base ProviderSettingsRepository.
+///
+/// Stores configuration for Ollama Pro / Ollama Cloud quota monitoring:
+/// probe mode (API vs Web), an optional API key entered in the Settings UI,
+/// and the name of an environment variable to consult for the API key when
+/// none is saved.
+public protocol OllamaSettingsRepository: ProviderSettingsRepository {
+    /// Gets the probe mode for Ollama (API or Web)
+    func ollamaProbeMode() -> OllamaProbeMode
+
+    /// Sets the probe mode for Ollama
+    func setOllamaProbeMode(_ mode: OllamaProbeMode)
+
+    /// Gets the environment variable name for the Ollama API key
+    /// (empty = use the default `OLLAMA_API_KEY`).
+    func ollamaAuthEnvVar() -> String
+
+    /// Sets the environment variable name for the Ollama API key.
+    func setOllamaAuthEnvVar(_ envVar: String)
+
+    /// Saves the Ollama API key (for Settings UI input).
+    func saveOllamaApiKey(_ key: String)
+
+    /// Retrieves the Ollama API key (if one was saved via Settings).
+    func getOllamaApiKey() -> String?
+
+    /// Deletes the saved Ollama API key.
+    func deleteOllamaApiKey()
+
+    /// Whether an Ollama API key is currently saved.
+    func hasOllamaApiKey() -> Bool
+}
+
 /// MiniMax-specific settings repository, extending base ProviderSettingsRepository.
 /// Stores API key and region configuration for MiniMax Coding Plan quota monitoring.
 /// Tests can use UserDefaultsProviderSettingsRepository with test UserDefaults.

--- a/Sources/Infrastructure/Ollama/OllamaUsageProbe.swift
+++ b/Sources/Infrastructure/Ollama/OllamaUsageProbe.swift
@@ -106,8 +106,11 @@ public struct OllamaUsageProbe: UsageProbe {
             AppLog.probes.error("Ollama API: rate limited (429)")
             throw ProbeError.rateLimited(retryAt: Date().addingTimeInterval(60))
         default:
-            let body = String(data: data, encoding: .utf8) ?? "<binary>"
-            AppLog.probes.error("Ollama API: HTTP \(httpResponse.statusCode) - \(body.prefix(200))")
+            // Never log the raw response body — Ollama responses can embed
+            // account email, plan name, session token IDs, etc. The status
+            // code plus body length is enough signal for debugging (CodeRabbit
+            // review on PR #197).
+            AppLog.probes.error("Ollama API: HTTP \(httpResponse.statusCode) (\(data.count) bytes)")
             throw ProbeError.executionFailed("Ollama API returned HTTP \(httpResponse.statusCode)")
         }
     }

--- a/Sources/Infrastructure/Ollama/OllamaUsageProbe.swift
+++ b/Sources/Infrastructure/Ollama/OllamaUsageProbe.swift
@@ -1,0 +1,178 @@
+import Foundation
+import Domain
+
+// MARK: - Ollama API Probe
+
+/// Probes the Ollama Cloud usage endpoint using a Bearer API key.
+///
+/// Ollama Pro / Ollama Cloud is a paid subscription on `ollama.com` (distinct
+/// from the open-source local-only Ollama runtime). Users with the paid plan
+/// can issue an API key from `https://ollama.com/settings/keys` and set it
+/// via either:
+///
+/// - the `OLLAMA_API_KEY` (or `OLLAMA_KEY`) environment variable, OR
+/// - the **API KEY** field in ClaudeBar's Settings UI.
+///
+/// The probe is "available" whenever an API key is resolvable; it does not
+/// require any local CLI install.
+///
+/// ## Note on the endpoint
+///
+/// At the time of writing, Ollama Cloud does not expose a dedicated public
+/// usage-JSON endpoint. We use `/api/tags` (the standard model-list endpoint)
+/// as a connectivity probe; reaching it confirms the key is valid and lets
+/// the snapshot surface "logged in via API key" identity info in the UI.
+/// Once Ollama publishes a real usage endpoint, switch the URL here and
+/// extend `parseUsageResponse(_:)` to populate session/weekly quotas.
+public struct OllamaUsageProbe: UsageProbe {
+    /// The default Ollama Cloud API host.
+    public static let defaultBaseURL = URL(string: "https://ollama.com")!
+
+    /// Names of environment variables consulted for the API key, in order.
+    public static let apiKeyEnvironmentKeys = ["OLLAMA_API_KEY", "OLLAMA_KEY"]
+
+    private let networkClient: any NetworkClient
+    private let settingsRepository: any OllamaSettingsRepository
+    private let environment: [String: String]
+    private let baseURL: URL
+    private let timeout: TimeInterval
+
+    /// Creates an Ollama API probe.
+    /// - Parameters:
+    ///   - networkClient: HTTP client (defaults to `URLSession.shared`).
+    ///   - settingsRepository: Settings repository where the API key and
+    ///     env-var-name override are persisted.
+    ///   - environment: Process environment to consult for the API key.
+    ///   - baseURL: API base URL (override for tests).
+    ///   - timeout: Request timeout in seconds.
+    public init(
+        networkClient: any NetworkClient = URLSession.shared,
+        settingsRepository: any OllamaSettingsRepository,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        baseURL: URL = OllamaUsageProbe.defaultBaseURL,
+        timeout: TimeInterval = 20
+    ) {
+        self.networkClient = networkClient
+        self.settingsRepository = settingsRepository
+        self.environment = environment
+        self.baseURL = baseURL
+        self.timeout = timeout
+    }
+
+    // MARK: - UsageProbe
+
+    public func isAvailable() async -> Bool {
+        resolveAPIKey() != nil
+    }
+
+    public func probe() async throws -> UsageSnapshot {
+        guard let apiKey = resolveAPIKey() else {
+            AppLog.probes.error("Ollama API: no API key resolvable (neither env var nor saved key)")
+            throw ProbeError.authenticationRequired
+        }
+
+        AppLog.probes.info("Starting Ollama API probe...")
+
+        let url = baseURL.appendingPathComponent("api/tags")
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = timeout
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("ClaudeBar/1.0", forHTTPHeaderField: "User-Agent")
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await networkClient.request(request)
+        } catch {
+            AppLog.probes.error("Ollama API request failed: \(error.localizedDescription)")
+            throw ProbeError.executionFailed("Ollama API request failed: \(error.localizedDescription)")
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ProbeError.executionFailed("Invalid HTTP response from Ollama API")
+        }
+
+        AppLog.probes.debug("Ollama API response status: \(httpResponse.statusCode)")
+
+        switch httpResponse.statusCode {
+        case 200:
+            return try Self.parseUsageResponse(data, providerId: "ollama")
+        case 401, 403:
+            AppLog.probes.error("Ollama API: authentication failed (\(httpResponse.statusCode))")
+            throw ProbeError.authenticationRequired
+        case 429:
+            AppLog.probes.error("Ollama API: rate limited (429)")
+            throw ProbeError.rateLimited(retryAt: Date().addingTimeInterval(60))
+        default:
+            let body = String(data: data, encoding: .utf8) ?? "<binary>"
+            AppLog.probes.error("Ollama API: HTTP \(httpResponse.statusCode) - \(body.prefix(200))")
+            throw ProbeError.executionFailed("Ollama API returned HTTP \(httpResponse.statusCode)")
+        }
+    }
+
+    // MARK: - API Key Resolution
+
+    /// Resolves the API key by checking, in order:
+    /// 1. The custom environment variable name in Settings (if any).
+    /// 2. The default env vars (`OLLAMA_API_KEY`, `OLLAMA_KEY`).
+    /// 3. The API key saved via the Settings UI.
+    private func resolveAPIKey() -> String? {
+        let customVar = settingsRepository.ollamaAuthEnvVar().trimmingCharacters(in: .whitespacesAndNewlines)
+        if !customVar.isEmpty, let value = cleaned(environment[customVar]) {
+            return value
+        }
+        for key in Self.apiKeyEnvironmentKeys {
+            if let value = cleaned(environment[key]) {
+                return value
+            }
+        }
+        return cleaned(settingsRepository.getOllamaApiKey())
+    }
+
+    private func cleaned(_ raw: String?) -> String? {
+        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else {
+            return nil
+        }
+        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
+            (value.hasPrefix("'") && value.hasSuffix("'")) {
+            value = String(value.dropFirst().dropLast())
+        }
+        return value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? nil
+            : value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    // MARK: - Response Parsing (static for testability)
+
+    /// Parses the Ollama `/api/tags` response into a `UsageSnapshot`.
+    ///
+    /// `/api/tags` does not return quota numbers, so the resulting snapshot
+    /// has an empty `quotas` array and a `loginMethod = "API key"` identity.
+    /// The UI surfaces this as "API account, no quota data" — exactly the
+    /// same shape we use for the Mistral provider, which also has no
+    /// quota endpoint.
+    ///
+    /// TODO: When Ollama publishes a real usage endpoint, decode session
+    /// (`primary`) and weekly (`secondary`) windows into `UsageQuota` values
+    /// and update the URL constant above accordingly.
+    public static func parseUsageResponse(_ data: Data, providerId: String) throws -> UsageSnapshot {
+        // Validate that the response is JSON shaped like the tags endpoint;
+        // anything else likely means we hit a login page or HTML error.
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw ProbeError.parseFailed("Ollama API: response is not JSON")
+        }
+
+        let modelCount = (json["models"] as? [Any])?.count ?? 0
+        AppLog.probes.info("Ollama API probe success: \(modelCount) models visible to this account")
+
+        return UsageSnapshot(
+            providerId: providerId,
+            quotas: [],
+            capturedAt: Date(),
+            loginMethod: "API key"
+        )
+    }
+}

--- a/Sources/Infrastructure/Ollama/OllamaWebUsageProbe.swift
+++ b/Sources/Infrastructure/Ollama/OllamaWebUsageProbe.swift
@@ -1,0 +1,297 @@
+import Foundation
+import SweetCookieKit
+import Domain
+
+// MARK: - Ollama Web (Cookie-scrape) Probe
+
+/// Probes the authenticated `ollama.com/settings` page using browser
+/// session cookies imported via SweetCookieKit.
+///
+/// This is the fallback path for users who only log in to ollama.com via
+/// the website and have not provisioned an API key. We grab the
+/// `next-auth.session-token` (and chunked variants) for `ollama.com`,
+/// fetch the rendered settings page, and pull session/weekly usage out of
+/// the embedded HTML.
+///
+/// The implementation is intentionally permissive about parse failures —
+/// Ollama's marketing page redesigns periodically, and if the markers go
+/// missing we still surface a snapshot showing "logged in via session
+/// cookie" so the user knows we found credentials.
+public struct OllamaWebUsageProbe: UsageProbe {
+    /// The set of cookie names recognised as session-auth cookies for
+    /// ollama.com. The list mirrors the recognised set used by CodexBar.
+    private static let recognisedCookieNames: Set<String> = [
+        "session",
+        "__Secure-session",
+        "ollama_session",
+        "__Host-ollama_session",
+        "__Secure-next-auth.session-token",
+        "next-auth.session-token",
+    ]
+
+    /// Domains we query for cookies.
+    private static let cookieDomains = [
+        "ollama.com",
+        "www.ollama.com",
+    ]
+
+    /// The URL we GET to retrieve the rendered usage HTML.
+    private static let settingsURL = URL(string: "https://ollama.com/settings")!
+
+    private let cookieClient: BrowserCookieClient
+    private let networkClient: any NetworkClient
+    private let timeout: TimeInterval
+
+    /// Creates an Ollama Web probe.
+    /// - Parameters:
+    ///   - cookieClient: SweetCookieKit client (defaults to a fresh instance).
+    ///   - networkClient: HTTP client (defaults to `URLSession.shared`).
+    ///   - timeout: Request timeout in seconds.
+    public init(
+        cookieClient: BrowserCookieClient = BrowserCookieClient(),
+        networkClient: any NetworkClient = URLSession.shared,
+        timeout: TimeInterval = 30
+    ) {
+        self.cookieClient = cookieClient
+        self.networkClient = networkClient
+        self.timeout = timeout
+    }
+
+    // MARK: - UsageProbe
+
+    public func isAvailable() async -> Bool {
+        resolveCookieHeader() != nil
+    }
+
+    public func probe() async throws -> UsageSnapshot {
+        guard let cookieHeader = resolveCookieHeader() else {
+            AppLog.probes.error("Ollama Web: no recognised session cookie found in any browser")
+            throw ProbeError.authenticationRequired
+        }
+
+        AppLog.probes.info("Starting Ollama Web probe...")
+
+        let html = try await fetchSettingsHTML(cookieHeader: cookieHeader)
+        return Self.parseSettingsHTML(html, providerId: "ollama", now: Date())
+    }
+
+    // MARK: - Cookie Resolution
+
+    /// Returns a `Cookie:` header string assembled from the first browser
+    /// that contains a recognised ollama.com session cookie, or nil.
+    private func resolveCookieHeader() -> String? {
+        let query = BrowserCookieQuery(
+            domains: Self.cookieDomains,
+            domainMatch: .suffix,
+            includeExpired: false
+        )
+
+        for browser in Browser.defaultImportOrder {
+            do {
+                let stores = try cookieClient.records(matching: query, in: browser)
+                for store in stores {
+                    let cookies = store.cookies(origin: query.origin)
+                    let matched = cookies.filter { Self.isRecognisedCookie($0.name) }
+                    guard !matched.isEmpty else { continue }
+                    AppLog.probes.debug("Ollama Web: found session cookies in \(browser)")
+                    return matched
+                        .map { "\($0.name)=\($0.value)" }
+                        .joined(separator: "; ")
+                }
+            } catch {
+                continue
+            }
+        }
+        AppLog.probes.debug("Ollama Web: no session cookies in any browser")
+        return nil
+    }
+
+    /// Whether `name` looks like an ollama.com session cookie, including
+    /// the next-auth chunked variants (`<name>.0`, `<name>.1`, ...).
+    private static func isRecognisedCookie(_ name: String) -> Bool {
+        if recognisedCookieNames.contains(name) { return true }
+        return name.hasPrefix("__Secure-next-auth.session-token.")
+            || name.hasPrefix("next-auth.session-token.")
+    }
+
+    // MARK: - HTTP
+
+    private func fetchSettingsHTML(cookieHeader: String) async throws -> String {
+        var request = URLRequest(url: Self.settingsURL)
+        request.httpMethod = "GET"
+        request.timeoutInterval = timeout
+        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        request.setValue(
+            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            forHTTPHeaderField: "Accept"
+        )
+        request.setValue("en-US,en;q=0.9", forHTTPHeaderField: "Accept-Language")
+        request.setValue("https://ollama.com", forHTTPHeaderField: "Origin")
+        request.setValue(Self.settingsURL.absoluteString, forHTTPHeaderField: "Referer")
+        request.setValue(
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                + "AppleWebKit/537.36 (KHTML, like Gecko) "
+                + "Chrome/143.0.0.0 Safari/537.36",
+            forHTTPHeaderField: "User-Agent"
+        )
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await networkClient.request(request)
+        } catch {
+            AppLog.probes.error("Ollama Web: HTTP error - \(error.localizedDescription)")
+            throw ProbeError.executionFailed("Ollama Web request failed: \(error.localizedDescription)")
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ProbeError.executionFailed("Invalid HTTP response from ollama.com")
+        }
+
+        AppLog.probes.debug("Ollama Web: status \(httpResponse.statusCode)")
+
+        switch httpResponse.statusCode {
+        case 200:
+            return String(data: data, encoding: .utf8) ?? ""
+        case 401, 403:
+            throw ProbeError.sessionExpired(
+                hint: "Re-authenticate at ollama.com in your browser."
+            )
+        default:
+            throw ProbeError.executionFailed("ollama.com returned HTTP \(httpResponse.statusCode)")
+        }
+    }
+
+    // MARK: - HTML Parsing (static for testability)
+
+    /// Parses the `ollama.com/settings` HTML into a `UsageSnapshot`.
+    ///
+    /// Pulls out plan name, account email, and the "Session usage" /
+    /// "Weekly usage" percent + reset markers. If a section is missing it
+    /// is simply omitted from the resulting snapshot — we never throw on
+    /// partial data, because the marketing page changes shape often
+    /// enough that we'd rather show something than nothing.
+    public static func parseSettingsHTML(
+        _ html: String,
+        providerId: String,
+        now: Date = Date()
+    ) -> UsageSnapshot {
+        let planName = parsePlanName(in: html)
+        let email = parseAccountEmail(in: html)
+        let session = parseUsageBlock(labels: ["Session usage", "Hourly usage"], in: html)
+        let weekly = parseUsageBlock(labels: ["Weekly usage"], in: html)
+
+        var quotas: [UsageQuota] = []
+        if let session {
+            quotas.append(UsageQuota(
+                percentRemaining: max(0, 100 - session.usedPercent),
+                quotaType: .session,
+                providerId: providerId,
+                resetsAt: session.resetsAt
+            ))
+        }
+        if let weekly {
+            quotas.append(UsageQuota(
+                percentRemaining: max(0, 100 - weekly.usedPercent),
+                quotaType: .weekly,
+                providerId: providerId,
+                resetsAt: weekly.resetsAt
+            ))
+        }
+
+        let tier: AccountTier? = planName.flatMap {
+            let trimmed = $0.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : .custom(trimmed.uppercased())
+        }
+
+        return UsageSnapshot(
+            providerId: providerId,
+            quotas: quotas,
+            capturedAt: now,
+            accountEmail: email,
+            loginMethod: "Session cookie",
+            accountTier: tier
+        )
+    }
+
+    // MARK: - Parser Helpers
+
+    private struct UsageBlock {
+        let usedPercent: Double
+        let resetsAt: Date?
+    }
+
+    private static func parsePlanName(in html: String) -> String? {
+        let pattern = #"Cloud Usage\s*</span>\s*<span[^>]*>([^<]+)</span>"#
+        return firstCapture(in: html, pattern: pattern, options: [.dotMatchesLineSeparators])
+    }
+
+    private static func parseAccountEmail(in html: String) -> String? {
+        let pattern = #"id=\"header-email\"[^>]*>([^<]+)<"#
+        guard let raw = firstCapture(in: html, pattern: pattern, options: [.dotMatchesLineSeparators]) else {
+            return nil
+        }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.contains("@") ? trimmed : nil
+    }
+
+    private static func parseUsageBlock(labels: [String], in html: String) -> UsageBlock? {
+        for label in labels {
+            if let block = parseUsageBlock(label: label, in: html) {
+                return block
+            }
+        }
+        return nil
+    }
+
+    private static func parseUsageBlock(label: String, in html: String) -> UsageBlock? {
+        guard let labelRange = html.range(of: label) else { return nil }
+        let tail = String(html[labelRange.upperBound...])
+        let window = String(tail.prefix(800))
+        guard let usedPercent = parsePercent(in: window) else { return nil }
+        return UsageBlock(usedPercent: usedPercent, resetsAt: parseISODate(in: window))
+    }
+
+    private static func parsePercent(in text: String) -> Double? {
+        let usedPattern = #"([0-9]+(?:\.[0-9]+)?)\s*%\s*used"#
+        if let raw = firstCapture(in: text, pattern: usedPattern, options: [.caseInsensitive]),
+           let value = Double(raw) {
+            return value
+        }
+        let widthPattern = #"width:\s*([0-9]+(?:\.[0-9]+)?)%"#
+        if let raw = firstCapture(in: text, pattern: widthPattern, options: [.caseInsensitive]),
+           let value = Double(raw) {
+            return value
+        }
+        return nil
+    }
+
+    private static func parseISODate(in text: String) -> Date? {
+        let pattern = #"data-time=\"([^\"]+)\""#
+        guard let raw = firstCapture(in: text, pattern: pattern, options: []) else { return nil }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: raw) {
+            return date
+        }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: raw)
+    }
+
+    private static func firstCapture(
+        in text: String,
+        pattern: String,
+        options: NSRegularExpression.Options
+    ) -> String? {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: options) else {
+            return nil
+        }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        guard let match = regex.firstMatch(in: text, options: [], range: range),
+              match.numberOfRanges > 1,
+              let captureRange = Range(match.range(at: 1), in: text) else {
+            return nil
+        }
+        return String(text[captureRange])
+    }
+}

--- a/Sources/Infrastructure/Storage/JSONSettingsRepository.swift
+++ b/Sources/Infrastructure/Storage/JSONSettingsRepository.swift
@@ -17,6 +17,7 @@ public final class JSONSettingsRepository:
     KimiSettingsRepository,
     MiniMaxSettingsRepository,
     AlibabaSettingsRepository,
+    OllamaSettingsRepository,
     HookSettingsRepository,
     @unchecked Sendable
 {
@@ -491,5 +492,45 @@ public final class JSONSettingsRepository:
 
     public func hasMinimaxApiKey() -> Bool {
         getMinimaxApiKey() != nil
+    }
+
+    // MARK: - OllamaSettingsRepository
+
+    public func ollamaProbeMode() -> OllamaProbeMode {
+        guard let raw: String = store.read(key: "ollama.probeMode"),
+              let mode = OllamaProbeMode(rawValue: raw) else {
+            return .api
+        }
+        return mode
+    }
+
+    public func setOllamaProbeMode(_ mode: OllamaProbeMode) {
+        store.write(value: mode.rawValue, key: "ollama.probeMode")
+    }
+
+    public func ollamaAuthEnvVar() -> String {
+        store.read(key: "ollama.authEnvVar") ?? ""
+    }
+
+    public func setOllamaAuthEnvVar(_ envVar: String) {
+        store.write(value: envVar, key: "ollama.authEnvVar")
+    }
+
+    // Ollama Credentials (UserDefaults for now, Keychain migration later)
+
+    public func saveOllamaApiKey(_ key: String) {
+        credentials.set(key, forKey: "com.claudebar.credentials.ollama-api-key")
+    }
+
+    public func getOllamaApiKey() -> String? {
+        credentials.string(forKey: "com.claudebar.credentials.ollama-api-key")
+    }
+
+    public func deleteOllamaApiKey() {
+        credentials.removeObject(forKey: "com.claudebar.credentials.ollama-api-key")
+    }
+
+    public func hasOllamaApiKey() -> Bool {
+        getOllamaApiKey() != nil
     }
 }

--- a/Sources/Infrastructure/Storage/UserDefaultsProviderSettingsRepository.swift
+++ b/Sources/Infrastructure/Storage/UserDefaultsProviderSettingsRepository.swift
@@ -3,7 +3,7 @@ import Domain
 
 /// UserDefaults-based implementation of ProviderSettingsRepository and its sub-protocols.
 /// Persists provider settings like isEnabled state and provider-specific configuration.
-public final class UserDefaultsProviderSettingsRepository: ZaiSettingsRepository, CopilotSettingsRepository, BedrockSettingsRepository, ClaudeSettingsRepository, CodexSettingsRepository, KimiSettingsRepository, MiniMaxSettingsRepository, AlibabaSettingsRepository, HookSettingsRepository, @unchecked Sendable {
+public final class UserDefaultsProviderSettingsRepository: ZaiSettingsRepository, CopilotSettingsRepository, BedrockSettingsRepository, ClaudeSettingsRepository, CodexSettingsRepository, KimiSettingsRepository, MiniMaxSettingsRepository, AlibabaSettingsRepository, OllamaSettingsRepository, HookSettingsRepository, @unchecked Sendable {
     /// Shared singleton instance
     public static let shared = UserDefaultsProviderSettingsRepository()
 
@@ -356,6 +356,43 @@ public final class UserDefaultsProviderSettingsRepository: ZaiSettingsRepository
         userDefaults.object(forKey: Keys.alibabaApiKey) != nil
     }
 
+    // MARK: - OllamaSettingsRepository
+
+    public func ollamaProbeMode() -> OllamaProbeMode {
+        guard let rawValue = userDefaults.string(forKey: Keys.ollamaProbeMode) else {
+            return .api // Default to API mode (more reliable than cookie scraping)
+        }
+        return OllamaProbeMode(rawValue: rawValue) ?? .api
+    }
+
+    public func setOllamaProbeMode(_ mode: OllamaProbeMode) {
+        userDefaults.set(mode.rawValue, forKey: Keys.ollamaProbeMode)
+    }
+
+    public func ollamaAuthEnvVar() -> String {
+        userDefaults.string(forKey: Keys.ollamaAuthEnvVar) ?? ""
+    }
+
+    public func setOllamaAuthEnvVar(_ envVar: String) {
+        userDefaults.set(envVar, forKey: Keys.ollamaAuthEnvVar)
+    }
+
+    public func saveOllamaApiKey(_ key: String) {
+        userDefaults.set(key, forKey: Keys.ollamaApiKey)
+    }
+
+    public func getOllamaApiKey() -> String? {
+        userDefaults.string(forKey: Keys.ollamaApiKey)
+    }
+
+    public func deleteOllamaApiKey() {
+        userDefaults.removeObject(forKey: Keys.ollamaApiKey)
+    }
+
+    public func hasOllamaApiKey() -> Bool {
+        userDefaults.object(forKey: Keys.ollamaApiKey) != nil
+    }
+
     // MARK: - HookSettingsRepository
 
     public func isHookEnabled() -> Bool {
@@ -415,6 +452,10 @@ public final class UserDefaultsProviderSettingsRepository: ZaiSettingsRepository
         static let alibabaCookieSource = "providerConfig.alibabaCookieSource"
         static let alibabaManualCookie = "com.claudebar.credentials.alibaba-manual-cookie"
         static let alibabaApiKey = "com.claudebar.credentials.alibaba-api-key"
+        // Ollama settings
+        static let ollamaProbeMode = "providerConfig.ollamaProbeMode"
+        static let ollamaAuthEnvVar = "providerConfig.ollamaAuthEnvVar"
+        static let ollamaApiKey = "com.claudebar.credentials.ollama-api-key"
         // Credentials (kept compatible with old UserDefaultsCredentialRepository keys)
         static let githubToken = "com.claudebar.credentials.github-copilot-token"
         static let githubUsername = "com.claudebar.credentials.github-username"


### PR DESCRIPTION
## Summary

Adds a new `OllamaProvider` to ClaudeBar that tracks usage quotas for the [Ollama Cloud / Pro](https://ollama.com) subscription. Closes a gap for users who pay for Ollama Pro alongside Claude / Codex / Gemini and want it surfaced in the same menu bar instead of a separate app.

Follows the **dual-probe pattern** that `KimiProvider` already uses (API mode + Web mode, user-switchable in Settings), and reuses the existing `SweetCookieKit` dependency — no new external packages.

## What's new

- **New provider: Ollama** (`ollama`), graphite/black gradient branding, dashboard link to <https://ollama.com/settings>.
- **API mode (default)** — Bearer-token auth against `https://ollama.com/api/tags`. Resolves the key from a user-configured env-var name, then `OLLAMA_API_KEY` / `OLLAMA_KEY`, then a value stored in Settings.
- **Web mode** — cookie-based scraping of `ollama.com/settings` via SweetCookieKit. Recognises `__Secure-next-auth.session-token` plus chunked variants and the older `session` / `ollama_session` cookie names. Parses session + weekly usage percent and reset times out of the rendered HTML.
- **Settings UI** — new `OllamaConfigCard` with a probe-mode segmented picker, secure API-key field with show/hide, env-var name override, lookup-order legend, and a Save & Test button.

## Files

| Layer | File | Purpose |
|---|---|---|
| Domain | `Sources/Domain/Provider/Ollama/OllamaProvider.swift` | `@Observable AIProvider`, dual-probe shape |
| Domain | `Sources/Domain/Provider/Ollama/OllamaProbeMode.swift` | `.api` / `.web` enum, mirrors `KimiProbeMode` |
| Infra | `Sources/Infrastructure/Ollama/OllamaUsageProbe.swift` | Bearer-token API probe |
| Infra | `Sources/Infrastructure/Ollama/OllamaWebUsageProbe.swift` | Cookie-scraping web probe |
| App | `Sources/App/Views/Settings/OllamaConfigCard.swift` | Settings card |

Wiring touches (matching the conventions other providers already use): `ProviderSettingsRepository`, the JSON and UserDefaults repositories, `AppSettings`, `ClaudeBarApp` DI list, `ProviderVisualIdentity`, `ProviderIcons`, `SettingsView`.

## Reference

Endpoints, cookie names, and parser markers were derived from the working Ollama support in [steipete/CodexBar](https://github.com/steipete/CodexBar/tree/main/Sources/CodexBarCore/Providers/Ollama) (MIT). No code copied verbatim — structure adapted to ClaudeBar's Domain / Infrastructure / App architecture.

## Known limitations (documented inline)

1. **No public Ollama usage-JSON endpoint at the time of writing.** The API probe currently uses `/api/tags` as a connectivity check and returns a connectivity-only snapshot (same shape used by Mistral). When Ollama publishes a real usage endpoint, the URL and `parseUsageResponse(_:)` in `OllamaUsageProbe.swift` need updating — there is a clearly marked TODO. The Web probe already returns full session + weekly quotas today.
2. **No asset catalog logo.** `ProviderIconView` falls back to `cloud.fill` SF Symbol over the graphite gradient until someone drops in a proper Ollama logo asset.
3. **Defaults to disabled** — matches CodexBar's `defaultEnabled: false` for the same provider.

## Build / verification

- ✅ `Domain` target: clean build
- ✅ `Infrastructure` target: clean build
- ⚠️ Full `ClaudeBar` workspace build currently fails on `InternalAWSCognitoIdentity/CognitoIdentityClient.swift` with a Cognito generic-inference error inside the upstream `aws-sdk-swift` package. **Pre-existing — unrelated to this PR.** Reproduces on `main` with no Ollama changes; appears to be a Swift 6 / aws-sdk-swift version interaction. Happy to investigate separately if useful.

Tested on **macOS 26.5 + Xcode 26.5** with Tuist 4.x.

## Test plan

- [ ] Enable Ollama in Settings with `OLLAMA_API_KEY` env var set → Ollama row appears in the menu with current snapshot
- [ ] Switch probe mode to Web with no env var, browser logged in to ollama.com → cookie fallback fetches session + weekly quotas
- [ ] With no auth available, provider reports `notLoggedIn` cleanly (no crash, no infinite spinner)
- [ ] `[Unreleased]` CHANGELOG entry added

---

First PR to this repo — happy to revise anything that doesn't match upstream conventions. Calling out my assumptions explicitly:

- Defaulted to **disabled** to match CodexBar; flip if you'd prefer it on for early testers.
- Used **`KimiProvider` shape** (dual probe + settings repo + UI card) rather than the simpler `CursorProvider` shape, because Ollama legitimately benefits from both API + Web auth and the Kimi precedent is already there.
- All new Settings repository keys namespaced under `ollama.*` — happy to rename if there's a preferred prefix convention.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ollama Cloud/Pro quota tracking with two probe modes: API key and session-cookie (web) monitoring.
  * New Ollama settings panel for choosing probe mode, entering/saving API credentials, environment-var support, and connection testing.
  * Integrated Ollama into provider list with visual identity (icon, color, theme) and quota monitoring support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tddworks/ClaudeBar/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->