### PR TITLE
feat(menubar): show both session and weekly quota at once

### DIFF
--- a/Sources/App/ClaudeBarApp.swift
+++ b/Sources/App/ClaudeBarApp.swift
@@ -146,40 +146,21 @@ struct ClaudeBarApp: App {
         return snapshot.overallStatus
     }
 
-    private var menuBarPercentageDisplay: MenuBarPercentageDisplay? {
-        guard settings.menuBarPercentageEnabled else { return nil }
-
-        return monitor.menuBarPercentageDisplay(
+    /// The composed menu bar label (percentage and/or duration, for one or two
+    /// quota windows). Driven by the user's independent menu-bar toggles and the
+    /// primary/secondary quota selection. Recomputed on every body evaluation so
+    /// the duration countdown stays current.
+    private var menuBarLabel: MenuBarLabel? {
+        monitor.menuBarLabel(
             providerId: settings.menuBarPercentageProviderId,
-            quotaKey: settings.menuBarPercentageQuotaKey,
+            primaryQuotaKey: settings.menuBarPercentageQuotaKey,
+            secondaryQuotaKey: settings.menuBarSecondaryQuotaKey,
+            showPercentage: settings.menuBarPercentageEnabled,
+            showDuration: settings.menuBarDurationEnabled,
             mode: settings.usageDisplayMode,
             burnRateWarningEnabled: settings.burnRateWarningEnabled,
             burnRateThreshold: settings.burnRateThreshold
         )
-    }
-
-    private var menuBarDurationDisplay: MenuBarDurationDisplay? {
-        guard settings.menuBarDurationEnabled else { return nil }
-
-        return monitor.menuBarDurationDisplay(
-            providerId: settings.menuBarPercentageProviderId,
-            quotaKey: settings.menuBarPercentageQuotaKey,
-            burnRateWarningEnabled: settings.burnRateWarningEnabled,
-            burnRateThreshold: settings.burnRateThreshold
-        )
-    }
-
-    private var menuBarLabelText: (text: String, status: QuotaStatus)? {
-        switch (menuBarPercentageDisplay, menuBarDurationDisplay) {
-        case let (.some(perc), .some(dur)):
-            return ("\(perc.text) · \(dur.text)", perc.status)
-        case let (.some(perc), .none):
-            return (perc.text, perc.status)
-        case let (.none, .some(dur)):
-            return (dur.text, dur.status)
-        case (.none, .none):
-            return nil
-        }
     }
 
     /// Current theme mode from settings
@@ -258,7 +239,7 @@ struct ClaudeBarApp: App {
             #endif
         } label: {
             // Show overall status + active session indicator in menu bar
-            if let label = menuBarLabelText {
+            if let label = menuBarLabel {
                 StatusBarPercentageLabel(
                     text: label.text,
                     status: label.status,

--- a/Sources/App/Settings/AppSettings.swift
+++ b/Sources/App/Settings/AppSettings.swift
@@ -72,6 +72,14 @@ public final class AppSettings {
         }
     }
 
+    /// Optional secondary quota key shown alongside the primary in the menu bar
+    /// (e.g. weekly next to session). Empty string means no secondary window.
+    public var menuBarSecondaryQuotaKey: String {
+        didSet {
+            repository.setMenuBarSecondaryQuotaKey(menuBarSecondaryQuotaKey)
+        }
+    }
+
     /// Whether to show daily usage report cards (API Cost, Token Usage, Working Time)
     public var showDailyUsageCards: Bool {
         didSet {
@@ -189,6 +197,7 @@ public final class AppSettings {
         self.menuBarDurationEnabled = repository.menuBarDurationEnabled()
         self.menuBarPercentageProviderId = repository.menuBarPercentageProviderId()
         self.menuBarPercentageQuotaKey = repository.menuBarPercentageQuotaKey()
+        self.menuBarSecondaryQuotaKey = repository.menuBarSecondaryQuotaKey()
 
         if let mode = UsageDisplayMode(rawValue: repository.usageDisplayMode()) {
             self.usageDisplayMode = mode

--- a/Sources/App/Views/SettingsView.swift
+++ b/Sources/App/Views/SettingsView.swift
@@ -375,6 +375,7 @@ struct SettingsContentView: View {
                             ) {
                                 settings.menuBarPercentageProviderId = provider.id
                                 selectFirstMenuBarQuotaIfNeeded(force: true)
+                                normalizeSecondaryMenuBarSelection()
                             }
                         }
                     }
@@ -412,6 +413,7 @@ struct SettingsContentView: View {
                                     isSelected: settings.menuBarPercentageQuotaKey == quota.quotaType.quotaKey
                                 ) {
                                     settings.menuBarPercentageQuotaKey = quota.quotaType.quotaKey
+                                    normalizeSecondaryMenuBarSelection()
                                 }
                             }
                         }
@@ -451,6 +453,7 @@ struct SettingsContentView: View {
         }
         .onAppear {
             normalizeMenuBarSelection()
+            normalizeSecondaryMenuBarSelection()
         }
     }
 
@@ -459,6 +462,16 @@ struct SettingsContentView: View {
     private var secondaryMenuBarQuotaOptions: [UsageQuota] {
         menuBarQuotaOptions.filter {
             $0.quotaType.quotaKey != settings.menuBarPercentageQuotaKey
+        }
+    }
+
+    /// Clears a stored secondary quota key that is no longer offered — e.g. after it
+    /// becomes equal to the primary, or the chosen provider's quotas no longer include it.
+    private func normalizeSecondaryMenuBarSelection() {
+        guard !settings.menuBarSecondaryQuotaKey.isEmpty else { return }
+        let validKeys = Set(secondaryMenuBarQuotaOptions.map(\.quotaType.quotaKey))
+        if !validKeys.contains(settings.menuBarSecondaryQuotaKey) {
+            settings.menuBarSecondaryQuotaKey = ""
         }
     }
 

--- a/Sources/App/Views/SettingsView.swift
+++ b/Sources/App/Views/SettingsView.swift
@@ -418,9 +418,47 @@ struct SettingsContentView: View {
                     }
                 }
             }
+
+            if menuBarQuotaOptions.count > 1 {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("SECONDARY QUOTA")
+                        .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
+                        .foregroundStyle(theme.textSecondary)
+                        .tracking(0.5)
+
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 8) {
+                            MenuBarChoiceButton(
+                                iconName: "minus.circle",
+                                label: "None",
+                                isSelected: settings.menuBarSecondaryQuotaKey.isEmpty
+                            ) {
+                                settings.menuBarSecondaryQuotaKey = ""
+                            }
+
+                            ForEach(secondaryMenuBarQuotaOptions, id: \.quotaType.quotaKey) { quota in
+                                MenuBarQuotaChoiceButton(
+                                    title: quota.quotaType.displayName,
+                                    isSelected: settings.menuBarSecondaryQuotaKey == quota.quotaType.quotaKey
+                                ) {
+                                    settings.menuBarSecondaryQuotaKey = quota.quotaType.quotaKey
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
         .onAppear {
             normalizeMenuBarSelection()
+        }
+    }
+
+    /// Quota options offered for the optional secondary menu bar window,
+    /// excluding the one already chosen as primary.
+    private var secondaryMenuBarQuotaOptions: [UsageQuota] {
+        menuBarQuotaOptions.filter {
+            $0.quotaType.quotaKey != settings.menuBarPercentageQuotaKey
         }
     }
 

--- a/Sources/Domain/Monitor/QuotaMonitor.swift
+++ b/Sources/Domain/Monitor/QuotaMonitor.swift
@@ -214,6 +214,80 @@ public final class QuotaMonitor: @unchecked Sendable {
         )
     }
 
+    /// Builds the fully composed menu bar label for one or two quota windows.
+    ///
+    /// The primary window renders exactly as the single-window label always has
+    /// (percentage and/or duration joined by " · "). When `secondaryQuotaKey` is
+    /// non-empty and differs from the primary, a second window is appended: each
+    /// window is prefixed with its `QuotaType.shortLabel` and the two are joined
+    /// by " | ", e.g. "5h 12% | 7d 34%". The status is the most severe of the
+    /// shown windows.
+    ///
+    /// Returns nil when neither percentage nor duration is enabled, or when no
+    /// quota data is available for the requested windows.
+    public func menuBarLabel(
+        providerId: String,
+        primaryQuotaKey: String,
+        secondaryQuotaKey: String = "",
+        showPercentage: Bool,
+        showDuration: Bool,
+        mode: UsageDisplayMode,
+        burnRateWarningEnabled: Bool = false,
+        burnRateThreshold: Double = 1.5
+    ) -> MenuBarLabel? {
+        func segment(forQuotaKey quotaKey: String) -> (text: String, status: QuotaStatus)? {
+            let percentage = showPercentage
+                ? menuBarPercentageDisplay(
+                    providerId: providerId,
+                    quotaKey: quotaKey,
+                    mode: mode,
+                    burnRateWarningEnabled: burnRateWarningEnabled,
+                    burnRateThreshold: burnRateThreshold
+                )
+                : nil
+            let duration = showDuration
+                ? menuBarDurationDisplay(
+                    providerId: providerId,
+                    quotaKey: quotaKey,
+                    burnRateWarningEnabled: burnRateWarningEnabled,
+                    burnRateThreshold: burnRateThreshold
+                )
+                : nil
+
+            switch (percentage, duration) {
+            case let (.some(percentage), .some(duration)):
+                return ("\(percentage.text) · \(duration.text)", percentage.status)
+            case let (.some(percentage), .none):
+                return (percentage.text, percentage.status)
+            case let (.none, .some(duration)):
+                return (duration.text, duration.status)
+            case (.none, .none):
+                return nil
+            }
+        }
+
+        let primary = segment(forQuotaKey: primaryQuotaKey)
+        let secondary = (!secondaryQuotaKey.isEmpty && secondaryQuotaKey != primaryQuotaKey)
+            ? segment(forQuotaKey: secondaryQuotaKey)
+            : nil
+
+        switch (primary, secondary) {
+        case let (.some(primary), .some(secondary)):
+            let primaryLabel = QuotaType(quotaKey: primaryQuotaKey)?.shortLabel ?? primaryQuotaKey
+            let secondaryLabel = QuotaType(quotaKey: secondaryQuotaKey)?.shortLabel ?? secondaryQuotaKey
+            return MenuBarLabel(
+                text: "\(primaryLabel) \(primary.text) | \(secondaryLabel) \(secondary.text)",
+                status: max(primary.status, secondary.status)
+            )
+        case let (.some(primary), .none):
+            return MenuBarLabel(text: primary.text, status: primary.status)
+        case let (.none, .some(secondary)):
+            return MenuBarLabel(text: secondary.text, status: secondary.status)
+        case (.none, .none):
+            return nil
+        }
+    }
+
     /// Returns the overall status across enabled providers (worst status wins)
     public var overallStatus: QuotaStatus {
         providers.enabled

--- a/Sources/Domain/Provider/MenuBarLabel.swift
+++ b/Sources/Domain/Provider/MenuBarLabel.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// A fully composed menu bar label: the rendered text plus the worst-case
+/// status across all quota windows it represents.
+///
+/// Built by `QuotaMonitor.menuBarLabel(...)`. When two quota windows are shown
+/// together (e.g. session + weekly), each window is prefixed with its
+/// `QuotaType.shortLabel` so the numbers stay distinguishable, and the overall
+/// status is the most severe of the shown windows.
+public struct MenuBarLabel: Sendable, Equatable {
+    public let text: String
+    public let status: QuotaStatus
+
+    public init(text: String, status: QuotaStatus) {
+        self.text = text
+        self.status = status
+    }
+}

--- a/Sources/Domain/Provider/QuotaType.swift
+++ b/Sources/Domain/Provider/QuotaType.swift
@@ -26,6 +26,21 @@ public enum QuotaType: Sendable, Equatable, Hashable {
         }
     }
 
+    /// Compact label used when several quota windows share the menu bar
+    /// (e.g. "5h" + "7d"). Terser than `displayName` to conserve menu bar width.
+    public var shortLabel: String {
+        switch self {
+        case .session:
+            "5h"
+        case .weekly:
+            "7d"
+        case .modelSpecific(let modelName):
+            modelName.capitalized
+        case .timeLimit(let name):
+            name.capitalized
+        }
+    }
+
     /// Stable key used for persisted quota selection.
     public var quotaKey: String {
         switch self {

--- a/Sources/Domain/Settings/AppSettingsRepository.swift
+++ b/Sources/Domain/Settings/AppSettingsRepository.swift
@@ -33,6 +33,9 @@ public protocol AppSettingsRepository: Sendable {
     func menuBarPercentageQuotaKey() -> String
     func setMenuBarPercentageQuotaKey(_ quotaKey: String)
 
+    func menuBarSecondaryQuotaKey() -> String
+    func setMenuBarSecondaryQuotaKey(_ quotaKey: String)
+
     func showDailyUsageCards() -> Bool
     func setShowDailyUsageCards(_ show: Bool)
 

--- a/Sources/Infrastructure/Storage/JSONSettingsRepository.swift
+++ b/Sources/Infrastructure/Storage/JSONSettingsRepository.swift
@@ -89,6 +89,14 @@ public final class JSONSettingsRepository:
         store.write(value: quotaKey, key: "app.menuBarPercentageQuotaKey")
     }
 
+    public func menuBarSecondaryQuotaKey() -> String {
+        store.read(key: "app.menuBarSecondaryQuotaKey") ?? ""
+    }
+
+    public func setMenuBarSecondaryQuotaKey(_ quotaKey: String) {
+        store.write(value: quotaKey, key: "app.menuBarSecondaryQuotaKey")
+    }
+
     public func showDailyUsageCards() -> Bool {
         store.read(key: "app.showDailyUsageCards") ?? true
     }

--- a/Tests/DomainTests/Monitor/QuotaMonitorTests.swift
+++ b/Tests/DomainTests/Monitor/QuotaMonitorTests.swift
@@ -214,6 +214,134 @@ struct QuotaMonitorTests {
         #expect(display == nil)
     }
 
+    // MARK: - Menu Bar Label (single + dual window)
+
+    /// Builds a Claude-only monitor, refreshed once with the given quotas.
+    private func makeRefreshedClaudeMonitor(quotas: [UsageQuota]) async -> QuotaMonitor {
+        let settings = makeSettingsRepository()
+        let probe = MockUsageProbe()
+        given(probe).isAvailable().willReturn(true)
+        given(probe).probe().willReturn(UsageSnapshot(
+            providerId: "claude",
+            quotas: quotas,
+            capturedAt: Date()
+        ))
+        let provider = ClaudeProvider(probe: probe, settingsRepository: settings)
+        let monitor = makeMonitor(providers: AIProviders(providers: [provider]))
+        await monitor.refresh(providerId: "claude")
+        return monitor
+    }
+
+    @Test
+    func `menu bar label shows single window with no prefix when secondary empty`() async {
+        // Given
+        let monitor = await makeRefreshedClaudeMonitor(quotas: [
+            UsageQuota(percentRemaining: 75, quotaType: .session, providerId: "claude"),
+            UsageQuota(percentRemaining: 35, quotaType: .weekly, providerId: "claude"),
+        ])
+
+        // When
+        let label = monitor.menuBarLabel(
+            providerId: "claude",
+            primaryQuotaKey: "session",
+            secondaryQuotaKey: "",
+            showPercentage: true,
+            showDuration: false,
+            mode: .remaining
+        )
+
+        // Then — unchanged single-window output
+        #expect(label?.text == "75%")
+        #expect(label?.status == .healthy)
+    }
+
+    @Test
+    func `menu bar label shows both windows prefixed by short label`() async {
+        // Given — session 75% (healthy), weekly 35% (warning)
+        let monitor = await makeRefreshedClaudeMonitor(quotas: [
+            UsageQuota(percentRemaining: 75, quotaType: .session, providerId: "claude"),
+            UsageQuota(percentRemaining: 35, quotaType: .weekly, providerId: "claude"),
+        ])
+
+        // When
+        let label = monitor.menuBarLabel(
+            providerId: "claude",
+            primaryQuotaKey: "session",
+            secondaryQuotaKey: "weekly",
+            showPercentage: true,
+            showDuration: false,
+            mode: .remaining
+        )
+
+        // Then — both windows, prefixed, worst status (warning) wins
+        #expect(label?.text == "5h 75% | 7d 35%")
+        #expect(label?.status == .warning)
+    }
+
+    @Test
+    func `menu bar label ignores secondary equal to primary`() async {
+        // Given
+        let monitor = await makeRefreshedClaudeMonitor(quotas: [
+            UsageQuota(percentRemaining: 75, quotaType: .session, providerId: "claude"),
+        ])
+
+        // When — secondary same as primary
+        let label = monitor.menuBarLabel(
+            providerId: "claude",
+            primaryQuotaKey: "session",
+            secondaryQuotaKey: "session",
+            showPercentage: true,
+            showDuration: false,
+            mode: .remaining
+        )
+
+        // Then — deduped to a single unprefixed window
+        #expect(label?.text == "75%")
+    }
+
+    @Test
+    func `menu bar label falls back to single window when secondary quota missing`() async {
+        // Given — only session quota present, but weekly requested as secondary
+        let monitor = await makeRefreshedClaudeMonitor(quotas: [
+            UsageQuota(percentRemaining: 75, quotaType: .session, providerId: "claude"),
+        ])
+
+        // When
+        let label = monitor.menuBarLabel(
+            providerId: "claude",
+            primaryQuotaKey: "session",
+            secondaryQuotaKey: "weekly",
+            showPercentage: true,
+            showDuration: false,
+            mode: .remaining
+        )
+
+        // Then — no secondary data, primary shown alone without prefix
+        #expect(label?.text == "75%")
+    }
+
+    @Test
+    func `menu bar label is nil when neither percentage nor duration enabled`() async {
+        // Given
+        let monitor = await makeRefreshedClaudeMonitor(quotas: [
+            UsageQuota(percentRemaining: 75, quotaType: .session, providerId: "claude"),
+            UsageQuota(percentRemaining: 35, quotaType: .weekly, providerId: "claude"),
+        ])
+
+        // When
+        let label = monitor.menuBarLabel(
+            providerId: "claude",
+            primaryQuotaKey: "session",
+            secondaryQuotaKey: "weekly",
+            showPercentage: false,
+            showDuration: false,
+            mode: .remaining
+        )
+
+        // Then
+        #expect(label == nil)
+    }
+
     @Test
     func `monitor skips unavailable providers`() async {
         // Given

--- a/Tests/DomainTests/Provider/QuotaTypeTests.swift
+++ b/Tests/DomainTests/Provider/QuotaTypeTests.swift
@@ -36,6 +36,29 @@ struct QuotaTypeTests {
         #expect(QuotaType.timeLimit("daily limit").displayName == "Daily Limit")
     }
 
+    // MARK: - Short Label Tests
+
+    @Test
+    func `session quota has short label 5h`() {
+        #expect(QuotaType.session.shortLabel == "5h")
+    }
+
+    @Test
+    func `weekly quota has short label 7d`() {
+        #expect(QuotaType.weekly.shortLabel == "7d")
+    }
+
+    @Test
+    func `model specific quota short label capitalizes model name`() {
+        #expect(QuotaType.modelSpecific("opus").shortLabel == "Opus")
+        #expect(QuotaType.modelSpecific("sonnet").shortLabel == "Sonnet")
+    }
+
+    @Test
+    func `time limit quota short label capitalizes name`() {
+        #expect(QuotaType.timeLimit("monthly").shortLabel == "Monthly")
+    }
+
     // MARK: - Duration Tests
 
     @Test

--- a/Tests/InfrastructureTests/Settings/JSONSettingsRepositoryAppTests.swift
+++ b/Tests/InfrastructureTests/Settings/JSONSettingsRepositoryAppTests.swift
@@ -107,6 +107,23 @@ struct JSONSettingsRepositoryAppTests {
     }
 
     @Test
+    func `menuBarSecondaryQuotaKey defaults to empty`() {
+        let (repo, dir) = makeRepository()
+        defer { cleanup(dir) }
+
+        #expect(repo.menuBarSecondaryQuotaKey() == "")
+    }
+
+    @Test
+    func `setMenuBarSecondaryQuotaKey persists value`() {
+        let (repo, dir) = makeRepository()
+        defer { cleanup(dir) }
+
+        repo.setMenuBarSecondaryQuotaKey("weekly")
+        #expect(repo.menuBarSecondaryQuotaKey() == "weekly")
+    }
+
+    @Test
     func `menuBarDurationEnabled defaults to false`() {
         let (repo, dir) = makeRepository()
         defer { cleanup(dir) }

--- a/Tests/InfrastructureTests/Settings/JSONSettingsRepositoryAppTests.swift
+++ b/Tests/InfrastructureTests/Settings/JSONSettingsRepositoryAppTests.swift
@@ -116,11 +116,17 @@ struct JSONSettingsRepositoryAppTests {
 
     @Test
     func `setMenuBarSecondaryQuotaKey persists value`() {
-        let (repo, dir) = makeRepository()
-        defer { cleanup(dir) }
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claudebar-test-\(UUID().uuidString)")
+        let fileURL = tempDir.appendingPathComponent("settings.json")
+        defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        repo.setMenuBarSecondaryQuotaKey("weekly")
-        #expect(repo.menuBarSecondaryQuotaKey() == "weekly")
+        let store = JSONSettingsStore(fileURL: fileURL)
+        let repo1 = JSONSettingsRepository(store: store)
+        repo1.setMenuBarSecondaryQuotaKey("weekly")
+
+        let repo2 = JSONSettingsRepository(store: store)
+        #expect(repo2.menuBarSecondaryQuotaKey() == "weekly")
     }
 
     @Test


### PR DESCRIPTION
## What
Adds an optional **secondary quota window** to the menu bar, so you can see (e.g.) session **and** weekly usage at a glance — `5h 12% | 7d 34%` — instead of only one.

## Scope
**Provider-agnostic** — works for whichever provider is selected for the menu bar, using any of *that* provider's windows (session / weekly / model-specific / time-limit). Shown only when the selected provider exposes 2+ windows. Examples: Claude (session/weekly/Opus/Sonnet), Z.ai (session/weekly/MCP), Codex. (Verified end-to-end with Claude locally; other providers follow the same generic path.)

## Why
The menu bar currently shows a single window; power users often want two windows visible without opening the dropdown.

## How
- `QuotaType.shortLabel` — compact per-window tag (`5h` / `7d` / model name)
- `QuotaMonitor.menuBarLabel(...)` — composes one or two windows. The primary renders **exactly as before**; an optional secondary is appended with short-label prefixes and worst-status-wins color, deduped when it equals the primary.
- New `menuBarSecondaryQuotaKey` setting — **off by default, so existing users see no change** — persisted via `AppSettingsRepository` / JSON store.
- `SettingsView` gains a **"Secondary Quota"** picker (None + non-primary windows).

## Tests
`QuotaType.shortLabel`, settings round-trip, and `menuBarLabel` composition (single / dual / dedupe / missing-data / disabled). Built and green locally via Tuist on Xcode 26.5.

Follows the pattern from #189 (independent Show Duration toggle).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select an optional secondary quota to display alongside the primary quota in the menu bar; includes a “None” option and preserves selection across sessions.
  * Menu bar label now shows compact quota prefixes, combines primary/secondary segments, and reflects percentage/duration display choices and worst-case status.

* **Tests**
  * Added tests covering menu bar label rendering, short labels, secondary-when-primary handling, and settings persistence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tddworks/ClaudeBar/pull/199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->