### PR TITLE
feat(menubar): keep the menu-bar number fresh in the background

### DIFF
--- a/Sources/App/ClaudeBarApp.swift
+++ b/Sources/App/ClaudeBarApp.swift
@@ -199,6 +199,9 @@ struct ClaudeBarApp: App {
         let providerIds: [String]?
     }
 
+    /// The current `RefreshLoopKey` derived from settings + monitor state. The
+    /// scene `.task(id:)` observes this, so any change here (cadence toggled,
+    /// selected or menu-bar provider switched) tears down and restarts the loop.
     private var refreshLoopKey: RefreshLoopKey {
         let interval = settings.refreshInterval
         return RefreshLoopKey(
@@ -211,13 +214,16 @@ struct ClaudeBarApp: App {
     /// While the dropdown is closed we only need the menu-bar provider(s) fresh,
     /// so narrow the periodic refresh to the selected + configured menu-bar
     /// provider when a menu-bar readout is on; otherwise just the selected
-    /// provider. Keeps background work minimal for energy (issue #67).
+    /// provider. Disabled providers are dropped — their readouts never render,
+    /// so polling them would be wasted work. Keeps background work minimal for
+    /// energy (issue #67).
     private var backgroundRefreshProviderIds: [String]? {
         guard settings.menuBarPercentageEnabled || settings.menuBarDurationEnabled else { return nil }
+        let enabledProviderIds = Set(monitor.enabledProviders.map(\.id))
         return [
             monitor.selectedProviderId,
             settings.menuBarPercentageProviderId,
-        ]
+        ].filter { enabledProviderIds.contains($0) }
     }
 
     private func startHookServer() {

--- a/Sources/App/ClaudeBarApp.swift
+++ b/Sources/App/ClaudeBarApp.swift
@@ -187,6 +187,39 @@ struct ClaudeBarApp: App {
         ThemeMode(rawValue: settings.themeMode) ?? .system
     }
 
+    // MARK: - Background Refresh
+
+    /// Identity for the app-lifetime background-refresh loop. When any field
+    /// changes, the scene `.task(id:)` cancels the running loop and restarts it
+    /// with the new cadence/target — replacing the per-setting `.onChange`
+    /// restarts that used to live in `MenuContentView`.
+    private struct RefreshLoopKey: Hashable {
+        let isEnabled: Bool
+        let seconds: Int
+        let providerIds: [String]?
+    }
+
+    private var refreshLoopKey: RefreshLoopKey {
+        let interval = settings.refreshInterval
+        return RefreshLoopKey(
+            isEnabled: interval.isEnabled,
+            seconds: interval.seconds ?? 0,
+            providerIds: backgroundRefreshProviderIds
+        )
+    }
+
+    /// While the dropdown is closed we only need the menu-bar provider(s) fresh,
+    /// so narrow the periodic refresh to the selected + configured menu-bar
+    /// provider when a menu-bar readout is on; otherwise just the selected
+    /// provider. Keeps background work minimal for energy (issue #67).
+    private var backgroundRefreshProviderIds: [String]? {
+        guard settings.menuBarPercentageEnabled || settings.menuBarDurationEnabled else { return nil }
+        return [
+            monitor.selectedProviderId,
+            settings.menuBarPercentageProviderId,
+        ]
+    }
+
     private func startHookServer() {
         // Cancel any existing server task
         hookServerTask?.cancel()
@@ -257,17 +290,40 @@ struct ClaudeBarApp: App {
                 .appThemeProvider(themeModeId: settings.themeMode)
             #endif
         } label: {
-            // Show overall status + active session indicator in menu bar
-            if let label = menuBarLabelText {
-                StatusBarPercentageLabel(
-                    text: label.text,
-                    status: label.status,
-                    activeSession: sessionMonitor.activeSession
-                )
-                .appThemeProvider(themeModeId: settings.themeMode)
-            } else {
-                StatusBarIcon(status: effectiveSelectedProviderStatus, activeSession: sessionMonitor.activeSession)
+            // Show overall status + active session indicator in menu bar.
+            //
+            // The background-refresh loop is attached here, to the always-present
+            // menu-bar label, so it runs for the app's lifetime independent of
+            // whether the dropdown is open — keeping the at-a-glance number fresh
+            // while the popover is closed. `.task(id:)` restarts the loop when the
+            // cadence or target provider changes and SwiftUI tears it down on exit.
+            Group {
+                if let label = menuBarLabelText {
+                    StatusBarPercentageLabel(
+                        text: label.text,
+                        status: label.status,
+                        activeSession: sessionMonitor.activeSession
+                    )
                     .appThemeProvider(themeModeId: settings.themeMode)
+                } else {
+                    StatusBarIcon(status: effectiveSelectedProviderStatus, activeSession: sessionMonitor.activeSession)
+                        .appThemeProvider(themeModeId: settings.themeMode)
+                }
+            }
+            .task(id: refreshLoopKey) {
+                guard refreshLoopKey.isEnabled else {
+                    monitor.stopMonitoring()
+                    return
+                }
+                AppLog.monitor.info("Background refresh starting (interval: \(refreshLoopKey.seconds)s, providers: \(refreshLoopKey.providerIds?.joined(separator: ",") ?? "selected"))")
+                let stream = monitor.startMonitoring(
+                    interval: .seconds(refreshLoopKey.seconds),
+                    providerIds: refreshLoopKey.providerIds
+                )
+                for await _ in stream {
+                    // QuotaMonitor updates provider snapshots; the menu-bar label
+                    // re-renders from observable state — nothing to do per event.
+                }
             }
         }
         .menuBarExtraStyle(.window)

--- a/Sources/App/Settings/AppSettings.swift
+++ b/Sources/App/Settings/AppSettings.swift
@@ -104,6 +104,28 @@ public final class AppSettings {
         }
     }
 
+    /// The background-refresh cadence (Off / 1 / 5 / 15 min) as a single
+    /// picker-friendly value. Computed over the legacy `backgroundSyncEnabled`
+    /// + `backgroundSyncInterval` pair so `settings.json` stays backward
+    /// compatible — "Off" maps to `backgroundSyncEnabled == false`, the others
+    /// to enabled + 60/300/900s. Setting it persists both underlying keys.
+    public var refreshInterval: RefreshInterval {
+        get {
+            RefreshInterval.migrating(
+                enabled: backgroundSyncEnabled,
+                storedSeconds: backgroundSyncInterval
+            )
+        }
+        set {
+            // Set the interval before flipping enabled so anything observing the
+            // change sees the final cadence in a single pass.
+            if let seconds = newValue.seconds {
+                backgroundSyncInterval = TimeInterval(seconds)
+            }
+            backgroundSyncEnabled = newValue.isEnabled
+        }
+    }
+
     // MARK: - Claude API Budget Settings
 
     /// Whether Claude API budget tracking is enabled

--- a/Sources/App/Views/MenuContentView.swift
+++ b/Sources/App/Views/MenuContentView.swift
@@ -117,11 +117,6 @@ struct MenuContentView: View {
                 hasRequestedNotificationPermission = true
                 let granted = await quotaAlerter.requestPermission()
                 AppLog.notifications.info("Alert permission request result: \(granted ? "granted" : "denied")")
-
-                // Start background sync on first app launch (only once)
-                if settings.backgroundSyncEnabled && !monitor.isMonitoring {
-                    startBackgroundSync()
-                }
             }
 
             // Show header and tabs immediately
@@ -143,74 +138,14 @@ struct MenuContentView: View {
             #endif
         }
         .onChange(of: selectedProviderId) { _, newProviderId in
-            // Refresh when user switches provider
+            // Refresh immediately when the user switches provider while the
+            // dropdown is open. Periodic background refresh is owned by the
+            // app-lifetime loop in ClaudeBarApp, which restarts itself when the
+            // selected or menu-bar provider changes.
             Task {
                 await refresh(providerId: newProviderId)
             }
-            if settings.backgroundSyncEnabled && (settings.menuBarPercentageEnabled || settings.menuBarDurationEnabled) {
-                restartBackgroundSync()
-            }
         }
-        .onChange(of: settings.backgroundSyncEnabled) { _, enabled in
-            // React to background sync toggle
-            if enabled {
-                startBackgroundSync()
-            } else {
-                stopBackgroundSync()
-            }
-        }
-        .onChange(of: settings.backgroundSyncInterval) { _, _ in
-            // Restart sync with new interval
-            if settings.backgroundSyncEnabled {
-                restartBackgroundSync()
-            }
-        }
-        .onChange(of: settings.menuBarPercentageEnabled) { _, _ in
-            if settings.backgroundSyncEnabled {
-                restartBackgroundSync()
-            }
-        }
-        .onChange(of: settings.menuBarDurationEnabled) { _, _ in
-            if settings.backgroundSyncEnabled {
-                restartBackgroundSync()
-            }
-        }
-        .onChange(of: settings.menuBarPercentageProviderId) { _, _ in
-            if settings.backgroundSyncEnabled && (settings.menuBarPercentageEnabled || settings.menuBarDurationEnabled) {
-                restartBackgroundSync()
-            }
-        }
-    }
-
-    // MARK: - Background Sync Control
-
-    private func startBackgroundSync() {
-        let interval = Duration.seconds(settings.backgroundSyncInterval)
-        AppLog.monitor.info("Starting background sync (interval: \(settings.backgroundSyncInterval)s)")
-        Task {
-            let stream = monitor.startMonitoring(interval: interval, providerIds: backgroundSyncProviderIds)
-            for await _ in stream {
-                // Events handled internally by QuotaMonitor
-            }
-        }
-    }
-
-    private var backgroundSyncProviderIds: [String]? {
-        guard settings.menuBarPercentageEnabled || settings.menuBarDurationEnabled else { return nil }
-        return [
-            selectedProviderId,
-            settings.menuBarPercentageProviderId,
-        ]
-    }
-
-    private func stopBackgroundSync() {
-        AppLog.monitor.info("Stopping background sync")
-        monitor.stopMonitoring()
-    }
-
-    private func restartBackgroundSync() {
-        stopBackgroundSync()
-        startBackgroundSync()
     }
 
     // MARK: - Background Orbs

--- a/Sources/App/Views/SettingsView.swift
+++ b/Sources/App/Views/SettingsView.swift
@@ -1053,26 +1053,23 @@ struct SettingsContentView: View {
 
             VStack(alignment: .leading, spacing: 14) {
                 VStack(alignment: .leading, spacing: 6) {
-                    Text("SYNC INTERVAL")
+                    Text("REFRESH INTERVAL")
                         .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
                         .foregroundStyle(theme.textSecondary)
                         .tracking(0.5)
 
-                    Picker("", selection: $settings.backgroundSyncInterval) {
-                        Text("30 seconds").tag(30.0)
-                        Text("1 minute").tag(60.0)
-                        Text("2 minutes").tag(120.0)
-                        Text("5 minutes").tag(300.0)
+                    Picker("", selection: $settings.refreshInterval) {
+                        ForEach(RefreshInterval.allCases, id: \.self) { interval in
+                            Text(interval.label).tag(interval)
+                        }
                     }
                     .pickerStyle(.segmented)
-                    .disabled(!settings.backgroundSyncEnabled)
                 }
 
-                Text("Sync usage data in the background so it's always fresh when you check.")
+                Text("Keep the menu-bar number fresh in the background. \"Off\" updates only when you open the menu. Never refreshes faster than once a minute.")
                     .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
                     .foregroundStyle(theme.textTertiary)
             }
-            .opacity(settings.backgroundSyncEnabled ? 1 : 0.6)
         } label: {
             backgroundSyncHeader
                 .contentShape(.rect)
@@ -1126,11 +1123,11 @@ struct SettingsContentView: View {
 
             Spacer()
 
-            Toggle("", isOn: $settings.backgroundSyncEnabled)
-                .toggleStyle(.switch)
-                .tint(theme.accentPrimary)
-                .scaleEffect(0.8)
-                .labelsHidden()
+            // The on/off control now lives in the picker's "Off" case; show the
+            // current cadence here so it's visible while the card is collapsed.
+            Text(settings.refreshInterval.label)
+                .font(.system(size: 11, weight: .semibold, design: theme.fontDesign))
+                .foregroundStyle(theme.textSecondary)
         }
     }
 

--- a/Sources/Domain/Monitor/QuotaMonitor.swift
+++ b/Sources/Domain/Monitor/QuotaMonitor.swift
@@ -12,8 +12,15 @@ public enum MonitoringEvent: Sendable {
 /// The main domain service that coordinates quota monitoring across AI providers.
 /// Providers are rich domain models that own their own snapshots.
 /// QuotaMonitor coordinates refreshes and alerts users when status changes.
+///
+/// Isolated to `@MainActor` because its `@Observable` state (`isMonitoring`,
+/// `selectedProviderId`, …) is consumed by SwiftUI. This keeps the background
+/// monitoring loop from mutating observable state off the main actor — the
+/// crash in issue #182 — and lets the compiler reject any future off-main
+/// mutation. Mirrors `SessionMonitor`, which is already `@MainActor @Observable`.
+@MainActor
 @Observable
-public final class QuotaMonitor: @unchecked Sendable {
+public final class QuotaMonitor {
     /// The providers repository (internal - access via delegation methods)
     private let providers: any AIProviderRepository
 
@@ -267,6 +274,16 @@ public final class QuotaMonitor: @unchecked Sendable {
 
     // MARK: - Continuous Monitoring
 
+    /// The hard lower bound on the monitoring interval. Background refresh must
+    /// never poll faster than once a minute (energy — issue #67).
+    public static let minimumInterval: Duration = .seconds(60)
+
+    /// Clamps a requested interval to the 1-minute floor. Exposed so the floor
+    /// can be unit-tested directly and so every caller funnels through one rule.
+    public static func clampedInterval(_ interval: Duration) -> Duration {
+        max(interval, minimumInterval)
+    }
+
     /// Refreshes only the currently selected provider.
     public func refreshSelected() async {
         await refresh(providerId: selectedProviderId)
@@ -275,6 +292,7 @@ public final class QuotaMonitor: @unchecked Sendable {
     /// Starts continuous monitoring at the specified interval.
     /// By default, refreshes the currently selected provider each cycle to minimize energy usage.
     /// When provider IDs are supplied, refreshes that de-duplicated provider set each cycle.
+    /// The interval is clamped to a 1-minute floor regardless of the value passed.
     /// Returns an AsyncStream of monitoring events.
     public func startMonitoring(
         interval: Duration = .seconds(60),
@@ -284,6 +302,10 @@ public final class QuotaMonitor: @unchecked Sendable {
         monitoringTask?.cancel()
 
         isMonitoring = true
+
+        // Enforce the 1-minute floor here too, so no caller or persisted value
+        // can drive a faster poll regardless of how startMonitoring is reached.
+        let effectiveInterval = Self.clampedInterval(interval)
 
         return AsyncStream { continuation in
             let task = Task {
@@ -296,7 +318,7 @@ public final class QuotaMonitor: @unchecked Sendable {
                     continuation.yield(.refreshed)
 
                     do {
-                        try await clock.sleep(for: interval)
+                        try await clock.sleep(for: effectiveInterval)
                     } catch {
                         break
                     }

--- a/Sources/Domain/Monitor/RefreshInterval.swift
+++ b/Sources/Domain/Monitor/RefreshInterval.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// The user-facing cadence for refreshing the menu-bar number in the background.
+///
+/// "Off" means no background refresh — the bar updates only when the dropdown
+/// opens (today's behaviour). The other cases map onto a 60 / 300 / 900-second
+/// poll. There is intentionally no sub-minute option: 1 minute is a hard floor
+/// to keep energy use low (issue #67).
+public enum RefreshInterval: String, Sendable, Equatable, CaseIterable {
+    case off
+    case oneMinute
+    case fiveMinutes
+    case fifteenMinutes
+
+    /// The poll interval in seconds, or `nil` when refresh is off.
+    public var seconds: Int? {
+        switch self {
+        case .off: nil
+        case .oneMinute: 60
+        case .fiveMinutes: 300
+        case .fifteenMinutes: 900
+        }
+    }
+
+    /// Whether background refresh runs for this option.
+    public var isEnabled: Bool { self != .off }
+
+    /// Short label for the settings picker.
+    public var label: String {
+        switch self {
+        case .off: "Off"
+        case .oneMinute: "1 min"
+        case .fiveMinutes: "5 min"
+        case .fifteenMinutes: "15 min"
+        }
+    }
+
+    /// Derives the option from the legacy settings pair (`backgroundSyncEnabled`
+    /// + `backgroundSyncInterval`), keeping `settings.json` backward compatible.
+    ///
+    /// Disabled → `.off`. Otherwise the stored seconds snap to the nearest
+    /// supported option and never below the 1-minute floor, so retired values
+    /// migrate cleanly: 30 → 1 min, 120 → 1 min, 300 → 5 min.
+    public static func migrating(enabled: Bool, storedSeconds: TimeInterval) -> RefreshInterval {
+        guard enabled else { return .off }
+        let options: [RefreshInterval] = [.oneMinute, .fiveMinutes, .fifteenMinutes]
+        return options.min { lhs, rhs in
+            abs(Double(lhs.seconds ?? 0) - storedSeconds) < abs(Double(rhs.seconds ?? 0) - storedSeconds)
+        } ?? .oneMinute
+    }
+}

--- a/Sources/Infrastructure/Extension/ExtensionRegistry.swift
+++ b/Sources/Infrastructure/Extension/ExtensionRegistry.swift
@@ -32,6 +32,9 @@ public final class ExtensionRegistry: Sendable {
 
     /// Scans for extensions and registers them with the monitor.
     /// Returns the list of registered extension providers.
+    /// `@MainActor` because `QuotaMonitor` is main-actor isolated; this runs once
+    /// during app init, which is already on the main actor.
+    @MainActor
     @discardableResult
     public func loadExtensions(into monitor: QuotaMonitor) -> [ExtensionProvider] {
         ensureDirectoryExists()

--- a/Tests/AcceptanceTests/ClaudeConfigSpec.swift
+++ b/Tests/AcceptanceTests/ClaudeConfigSpec.swift
@@ -24,6 +24,7 @@ struct ClaudeConfigSpec {
     // MARK: - #28: Switch Claude to API mode
 
     @Suite("Scenario: Switch probe mode")
+    @MainActor
     struct SwitchProbeMode {
         private struct TestClock: Clock {
             func sleep(for duration: Duration) async throws {}
@@ -218,6 +219,7 @@ struct ClaudeConfigSpec {
     // MARK: - #29: API mode credential status
 
     @Suite("Scenario: API mode credential availability")
+    @MainActor
     struct CredentialStatus {
 
         @Test
@@ -237,6 +239,7 @@ struct ClaudeConfigSpec {
     // MARK: - #30: Expired session error
 
     @Suite("Scenario: Expired session shows user-friendly error")
+    @MainActor
     struct SessionExpired {
         private struct TestClock: Clock {
             func sleep(for duration: Duration) async throws {}

--- a/Tests/AcceptanceTests/CodexConfigSpec.swift
+++ b/Tests/AcceptanceTests/CodexConfigSpec.swift
@@ -23,6 +23,7 @@ struct CodexConfigSpec {
     // MARK: - #33: Switch Codex to API mode
 
     @Suite("Scenario: Switch probe mode")
+    @MainActor
     struct SwitchProbeMode {
         private struct TestClock: Clock {
             func sleep(for duration: Duration) async throws {}
@@ -97,6 +98,7 @@ struct CodexConfigSpec {
     // MARK: - #34: API mode credential status
 
     @Suite("Scenario: API mode credential availability")
+    @MainActor
     struct CredentialStatus {
 
         @Test

--- a/Tests/AcceptanceTests/MenuBarSpec.swift
+++ b/Tests/AcceptanceTests/MenuBarSpec.swift
@@ -32,6 +32,7 @@ struct MenuBarSpec {
     // MARK: - #2: Overall status reflects worst provider
 
     @Suite("Scenario: Overall status calculation")
+    @MainActor
     struct OverallStatus {
         private struct TestClock: Clock {
             func sleep(for duration: Duration) async throws {}

--- a/Tests/AcceptanceTests/NotificationsSpec.swift
+++ b/Tests/AcceptanceTests/NotificationsSpec.swift
@@ -33,6 +33,7 @@ struct NotificationsSpec {
     // MARK: - #19–21: Quota degrades → notification sent
 
     @Suite("Scenario: Quota degrades")
+    @MainActor
     struct QuotaDegrades {
 
         private struct TestClock: Clock {
@@ -81,6 +82,7 @@ struct NotificationsSpec {
     // MARK: - #22: Quota stays the same → no notification
 
     @Suite("Scenario: Quota stays the same")
+    @MainActor
     struct QuotaUnchanged {
 
         private struct TestClock: Clock {
@@ -130,6 +132,7 @@ struct NotificationsSpec {
     // MARK: - Cross-behavior: One provider failure does not affect others
 
     @Suite("Scenario: Provider isolation")
+    @MainActor
     struct ProviderIsolation {
 
         private struct TestClock: Clock {

--- a/Tests/AcceptanceTests/ProviderEnableDisableSpec.swift
+++ b/Tests/AcceptanceTests/ProviderEnableDisableSpec.swift
@@ -32,6 +32,7 @@ struct ProviderEnableDisableSpec {
     // MARK: - #46: Disable provider excludes from monitoring
 
     @Suite("Scenario: Disable a provider")
+    @MainActor
     struct DisableProvider {
         private struct TestClock: Clock {
             func sleep(for duration: Duration) async throws {}
@@ -113,6 +114,7 @@ struct ProviderEnableDisableSpec {
     // MARK: - #47: Enable provider without changing selection
 
     @Suite("Scenario: Enable a provider")
+    @MainActor
     struct EnableProvider {
         private struct TestClock: Clock {
             func sleep(for duration: Duration) async throws {}
@@ -146,6 +148,7 @@ struct ProviderEnableDisableSpec {
     // MARK: - #48: Enabled state persists
 
     @Suite("Scenario: Enabled state persists across restarts")
+    @MainActor
     struct PersistEnabledState {
 
         @Test

--- a/Tests/AcceptanceTests/ProviderSelectionSpec.swift
+++ b/Tests/AcceptanceTests/ProviderSelectionSpec.swift
@@ -25,6 +25,7 @@ struct ProviderSelectionSpec {
     // MARK: - #4: Switch to a different provider
 
     @Suite("Scenario: Switch to a different provider")
+    @MainActor
     struct SwitchProvider {
         private struct TestClock: Clock {
             func sleep(for duration: Duration) async throws {}
@@ -83,6 +84,7 @@ struct ProviderSelectionSpec {
     // MARK: - #5: Only enabled providers appear as pills
 
     @Suite("Scenario: Only enabled providers appear as pills")
+    @MainActor
     struct EnabledProviders {
         private struct TestClock: Clock {
             func sleep(for duration: Duration) async throws {}
@@ -134,6 +136,7 @@ struct ProviderSelectionSpec {
     // MARK: - #6: Disabling the currently selected provider → auto-switches
 
     @Suite("Scenario: Disabling the currently selected provider")
+    @MainActor
     struct DisableSelectedProvider {
         private struct TestClock: Clock {
             func sleep(for duration: Duration) async throws {}
@@ -190,6 +193,7 @@ struct ProviderSelectionSpec {
     // MARK: - #7: Selecting a disabled provider is rejected
 
     @Suite("Scenario: Selecting a disabled provider")
+    @MainActor
     struct SelectDisabledProvider {
         private struct TestClock: Clock {
             func sleep(for duration: Duration) async throws {}

--- a/Tests/AcceptanceTests/QuotaDisplaySpec.swift
+++ b/Tests/AcceptanceTests/QuotaDisplaySpec.swift
@@ -26,6 +26,7 @@ struct QuotaDisplaySpec {
     // MARK: - #8: Account info card
 
     @Suite("Scenario: Account info displays after refresh")
+    @MainActor
     struct AccountInfo {
         private struct TestClock: Clock {
             func sleep(for duration: Duration) async throws {}
@@ -83,6 +84,7 @@ struct QuotaDisplaySpec {
     // MARK: - #9: Quota cards with percentage, status, reset time
 
     @Suite("Scenario: Quota cards display correctly after refresh")
+    @MainActor
     struct QuotaCards {
         private struct TestClock: Clock {
             func sleep(for duration: Duration) async throws {}
@@ -176,6 +178,7 @@ struct QuotaDisplaySpec {
     // MARK: - #10: Remaining vs Used display mode
 
     @Suite("Scenario: Toggle between Remaining and Used display")
+    @MainActor
     struct DisplayMode {
 
         @Test
@@ -207,6 +210,7 @@ struct QuotaDisplaySpec {
     // MARK: - #13: Unavailable provider shows error
 
     @Suite("Scenario: Unavailable provider shows error message")
+    @MainActor
     struct ProviderErrors {
         private struct TestClock: Clock {
             func sleep(for duration: Duration) async throws {}
@@ -268,6 +272,7 @@ struct QuotaDisplaySpec {
     // MARK: - #14: Over-quota negative percentages
 
     @Suite("Scenario: Over-quota displays negative percentages")
+    @MainActor
     struct OverQuota {
 
         @Test

--- a/Tests/AcceptanceTests/RefreshSpec.swift
+++ b/Tests/AcceptanceTests/RefreshSpec.swift
@@ -32,6 +32,7 @@ struct RefreshSpec {
     // MARK: - #15: Successful refresh
 
     @Suite("Scenario: Successful refresh")
+    @MainActor
     struct SuccessfulRefresh {
         private struct TestClock: Clock {
             func sleep(for duration: Duration) async throws {}
@@ -103,6 +104,7 @@ struct RefreshSpec {
     // MARK: - #18: Background sync
 
     @Suite("Scenario: Background sync")
+    @MainActor
     struct BackgroundSync {
         private struct TestClock: Clock {
             func sleep(for duration: Duration) async throws {}

--- a/Tests/DomainTests/Monitor/QuotaMonitorTests.swift
+++ b/Tests/DomainTests/Monitor/QuotaMonitorTests.swift
@@ -23,6 +23,9 @@ struct QuotaMonitorTests {
         private var continuation: CheckedContinuation<Void, Error>?
         private var cancelled = false
 
+        /// Parks the caller on a continuation that only resumes — throwing
+        /// `CancellationError` — once the surrounding task is cancelled, so the
+        /// monitoring loop suspends after one cycle instead of sleeping for real.
         func sleep(for duration: Duration) async throws {
             try await withTaskCancellationHandler {
                 try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
@@ -45,6 +48,7 @@ struct QuotaMonitorTests {
             }
         }
 
+        /// Bridges the legacy nanosecond API onto the cancellation-gated `sleep(for:)`.
         func sleep(nanoseconds: UInt64) async throws {
             try await sleep(for: .nanoseconds(Int64(nanoseconds)))
         }
@@ -625,6 +629,9 @@ struct QuotaMonitorTests {
         #expect(eventCount <= 2)
     }
 
+    /// #182 regression guard: monitoring flips `isMonitoring` on at start and
+    /// off at stop entirely on the main actor (this @MainActor suite would not
+    /// compile otherwise), so observable state is never mutated off-main.
     @Test
     func `startMonitoring keeps observable state on the main actor`() async {
         // Reading and writing isMonitoring here compiles only because both this
@@ -643,6 +650,8 @@ struct QuotaMonitorTests {
         #expect(monitor.isMonitoring == false)
     }
 
+    /// Sub-minute and zero intervals clamp up to the 1-minute floor, while
+    /// at- or above-floor intervals pass through unchanged (energy — #67).
     @Test
     func `clampedInterval enforces the one minute floor`() {
         #expect(QuotaMonitor.clampedInterval(.seconds(5)) == .seconds(60))

--- a/Tests/DomainTests/Monitor/QuotaMonitorTests.swift
+++ b/Tests/DomainTests/Monitor/QuotaMonitorTests.swift
@@ -5,21 +5,48 @@ import Mockable
 @testable import Infrastructure
 
 @Suite
+@MainActor
 struct QuotaMonitorTests {
     private struct TestClock: Clock {
         func sleep(for duration: Duration) async throws {}
         func sleep(nanoseconds: UInt64) async throws {}
     }
 
-    private struct SuspendingClock: Clock {
+    /// A clock whose `sleep` suspends until the surrounding task is cancelled,
+    /// rather than waiting real wall-clock time. The monitoring loop runs exactly
+    /// one cycle and then parks here; `stopMonitoring()` (or stream termination)
+    /// cancels the loop's task, resuming this with a `CancellationError` so the
+    /// loop ends at once. Replacing the old real `Task.sleep(60s)` removes the
+    /// timing race that made the continuous-monitoring tests flake under load.
+    private final class SuspendingClock: Clock, @unchecked Sendable {
+        private let lock = NSLock()
+        private var continuation: CheckedContinuation<Void, Error>?
+        private var cancelled = false
+
         func sleep(for duration: Duration) async throws {
-            // Keep the monitoring loop suspended after its first tick; stopMonitoring()
-            // cancels the task and interrupts this long sleep before the test waits.
-            try await Task.sleep(nanoseconds: 60_000_000_000)
+            try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+                    lock.lock()
+                    if cancelled {
+                        lock.unlock()
+                        cont.resume(throwing: CancellationError())
+                    } else {
+                        continuation = cont
+                        lock.unlock()
+                    }
+                }
+            } onCancel: {
+                lock.lock()
+                cancelled = true
+                let cont = continuation
+                continuation = nil
+                lock.unlock()
+                cont?.resume(throwing: CancellationError())
+            }
         }
 
         func sleep(nanoseconds: UInt64) async throws {
-            try await Task.sleep(nanoseconds: nanoseconds)
+            try await sleep(for: .nanoseconds(Int64(nanoseconds)))
         }
     }
 
@@ -596,6 +623,33 @@ struct QuotaMonitorTests {
 
         // Then - Stream should finish quickly after stop
         #expect(eventCount <= 2)
+    }
+
+    @Test
+    func `startMonitoring keeps observable state on the main actor`() async {
+        // Reading and writing isMonitoring here compiles only because both this
+        // suite and QuotaMonitor are @MainActor — the structural guard against
+        // the #182 off-main mutation. The flow asserts the flag flips on, then off.
+        let settings = makeSettingsRepository()
+        let provider = ClaudeProvider(probe: CountingUsageProbe(providerId: "claude"), settingsRepository: settings)
+        let monitor = makeSuspendingMonitor(providers: AIProviders(providers: [provider]))
+
+        let stream = monitor.startMonitoring(interval: .seconds(60))
+        #expect(monitor.isMonitoring == true)
+
+        for await _ in stream.prefix(1) {}
+        monitor.stopMonitoring()
+
+        #expect(monitor.isMonitoring == false)
+    }
+
+    @Test
+    func `clampedInterval enforces the one minute floor`() {
+        #expect(QuotaMonitor.clampedInterval(.seconds(5)) == .seconds(60))
+        #expect(QuotaMonitor.clampedInterval(.zero) == .seconds(60))
+        #expect(QuotaMonitor.clampedInterval(.seconds(60)) == .seconds(60))
+        #expect(QuotaMonitor.clampedInterval(.seconds(300)) == .seconds(300))
+        #expect(QuotaMonitor.clampedInterval(.seconds(900)) == .seconds(900))
     }
 
     // MARK: - Provider Collections

--- a/Tests/DomainTests/Monitor/RefreshIntervalTests.swift
+++ b/Tests/DomainTests/Monitor/RefreshIntervalTests.swift
@@ -4,6 +4,7 @@ import Foundation
 
 @Suite
 struct RefreshIntervalTests {
+    /// Each cadence exposes its poll interval in seconds, and `.off` has none.
     @Test
     func `seconds maps each option onto its poll interval`() {
         #expect(RefreshInterval.off.seconds == nil)
@@ -12,6 +13,7 @@ struct RefreshIntervalTests {
         #expect(RefreshInterval.fifteenMinutes.seconds == 900)
     }
 
+    /// Only `.off` disables background refresh; every timed option enables it.
     @Test
     func `isEnabled is false only for off`() {
         #expect(RefreshInterval.off.isEnabled == false)
@@ -20,6 +22,7 @@ struct RefreshIntervalTests {
         #expect(RefreshInterval.fifteenMinutes.isEnabled == true)
     }
 
+    /// Each option's picker label matches the exact copy shown in Settings.
     @Test
     func `label matches the picker copy`() {
         #expect(RefreshInterval.off.label == "Off")
@@ -28,12 +31,16 @@ struct RefreshIntervalTests {
         #expect(RefreshInterval.fifteenMinutes.label == "15 min")
     }
 
+    /// A disabled legacy `backgroundSyncEnabled` flag migrates to `.off`
+    /// regardless of the stored interval.
     @Test
     func `migrating returns off when background sync is disabled`() {
         #expect(RefreshInterval.migrating(enabled: false, storedSeconds: 60) == .off)
         #expect(RefreshInterval.migrating(enabled: false, storedSeconds: 900) == .off)
     }
 
+    /// An enabled legacy interval snaps to the nearest supported option, with
+    /// retired and below-floor values rounding up to the 1-minute floor.
     @Test
     func `migrating snaps a stored interval to the nearest supported option`() {
         // Retired 30s / 2m options and below-floor values snap up to 1 minute.
@@ -44,6 +51,7 @@ struct RefreshIntervalTests {
         #expect(RefreshInterval.migrating(enabled: true, storedSeconds: 900) == .fifteenMinutes)
     }
 
+    /// `allCases` is ordered exactly as the segmented picker renders the options.
     @Test
     func `allCases lists the options in picker order`() {
         #expect(RefreshInterval.allCases == [.off, .oneMinute, .fiveMinutes, .fifteenMinutes])

--- a/Tests/DomainTests/Monitor/RefreshIntervalTests.swift
+++ b/Tests/DomainTests/Monitor/RefreshIntervalTests.swift
@@ -1,0 +1,51 @@
+import Testing
+import Foundation
+@testable import Domain
+
+@Suite
+struct RefreshIntervalTests {
+    @Test
+    func `seconds maps each option onto its poll interval`() {
+        #expect(RefreshInterval.off.seconds == nil)
+        #expect(RefreshInterval.oneMinute.seconds == 60)
+        #expect(RefreshInterval.fiveMinutes.seconds == 300)
+        #expect(RefreshInterval.fifteenMinutes.seconds == 900)
+    }
+
+    @Test
+    func `isEnabled is false only for off`() {
+        #expect(RefreshInterval.off.isEnabled == false)
+        #expect(RefreshInterval.oneMinute.isEnabled == true)
+        #expect(RefreshInterval.fiveMinutes.isEnabled == true)
+        #expect(RefreshInterval.fifteenMinutes.isEnabled == true)
+    }
+
+    @Test
+    func `label matches the picker copy`() {
+        #expect(RefreshInterval.off.label == "Off")
+        #expect(RefreshInterval.oneMinute.label == "1 min")
+        #expect(RefreshInterval.fiveMinutes.label == "5 min")
+        #expect(RefreshInterval.fifteenMinutes.label == "15 min")
+    }
+
+    @Test
+    func `migrating returns off when background sync is disabled`() {
+        #expect(RefreshInterval.migrating(enabled: false, storedSeconds: 60) == .off)
+        #expect(RefreshInterval.migrating(enabled: false, storedSeconds: 900) == .off)
+    }
+
+    @Test
+    func `migrating snaps a stored interval to the nearest supported option`() {
+        // Retired 30s / 2m options and below-floor values snap up to 1 minute.
+        #expect(RefreshInterval.migrating(enabled: true, storedSeconds: 30) == .oneMinute)
+        #expect(RefreshInterval.migrating(enabled: true, storedSeconds: 60) == .oneMinute)
+        #expect(RefreshInterval.migrating(enabled: true, storedSeconds: 120) == .oneMinute)
+        #expect(RefreshInterval.migrating(enabled: true, storedSeconds: 300) == .fiveMinutes)
+        #expect(RefreshInterval.migrating(enabled: true, storedSeconds: 900) == .fifteenMinutes)
+    }
+
+    @Test
+    func `allCases lists the options in picker order`() {
+        #expect(RefreshInterval.allCases == [.off, .oneMinute, .fiveMinutes, .fifteenMinutes])
+    }
+}


### PR DESCRIPTION
## Summary

Keep the at-a-glance menu-bar usage number fresh **while the dropdown is closed**, instead of letting it go stale until you open the menu.

Previously the background-monitoring loop lived inside the dropdown view (`MenuContentView`), so it only ran while the popover was open. This hoists the loop up to an app-lifetime scene `.task(id:)` attached to the always-present menu-bar label in `ClaudeBarApp`, so the number refreshes on its own for the life of the app. The `.task(id:)` restarts the loop when the cadence or target provider changes and SwiftUI tears it down on exit.

Finishes **#48 / #58**.

## What changed

- **Refresh-interval picker (Off · 1 min · 5 min · 15 min)** with a hard **1-minute floor** enforced in `QuotaMonitor.startMonitoring` (energy — **#67**). Backed by a new `RefreshInterval` enum plus an `AppSettings.refreshInterval` facade computed over the existing `backgroundSyncEnabled` / `backgroundSyncInterval` keys, so `settings.json` stays **backward compatible** — no new key. Legacy values snap to the nearest supported option (30s → 1 min, 120s → 1 min, 300s → 5 min); the old on/off toggle folds into the picker's "Off" case.
- **App-lifetime loop** via a scene `.task(id:)` on the menu-bar label so monitoring runs independent of whether the dropdown is open. When the menu is closed and a menu-bar readout is on, background refresh is **narrowed to the selected + configured menu-bar provider(s)** to keep background work minimal (**#67**).
- **Fixes #182**: isolate `QuotaMonitor` to `@MainActor` (mirrors `SessionMonitor`) so its `@Observable` state is never mutated off the main actor — the compiler now rejects future off-main mutation regressions.
- **De-flaked** the continuous-monitoring tests with a cancellation-gated test clock (no real wall-clock sleeps); added #182 and 1-minute-floor regression tests.

## Scope note for reviewers

The **#182** fix here is intentionally focused: only `QuotaMonitor` is made `@MainActor`. The provider classes' own `@Observable` snapshot writes still happen off-main (pre-existing behaviour, not introduced by this PR) and are left untouched on purpose — that's a **tracked follow-up**, not a gap in this change. This keeps the PR focused on the crash path that was reported.

## Testing

- `tuist build ClaudeBar` ✅
- `tuist test Domain` ✅ (incl. new `RefreshIntervalTests` + `QuotaMonitor` #182/floor regression tests, ~ms each)
- `tuist test Infrastructure` ✅
- `tuist test AcceptanceTests` ✅
- Runtime: ran the debug build for an extended period — the menu-bar number refreshes on its own with the dropdown closed, no #182 crash.

Refs #48, #58, #67, #182


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Picker in Settings to choose background refresh: Off, 1 min, 5 min, 15 min.

* **Improvements**
  * Background refresh now only polls providers needed for visible menu-bar readouts.
  * Enforced 1-minute minimum polling interval for more reliable updates.
  * Settings UI now shows the selected refresh label consistently.

* **Tests**
  * Added and updated tests validating refresh behavior and interval clamping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->