### PR TITLE
fix(codex): show reset time in days/hours/mins

### DIFF
--- a/Sources/Infrastructure/Codex/CodexAPIUsageProbe.swift
+++ b/Sources/Infrastructure/Codex/CodexAPIUsageProbe.swift
@@ -331,10 +331,13 @@ public struct CodexAPIUsageProbe: UsageProbe, @unchecked Sendable {
         let seconds = date.timeIntervalSinceNow
         guard seconds > 0 else { return nil }
 
-        let hours = Int(seconds / 3600)
+        let days = Int(seconds / 86400)
+        let hours = Int((seconds.truncatingRemainder(dividingBy: 86400)) / 3600)
         let minutes = Int((seconds.truncatingRemainder(dividingBy: 3600)) / 60)
 
-        if hours > 0 {
+        if days > 0 {
+            return "Resets in \(days)d \(hours)h \(minutes)m"
+        } else if hours > 0 {
             return "Resets in \(hours)h \(minutes)m"
         } else if minutes > 0 {
             return "Resets in \(minutes)m"

--- a/Sources/Infrastructure/Codex/DefaultCodexRPCClient.swift
+++ b/Sources/Infrastructure/Codex/DefaultCodexRPCClient.swift
@@ -230,10 +230,13 @@ public final class DefaultCodexRPCClient: CodexRPCClient, @unchecked Sendable {
         let interval = date.timeIntervalSinceNow
         if interval <= 0 { return "Resets soon" }
 
-        let hours = Int(interval / 3600)
+        let days = Int(interval / 86400)
+        let hours = Int((interval.truncatingRemainder(dividingBy: 86400)) / 3600)
         let minutes = Int((interval.truncatingRemainder(dividingBy: 3600)) / 60)
 
-        if hours > 0 {
+        if days > 0 {
+            return "Resets in \(days)d \(hours)h \(minutes)m"
+        } else if hours > 0 {
             return "Resets in \(hours)h \(minutes)m"
         } else {
             return "Resets in \(minutes)m"

--- a/Tests/InfrastructureTests/Codex/DefaultCodexRPCClientTests.swift
+++ b/Tests/InfrastructureTests/Codex/DefaultCodexRPCClientTests.swift
@@ -217,6 +217,19 @@ struct DefaultCodexRPCClientTests {
     }
 
     @Test
+    func `formatResetTime shows days, hours and minutes`() {
+        let mockTransport = MockRPCTransport()
+        let client = DefaultCodexRPCClient(transport: mockTransport)
+
+        let futureDate = Date().addingTimeInterval(2 * 86400 + 3 * 3600 + 30 * 60) // 2d 3h 30m
+        let result = client.formatResetTime(futureDate)
+
+        #expect(result.contains("Resets in"))
+        #expect(result.contains("2d"))
+        #expect(result.contains("3h"))
+    }
+
+    @Test
     func `formatResetTime shows only minutes when less than an hour`() {
         let mockTransport = MockRPCTransport()
         let client = DefaultCodexRPCClient(transport: mockTransport)


### PR DESCRIPTION
## What

The Codex **weekly** quota window can reset up to ~7 days out, but both Codex reset-time formatters only rolled up to hours. A weekly reset rendered as `Resets in 167h 30m` instead of a readable `Resets in 6d 23h 30m`.

This adds a **days** component to both Codex probe-mode formatters so the reset text breaks out days, hours, and minutes — matching the existing day-aware convention used by other providers (e.g. Kimi's `6d 23h 22m`).

## Changes

- `Sources/Infrastructure/Codex/DefaultCodexRPCClient.swift` — `formatResetTime(_:)` (RPC mode, the default) now emits `Resets in Nd Nh Nm` when ≥ 1 day out.
- `Sources/Infrastructure/Codex/CodexAPIUsageProbe.swift` — `formatResetText(_:)` (API mode) gets the identical day rollover, preserving its existing `nil` / `Resets soon` edge cases.
- `Tests/InfrastructureTests/Codex/DefaultCodexRPCClientTests.swift` — adds `formatResetTime shows days, hours and minutes` (`2d 3h 30m` case). Existing hours/minutes/soon tests are unchanged.

Both Codex probe modes are updated so the fix shows regardless of the selected mode.

## Behavior

| Time until reset | Before | After |
|---|---|---|
| 2d 3h 30m | `Resets in 51h 30m` | `Resets in 2d 3h 30m` |
| 2h 30m | `Resets in 2h 30m` | `Resets in 2h 30m` |
| 45m | `Resets in 45m` | `Resets in 45m` |

## Testing

Run `tuist test InfrastructureTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API usage reset time display to include days in addition to hours and minutes for better clarity on remaining quota reset duration.

* **Tests**
  * Updated test coverage for reset time formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->