### PR TITLE
fix(menubar): drive the status item imperatively so the label survives sleep (#192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Menu-bar usage text no longer freezes or disappears after system sleep. SwiftUI's
+  `MenuBarExtra` label hosting can permanently stop receiving updates after wake (the
+  dropdown kept working while the label — and the refresh-loop restarts attached to it —
+  went dead until relaunch). The menu-bar pixels and the background-refresh lifecycle are
+  now driven imperatively (AppKit `NSStatusItem` via MenuBarExtraAccess + observation
+  tracking), independent of SwiftUI view invalidation. (#192)
+
 ---
 
 ## [0.4.68] - 2026-06-10

--- a/Project.swift
+++ b/Project.swift
@@ -83,6 +83,7 @@ let project = Project(
                 .target(name: "Domain"),
                 .target(name: "Infrastructure"),
                 .external(name: "Sparkle"),
+                .external(name: "MenuBarExtraAccess"),
             ],
             settings: .settings(
                 base: [

--- a/Sources/App/ClaudeBarApp.swift
+++ b/Sources/App/ClaudeBarApp.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import Domain
 import Infrastructure
+import MenuBarExtraAccess
 #if ENABLE_SPARKLE
 import Sparkle
 #endif
@@ -16,7 +17,16 @@ struct ClaudeBarApp: App {
     @State private var monitor: QuotaMonitor
 
     /// Monitors Claude Code sessions via hook events
-    @State private var sessionMonitor = SessionMonitor()
+    @State private var sessionMonitor: SessionMonitor
+
+    /// Drives the menu-bar pixels and the background-refresh lifecycle
+    /// imperatively, outside SwiftUI — the MenuBarExtra label hosting can
+    /// permanently stop re-evaluating after system sleep (issue #192).
+    private let statusItemDriver: StatusItemLabelDriver
+
+    /// Binding required by `.menuBarExtraAccess`; also enables programmatic
+    /// dropdown control if ever needed.
+    @State private var isMenuPresented = false
 
     /// The hook HTTP server that receives events from Claude Code
     private let hookServer = HookHTTPServer()
@@ -107,11 +117,25 @@ struct ClaudeBarApp: App {
 
         // Initialize the domain service with quota alerter
         // QuotaMonitor automatically validates selected provider on init
-        monitor = QuotaMonitor(
+        let monitor = QuotaMonitor(
             providers: repository,
             alerter: quotaAlerter
         )
+        self.monitor = monitor
         AppLog.monitor.info("QuotaMonitor initialized")
+
+        let sessionMonitor = SessionMonitor()
+        self.sessionMonitor = sessionMonitor
+
+        // The driver owns the menu-bar pixels and the refresh-loop lifecycle
+        // (outside SwiftUI — see StatusItemLabelDriver). Pixels start flowing
+        // once `.menuBarExtraAccess` hands over the NSStatusItem.
+        statusItemDriver = StatusItemLabelDriver(
+            monitor: monitor,
+            settings: AppSettings.shared,
+            sessionMonitor: sessionMonitor
+        )
+        statusItemDriver.startMonitoringLifecycle()
 
         // Load user extensions from ~/.claudebar/extensions/
         let extensionRegistry = ExtensionRegistry(
@@ -137,74 +161,9 @@ struct ClaudeBarApp: App {
     /// App settings for theme
     @State private var settings = AppSettings.shared
 
-    /// Status of selected provider, considering burn rate setting
-    private var effectiveSelectedProviderStatus: QuotaStatus {
-        guard let snapshot = monitor.selectedProvider?.snapshot else { return .healthy }
-        if settings.burnRateWarningEnabled {
-            return snapshot.paceAwareOverallStatus(burnRateThreshold: settings.burnRateThreshold)
-        }
-        return snapshot.overallStatus
-    }
-
-    /// The composed menu bar label (percentage and/or duration, for one or two
-    /// quota windows). Driven by the user's independent menu-bar toggles and the
-    /// primary/secondary quota selection. Recomputed on every body evaluation so
-    /// the duration countdown stays current.
-    private var menuBarLabel: MenuBarLabel? {
-        monitor.menuBarLabel(
-            providerId: settings.menuBarPercentageProviderId,
-            primaryQuotaKey: settings.menuBarPercentageQuotaKey,
-            secondaryQuotaKey: settings.menuBarSecondaryQuotaKey,
-            showPercentage: settings.menuBarPercentageEnabled,
-            showDuration: settings.menuBarDurationEnabled,
-            mode: settings.usageDisplayMode,
-            burnRateWarningEnabled: settings.burnRateWarningEnabled,
-            burnRateThreshold: settings.burnRateThreshold
-        )
-    }
-
     /// Current theme mode from settings
     private var currentThemeMode: ThemeMode {
         ThemeMode(rawValue: settings.themeMode) ?? .system
-    }
-
-    // MARK: - Background Refresh
-
-    /// Identity for the app-lifetime background-refresh loop. When any field
-    /// changes, the scene `.task(id:)` cancels the running loop and restarts it
-    /// with the new cadence/target — replacing the per-setting `.onChange`
-    /// restarts that used to live in `MenuContentView`.
-    private struct RefreshLoopKey: Hashable {
-        let isEnabled: Bool
-        let seconds: Int
-        let providerIds: [String]?
-    }
-
-    /// The current `RefreshLoopKey` derived from settings + monitor state. The
-    /// scene `.task(id:)` observes this, so any change here (cadence toggled,
-    /// selected or menu-bar provider switched) tears down and restarts the loop.
-    private var refreshLoopKey: RefreshLoopKey {
-        let interval = settings.refreshInterval
-        return RefreshLoopKey(
-            isEnabled: interval.isEnabled,
-            seconds: interval.seconds ?? 0,
-            providerIds: backgroundRefreshProviderIds
-        )
-    }
-
-    /// While the dropdown is closed we only need the menu-bar provider(s) fresh,
-    /// so narrow the periodic refresh to the selected + configured menu-bar
-    /// provider when a menu-bar readout is on; otherwise just the selected
-    /// provider. Disabled providers are dropped — their readouts never render,
-    /// so polling them would be wasted work. Keeps background work minimal for
-    /// energy (issue #67).
-    private var backgroundRefreshProviderIds: [String]? {
-        guard settings.menuBarPercentageEnabled || settings.menuBarDurationEnabled else { return nil }
-        let enabledProviderIds = Set(monitor.enabledProviders.map(\.id))
-        return [
-            monitor.selectedProviderId,
-            settings.menuBarPercentageProviderId,
-        ].filter { enabledProviderIds.contains($0) }
     }
 
     private func startHookServer() {
@@ -268,54 +227,37 @@ struct ClaudeBarApp: App {
 
     var body: some Scene {
         MenuBarExtra {
-            #if ENABLE_SPARKLE
-            MenuContentView(monitor: monitor, sessionMonitor: sessionMonitor, quotaAlerter: quotaAlerter) { enabled in
-                    if enabled { startHookServer() } else { stopHookServer() }
-                }
-                .appThemeProvider(themeModeId: settings.themeMode)
-                .environment(\.sparkleUpdater, sparkleUpdater)
-            #else
-            MenuContentView(monitor: monitor, sessionMonitor: sessionMonitor, quotaAlerter: quotaAlerter) { enabled in
-                    if enabled { startHookServer() } else { stopHookServer() }
-                }
-                .appThemeProvider(themeModeId: settings.themeMode)
-            #endif
-        } label: {
-            // Show overall status + active session indicator in menu bar.
-            //
-            // The background-refresh loop is attached here, to the always-present
-            // menu-bar label, so it runs for the app's lifetime independent of
-            // whether the dropdown is open — keeping the at-a-glance number fresh
-            // while the popover is closed. `.task(id:)` restarts the loop when the
-            // cadence or target provider changes and SwiftUI tears it down on exit.
             Group {
-                if let label = menuBarLabel {
-                    StatusBarPercentageLabel(
-                        text: label.text,
-                        status: label.status,
-                        activeSession: sessionMonitor.activeSession
-                    )
+                #if ENABLE_SPARKLE
+                MenuContentView(monitor: monitor, sessionMonitor: sessionMonitor, quotaAlerter: quotaAlerter) { enabled in
+                        if enabled { startHookServer() } else { stopHookServer() }
+                    }
                     .appThemeProvider(themeModeId: settings.themeMode)
-                } else {
-                    StatusBarIcon(status: effectiveSelectedProviderStatus, activeSession: sessionMonitor.activeSession)
-                        .appThemeProvider(themeModeId: settings.themeMode)
-                }
+                    .environment(\.sparkleUpdater, sparkleUpdater)
+                #else
+                MenuContentView(monitor: monitor, sessionMonitor: sessionMonitor, quotaAlerter: quotaAlerter) { enabled in
+                        if enabled { startHookServer() } else { stopHookServer() }
+                    }
+                    .appThemeProvider(themeModeId: settings.themeMode)
+                #endif
             }
-            .task(id: refreshLoopKey) {
-                guard refreshLoopKey.isEnabled else {
-                    monitor.stopMonitoring()
-                    return
-                }
-                AppLog.monitor.info("Background refresh starting (interval: \(refreshLoopKey.seconds)s, providers: \(refreshLoopKey.providerIds?.joined(separator: ",") ?? "selected"))")
-                let stream = monitor.startMonitoring(
-                    interval: .seconds(refreshLoopKey.seconds),
-                    providerIds: refreshLoopKey.providerIds
-                )
-                for await _ in stream {
-                    // QuotaMonitor updates provider snapshots; the menu-bar label
-                    // re-renders from observable state — nothing to do per event.
-                }
-            }
+            // Opening/closing the dropdown flips `isMenuPresented`, which makes
+            // SwiftUI re-evaluate the scene and wipe the AppKit-drawn button
+            // image. The dropdown's lifecycle maps 1:1 to those flips, so
+            // re-assert the menu-bar pixels on both edges.
+            .onAppear { statusItemDriver.reassertPresentation() }
+            .onDisappear { statusItemDriver.reassertPresentation() }
+        } label: {
+            // Deliberately static: the menu-bar pixels are drawn by
+            // StatusItemLabelDriver into the status item's button image,
+            // because this SwiftUI label hosting can permanently stop
+            // re-evaluating after system sleep (issue #192). The placeholder
+            // only gives the scene a label to anchor the dropdown to.
+            Color.clear.frame(width: 1, height: 1)
+        }
+        // Must be the first scene modifier (extends MenuBarExtra, not Scene).
+        .menuBarExtraAccess(isPresented: $isMenuPresented) { statusItem in
+            statusItemDriver.attach(statusItem)
         }
         .menuBarExtraStyle(.window)
     }
@@ -371,60 +313,6 @@ struct StatusBarIcon: View {
 
     private var iconColor: Color {
         theme.statusColor(for: status)
-    }
-}
-
-/// The menu bar text label for an opt-in provider/quota selection.
-/// Renders one composed string (percentage, duration, or both joined by " · ")
-/// driven by the user's independent menu-bar toggles.
-struct StatusBarPercentageLabel: View {
-    let text: String
-    let status: QuotaStatus
-    var activeSession: ClaudeSession? = nil
-
-    @Environment(\.appTheme) private var theme
-
-    var body: some View {
-        let statusColor = theme.statusColor(for: status)
-
-        HStack(spacing: 3) {
-            if let session = activeSession {
-                Image(systemName: "terminal.fill")
-                    .symbolRenderingMode(.palette)
-                    .foregroundStyle(sessionPhaseColor(session.phase))
-            }
-
-            Image(nsImage: StatusBarPercentageImageRenderer.image(
-                text: text,
-                color: statusColor
-            ))
-            .renderingMode(.original)
-            .accessibilityLabel(text)
-        }
-    }
-
-}
-
-/// Renders status text as an original-color image because macOS can ignore
-/// `Text.foregroundStyle` inside a `MenuBarExtra` label.
-private enum StatusBarPercentageImageRenderer {
-    @MainActor
-    static func image(text: String, color: Color) -> NSImage {
-        let font = NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .semibold)
-        let attributes: [NSAttributedString.Key: Any] = [
-            .font: font,
-            .foregroundColor: NSColor(color),
-        ]
-        let attributedText = NSAttributedString(string: text, attributes: attributes)
-        let textSize = attributedText.size()
-        let imageSize = NSSize(width: ceil(textSize.width), height: ceil(textSize.height))
-        let image = NSImage(size: imageSize, flipped: false) { _ in
-            attributedText.draw(at: .zero)
-            return true
-        }
-        image.isTemplate = false
-
-        return image
     }
 }
 

--- a/Sources/App/StatusItemLabelDriver.swift
+++ b/Sources/App/StatusItemLabelDriver.swift
@@ -1,0 +1,321 @@
+import AppKit
+import SwiftUI
+import Domain
+import Infrastructure
+
+/// Drives the menu-bar status item imperatively (AppKit), bypassing SwiftUI's
+/// `MenuBarExtra` label hosting entirely.
+///
+/// After system sleep, the MenuBarExtra label hosting view can permanently
+/// stop receiving SwiftUI invalidations: the dropdown window keeps updating
+/// while the label — and any `.task` attached to it — goes dead until relaunch
+/// (issue #192). This driver owns both things that used to live on that label:
+///
+/// 1. **The pixels** — an `ObservationRenderSync` reads the same observable
+///    state the SwiftUI label did (monitor, settings, session) and draws the
+///    composed label into `statusItem.button.image`.
+/// 2. **The background-refresh lifecycle** — a second sync watches the refresh
+///    cadence/target settings and restarts `QuotaMonitor.startMonitoring`,
+///    replacing the label's `.task(id:)`.
+///
+/// Lives for the app's lifetime; the closure retain cycles this creates are
+/// intentional and harmless.
+@MainActor
+final class StatusItemLabelDriver {
+    private let monitor: QuotaMonitor
+    private let settings: AppSettings
+    private let sessionMonitor: SessionMonitor
+
+    private var statusItem: NSStatusItem?
+    private var labelSync: ObservationRenderSync<LabelContent>?
+    private var loopSync: ObservationRenderSync<RefreshLoopKey>?
+    private var streamConsumer: Task<Void, Never>?
+    private var wakeObserver: NSObjectProtocol?
+
+    /// The image currently owned by this driver, and the content it encodes.
+    /// Used both to skip redundant redraws (repainting an intact image can
+    /// itself flicker) and to recognize external wipes via KVO.
+    private var lastImage: NSImage?
+    private var lastContent: LabelContent?
+    private var imageWipeObservation: NSKeyValueObservation?
+
+    init(monitor: QuotaMonitor, settings: AppSettings, sessionMonitor: SessionMonitor) {
+        self.monitor = monitor
+        self.settings = settings
+        self.sessionMonitor = sessionMonitor
+    }
+
+    // No deinit: this object lives for the app's lifetime, so the wake
+    // observer is intentionally never removed (and a nonisolated deinit
+    // could not touch the @MainActor-isolated observer under Swift 6).
+
+    // MARK: - Label Rendering
+
+    /// Everything the menu-bar pixels depend on. Reading these properties
+    /// inside the sync's `read` registers observation for each of them.
+    struct LabelContent: Equatable {
+        var label: MenuBarLabel?
+        var fallbackStatus: QuotaStatus
+        var sessionPhase: ClaudeSession.Phase?
+        var themeModeId: String
+    }
+
+    /// Attaches to the `NSStatusItem` exposed by MenuBarExtraAccess and starts
+    /// rendering. Repeated callbacks re-assert the image (cheap, idempotent).
+    func attach(_ statusItem: NSStatusItem) {
+        guard self.statusItem !== statusItem else {
+            labelSync?.renderNow()
+            return
+        }
+        self.statusItem = statusItem
+        labelSync?.stop()
+
+        let sync = ObservationRenderSync(
+            read: { [self] in currentLabelContent() },
+            render: { [self] content in render(content) }
+        )
+        labelSync = sync
+        sync.start()
+
+        // SwiftUI wipes `button.image` whenever the scene re-evaluates (every
+        // dropdown open/close flips the `isPresented` binding). Restore it
+        // synchronously in the same runloop pass so a blank frame never
+        // reaches the screen — repainting from `onAppear`/`onDisappear` alone
+        // leaves a visible flash.
+        imageWipeObservation?.invalidate()
+        imageWipeObservation = statusItem.button?.observe(\.image, options: [.new]) { [weak self] button, change in
+            MainActor.assumeIsolated {
+                guard let self, let owned = self.lastImage else { return }
+                if button.image !== owned {
+                    button.image = owned
+                }
+            }
+        }
+
+        if wakeObserver == nil {
+            // Belt-and-braces: repaint after wake even if nothing changed,
+            // in case the menu bar was rebuilt with stale content.
+            wakeObserver = NSWorkspace.shared.notificationCenter.addObserver(
+                forName: NSWorkspace.didWakeNotification, object: nil, queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in self?.labelSync?.renderNow() }
+            }
+        }
+    }
+
+    /// Defense-in-depth repaint around dropdown open/close (the KVO observer
+    /// in `attach` is the primary guard against SwiftUI's image wipes). A
+    /// no-op when the image is intact, so it never causes extra redraws.
+    func reassertPresentation() {
+        labelSync?.renderNow()
+    }
+
+    private func currentLabelContent() -> LabelContent {
+        LabelContent(
+            label: monitor.menuBarLabel(
+                providerId: settings.menuBarPercentageProviderId,
+                primaryQuotaKey: settings.menuBarPercentageQuotaKey,
+                secondaryQuotaKey: settings.menuBarSecondaryQuotaKey,
+                showPercentage: settings.menuBarPercentageEnabled,
+                showDuration: settings.menuBarDurationEnabled,
+                mode: settings.usageDisplayMode,
+                burnRateWarningEnabled: settings.burnRateWarningEnabled,
+                burnRateThreshold: settings.burnRateThreshold
+            ),
+            fallbackStatus: effectiveSelectedProviderStatus,
+            sessionPhase: sessionMonitor.activeSession?.phase,
+            themeModeId: settings.themeMode
+        )
+    }
+
+    /// Status of the selected provider, considering the burn-rate setting.
+    /// Mirrors the dropdown's status logic for the icon-only fallback.
+    private var effectiveSelectedProviderStatus: QuotaStatus {
+        guard let snapshot = monitor.selectedProvider?.snapshot else { return .healthy }
+        if settings.burnRateWarningEnabled {
+            return snapshot.paceAwareOverallStatus(burnRateThreshold: settings.burnRateThreshold)
+        }
+        return snapshot.overallStatus
+    }
+
+    private func render(_ content: LabelContent) {
+        guard let button = statusItem?.button else { return }
+        // Skip when nothing changed and our image is still in place —
+        // re-setting an identical image redraws the button and can flicker.
+        if content == lastContent, let lastImage, button.image === lastImage {
+            return
+        }
+        let image = Self.compose(content, theme: resolvedTheme(for: content.themeModeId))
+        lastContent = content
+        lastImage = image
+        button.image = image
+        button.imagePosition = .imageOnly
+        button.toolTip = content.label?.text
+    }
+
+    private func resolvedTheme(for themeModeId: String) -> any AppThemeProvider {
+        let scheme: ColorScheme = NSApp.effectiveAppearance
+            .bestMatch(from: [.darkAqua, .aqua]) == .darkAqua ? .dark : .light
+        return ThemeRegistry.shared.resolveTheme(for: themeModeId, systemColorScheme: scheme)
+    }
+
+    // MARK: - Image Composition
+
+    /// Composes the full status-item image: optional session glyph, then the
+    /// usage text — or the themed status icon when no label is configured or
+    /// no quota data exists yet. Mirrors the old SwiftUI label exactly.
+    static func compose(_ content: LabelContent, theme: any AppThemeProvider) -> NSImage {
+        var parts: [NSImage] = []
+
+        if let phase = content.sessionPhase {
+            parts.append(symbolImage("terminal.fill", color: NSColor(phase.color)))
+        }
+
+        if let label = content.label {
+            parts.append(StatusBarPercentageImageRenderer.image(
+                text: label.text,
+                color: theme.statusColor(for: label.status)
+            ))
+        } else {
+            let symbolName = theme.statusBarIconName ?? fallbackIconName(for: content.fallbackStatus)
+            parts.append(symbolImage(
+                symbolName,
+                color: NSColor(theme.statusColor(for: content.fallbackStatus))
+            ))
+        }
+
+        return hStack(parts, spacing: 3)
+    }
+
+    private static func fallbackIconName(for status: QuotaStatus) -> String {
+        switch status {
+        case .depleted: "chart.bar.xaxis"
+        case .critical: "exclamationmark.triangle.fill"
+        case .warning, .healthy: "chart.bar.fill"
+        }
+    }
+
+    /// Renders an SF Symbol tinted with a fixed color, since the status item
+    /// image is non-template (theme colors must survive menu bar appearance).
+    private static func symbolImage(_ name: String, color: NSColor) -> NSImage {
+        let configuration = NSImage.SymbolConfiguration(pointSize: 12, weight: .semibold)
+        guard let symbol = NSImage(systemSymbolName: name, accessibilityDescription: name)?
+            .withSymbolConfiguration(configuration) else {
+            return NSImage(size: .zero)
+        }
+        let size = symbol.size
+        let tinted = NSImage(size: size, flipped: false) { rect in
+            symbol.draw(in: rect)
+            color.set()
+            rect.fill(using: .sourceAtop)
+            return true
+        }
+        tinted.isTemplate = false
+        return tinted
+    }
+
+    /// Composites images horizontally, vertically centered.
+    private static func hStack(_ images: [NSImage], spacing: CGFloat) -> NSImage {
+        let images = images.filter { $0.size.width > 0 }
+        guard !images.isEmpty else { return NSImage(size: .zero) }
+
+        let width = images.map(\.size.width).reduce(0, +) + spacing * CGFloat(images.count - 1)
+        let height = images.map(\.size.height).max() ?? 0
+        let composed = NSImage(size: NSSize(width: ceil(width), height: ceil(height)), flipped: false) { _ in
+            var x: CGFloat = 0
+            for image in images {
+                image.draw(at: NSPoint(x: x, y: (height - image.size.height) / 2), from: .zero, operation: .sourceOver, fraction: 1)
+                x += image.size.width + spacing
+            }
+            return true
+        }
+        composed.isTemplate = false
+        return composed
+    }
+
+    // MARK: - Background Refresh Lifecycle
+
+    /// Identity for the background-refresh loop — replaces the `.task(id:)`
+    /// that lived on the (freeze-prone) SwiftUI label.
+    struct RefreshLoopKey: Equatable {
+        var isEnabled: Bool
+        var seconds: Int
+        var providerIds: [String]?
+    }
+
+    /// Starts watching the refresh cadence/target settings and (re)starts the
+    /// monitoring loop whenever they change. Call once at app startup.
+    func startMonitoringLifecycle() {
+        guard loopSync == nil else { return }
+        let sync = ObservationRenderSync(
+            read: { [self] in currentRefreshLoopKey() },
+            render: { [self] key in restartMonitoring(key) }
+        )
+        loopSync = sync
+        sync.start()
+    }
+
+    private func currentRefreshLoopKey() -> RefreshLoopKey {
+        let interval = settings.refreshInterval
+        return RefreshLoopKey(
+            isEnabled: interval.isEnabled,
+            seconds: interval.seconds ?? 0,
+            providerIds: backgroundRefreshProviderIds
+        )
+    }
+
+    /// While the dropdown is closed we only need the menu-bar provider(s)
+    /// fresh, so narrow the periodic refresh to the selected + configured
+    /// menu-bar provider when a menu-bar readout is on; otherwise just the
+    /// selected provider. Disabled providers are dropped (issue #67).
+    private var backgroundRefreshProviderIds: [String]? {
+        guard settings.menuBarPercentageEnabled || settings.menuBarDurationEnabled else { return nil }
+        let enabledProviderIds = Set(monitor.enabledProviders.map(\.id))
+        return [
+            monitor.selectedProviderId,
+            settings.menuBarPercentageProviderId,
+        ].filter { enabledProviderIds.contains($0) }
+    }
+
+    private func restartMonitoring(_ key: RefreshLoopKey) {
+        streamConsumer?.cancel()
+        streamConsumer = nil
+        guard key.isEnabled else {
+            monitor.stopMonitoring()
+            return
+        }
+        AppLog.monitor.info("Background refresh starting (interval: \(key.seconds)s, providers: \(key.providerIds?.joined(separator: ",") ?? "selected"))")
+        let stream = monitor.startMonitoring(
+            interval: .seconds(key.seconds),
+            providerIds: key.providerIds
+        )
+        streamConsumer = Task {
+            // QuotaMonitor updates provider snapshots; the label sync re-renders
+            // from observable state — nothing to do per event.
+            for await _ in stream {}
+        }
+    }
+}
+
+/// Renders status text as an original-color image because macOS can ignore
+/// `Text.foregroundStyle` inside a menu bar item.
+enum StatusBarPercentageImageRenderer {
+    @MainActor
+    static func image(text: String, color: Color) -> NSImage {
+        let font = NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .semibold)
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: NSColor(color),
+        ]
+        let attributedText = NSAttributedString(string: text, attributes: attributes)
+        let textSize = attributedText.size()
+        let imageSize = NSSize(width: ceil(textSize.width), height: ceil(textSize.height))
+        let image = NSImage(size: imageSize, flipped: false) { _ in
+            attributedText.draw(at: .zero)
+            return true
+        }
+        image.isTemplate = false
+
+        return image
+    }
+}

--- a/Sources/Domain/Monitor/ObservationRenderSync.swift
+++ b/Sources/Domain/Monitor/ObservationRenderSync.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Observation
+
+/// Keeps an imperative render sink in sync with `@Observable` domain state,
+/// independent of SwiftUI view invalidation.
+///
+/// SwiftUI's `MenuBarExtra` label hosting can permanently stop re-evaluating
+/// after system sleep: the dropdown window keeps updating while the label —
+/// and any `.task` attached to it — never receives invalidations again until
+/// relaunch (issue #192). This sync replaces that fragile path for the menu
+/// bar: it re-arms `withObservationTracking` around a `read` closure and
+/// pushes each distinct value to `render`, so whatever `render` drives (e.g.
+/// an `NSStatusItem` button image) stays correct for the app's lifetime.
+///
+/// `read` should gather *all* state the rendering depends on — every
+/// `@Observable` property it touches is tracked, and any change re-runs the
+/// cycle. `render` receives only values that differ from the last one
+/// rendered, so cheap no-op changes don't repaint the menu bar.
+@MainActor
+public final class ObservationRenderSync<Content: Equatable> {
+    private let read: @MainActor () -> Content
+    private let render: @MainActor (Content) -> Void
+    private var lastRendered: Content?
+    private var isStarted = false
+
+    public init(
+        read: @escaping @MainActor () -> Content,
+        render: @escaping @MainActor (Content) -> Void
+    ) {
+        self.read = read
+        self.render = render
+    }
+
+    /// Starts observing and renders the current value immediately.
+    public func start() {
+        guard !isStarted else { return }
+        isStarted = true
+        sync()
+    }
+
+    /// Stops observing and rendering. The in-flight tracking registration may
+    /// fire one final `onChange`, which is ignored once stopped.
+    public func stop() {
+        isStarted = false
+    }
+
+    /// Re-renders the current value even if unchanged — e.g. after system
+    /// wake, when the menu bar may have been repainted with stale content.
+    public func renderNow() {
+        guard isStarted else { return }
+        lastRendered = nil
+        sync()
+    }
+
+    private func sync() {
+        guard isStarted else { return }
+        let content = withObservationTracking {
+            read()
+        } onChange: { [weak self] in
+            // onChange fires on willSet; hop to the next main-actor turn so
+            // the re-read below observes the *new* value, then re-arm.
+            Task { @MainActor [weak self] in
+                self?.sync()
+            }
+        }
+        if content != lastRendered {
+            lastRendered = content
+            render(content)
+        }
+    }
+}

--- a/Tests/DomainTests/Monitor/ObservationRenderSyncTests.swift
+++ b/Tests/DomainTests/Monitor/ObservationRenderSyncTests.swift
@@ -1,0 +1,202 @@
+import Testing
+import Foundation
+import Mockable
+@testable import Domain
+@testable import Infrastructure
+
+/// `ObservationRenderSync` keeps an imperative render sink in sync with
+/// `@Observable` domain state, replacing SwiftUI's menu-bar label invalidation,
+/// which can permanently stop after system sleep (issue #192): the dropdown
+/// keeps working while the label and its attached tasks go dead. These tests
+/// verify the sync re-renders on state changes without any SwiftUI hosting.
+@Suite
+@MainActor
+struct ObservationRenderSyncTests {
+    /// Minimal observable state stand-in for QuotaMonitor/AppSettings reads.
+    @Observable
+    @MainActor
+    final class Source {
+        var value = "initial"
+    }
+
+    /// Records every value pushed to the render sink.
+    @MainActor
+    final class RenderRecorder {
+        private(set) var rendered: [String] = []
+        func record(_ value: String) { rendered.append(value) }
+    }
+
+    /// Yields the main actor until `condition` holds or ~2s elapse, so the
+    /// re-armed observation's main-actor hop gets a chance to run without
+    /// real-time sleeps.
+    private func waitUntil(_ condition: @MainActor () -> Bool) async {
+        let deadline = ContinuousClock.now.advanced(by: .seconds(2))
+        while !condition() && ContinuousClock.now < deadline {
+            await Task.yield()
+        }
+    }
+
+    @Test
+    func `renders the current value immediately on start`() {
+        // Given
+        let source = Source()
+        let recorder = RenderRecorder()
+        let sync = ObservationRenderSync(
+            read: { source.value },
+            render: { recorder.record($0) }
+        )
+
+        // When
+        sync.start()
+
+        // Then
+        #expect(recorder.rendered == ["initial"])
+    }
+
+    @Test
+    func `re-renders when observed state changes, without any SwiftUI hosting`() async {
+        // Given
+        let source = Source()
+        let recorder = RenderRecorder()
+        let sync = ObservationRenderSync(
+            read: { source.value },
+            render: { recorder.record($0) }
+        )
+        sync.start()
+
+        // When
+        source.value = "updated"
+        await waitUntil { recorder.rendered.count >= 2 }
+
+        // Then
+        #expect(recorder.rendered == ["initial", "updated"])
+    }
+
+    @Test
+    func `keeps tracking across multiple consecutive changes`() async {
+        // Given
+        let source = Source()
+        let recorder = RenderRecorder()
+        let sync = ObservationRenderSync(
+            read: { source.value },
+            render: { recorder.record($0) }
+        )
+        sync.start()
+
+        // When — each change must re-arm observation for the next one
+        source.value = "second"
+        await waitUntil { recorder.rendered.count >= 2 }
+        source.value = "third"
+        await waitUntil { recorder.rendered.count >= 3 }
+
+        // Then
+        #expect(recorder.rendered == ["initial", "second", "third"])
+    }
+
+    @Test
+    func `does not re-render when the read value is unchanged`() async {
+        // Given — read collapses state to a constant, so writes are invisible
+        let source = Source()
+        let recorder = RenderRecorder()
+        let sync = ObservationRenderSync(
+            read: { _ = source.value; return "constant" },
+            render: { recorder.record($0) }
+        )
+        sync.start()
+
+        // When
+        source.value = "changed underneath"
+        await waitUntil { recorder.rendered.count >= 2 }
+
+        // Then — still only the initial render
+        #expect(recorder.rendered == ["constant"])
+    }
+
+    @Test
+    func `stop ends rendering even if observed state keeps changing`() async {
+        // Given
+        let source = Source()
+        let recorder = RenderRecorder()
+        let sync = ObservationRenderSync(
+            read: { source.value },
+            render: { recorder.record($0) }
+        )
+        sync.start()
+
+        // When
+        sync.stop()
+        source.value = "after stop"
+        await waitUntil { recorder.rendered.count >= 2 }
+
+        // Then
+        #expect(recorder.rendered == ["initial"])
+    }
+
+    @Test
+    func `renderNow forces a redraw of the current value`() {
+        // Given — e.g. after system wake, the status item may need repainting
+        let source = Source()
+        let recorder = RenderRecorder()
+        let sync = ObservationRenderSync(
+            read: { source.value },
+            render: { recorder.record($0) }
+        )
+        sync.start()
+
+        // When
+        sync.renderNow()
+
+        // Then
+        #expect(recorder.rendered == ["initial", "initial"])
+    }
+
+    @Test
+    func `menu bar label content stays in sync with provider refreshes`() async {
+        // Given — the real domain chain: provider snapshot → monitor → label
+        let settings = MockProviderSettingsRepository()
+        given(settings).isEnabled(forProvider: .any, defaultValue: .any).willReturn(true)
+        given(settings).isEnabled(forProvider: .any).willReturn(true)
+        given(settings).setEnabled(.any, forProvider: .any).willReturn()
+
+        let probe = MockUsageProbe()
+        given(probe).isAvailable().willReturn(true)
+        given(probe).probe().willReturn(UsageSnapshot(
+            providerId: "claude",
+            quotas: [UsageQuota(percentRemaining: 64, quotaType: .session, providerId: "claude")],
+            capturedAt: Date()
+        ))
+        let provider = ClaudeProvider(probe: probe, settingsRepository: settings)
+        let monitor = QuotaMonitor(
+            providers: AIProviders(providers: [provider]),
+            clock: NoOpClock()
+        )
+
+        let recorder = RenderRecorder()
+        let sync = ObservationRenderSync(
+            read: {
+                monitor.menuBarLabel(
+                    providerId: "claude",
+                    primaryQuotaKey: "session",
+                    showPercentage: true,
+                    showDuration: false,
+                    mode: .remaining
+                )?.text ?? "no label"
+            },
+            render: { recorder.record($0) }
+        )
+        sync.start()
+        #expect(recorder.rendered == ["no label"])
+
+        // When — a refresh replaces the provider snapshot
+        await monitor.refresh(providerId: "claude")
+        await waitUntil { recorder.rendered.count >= 2 }
+
+        // Then — the sink saw the new label without any view re-evaluation
+        #expect(recorder.rendered == ["no label", "64%"])
+    }
+
+    private struct NoOpClock: Clock {
+        func sleep(for duration: Duration) async throws {}
+        func sleep(nanoseconds: UInt64) async throws {}
+    }
+}

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -32,5 +32,9 @@ let package = Package(
         .package(url: "https://github.com/migueldeicaza/SwiftTerm.git", exact: "1.12.0"),
         .package(url: "https://github.com/awslabs/aws-sdk-swift", exact: "1.6.99"),
         .package(url: "https://github.com/steipete/SweetCookieKit.git", from: "0.3.0"),
+        // Exposes MenuBarExtra's underlying NSStatusItem so the menu-bar label
+        // can be driven imperatively (AppKit), surviving the SwiftUI label
+        // freeze after system sleep (issue #192).
+        .package(url: "https://github.com/orchetect/MenuBarExtraAccess", from: "1.3.0"),
     ]
 )


### PR DESCRIPTION
## Problem

The menu-bar usage text would freeze or disappear after system sleep and stay that way until relaunch — likely the cause of #192. Diagnosis (confirmed live while the bug was active):

- SwiftUI's `MenuBarExtra` **label hosting permanently stops receiving invalidations** after wake. The dropdown window keeps updating; the label and the `.task(id:)` attached to it go dead — settings toggles produced no refresh-loop restart logs while quota data and probes were provably healthy.
- This left the menu bar stuck on a stale fallback icon while everything underneath worked.

## Fix

Move everything that lived on the freeze-prone label out of SwiftUI:

- **`ObservationRenderSync` (Domain)** — re-arms `withObservationTracking` around a `read` closure and pushes distinct values to a render sink. SwiftUI-free invalidation, covered by 7 unit tests including one driving the real probe → snapshot → label chain.
- **`StatusItemLabelDriver` (App)** — composes the label image (text, session glyph, themed colors, icon fallback) and assigns it to the `NSStatusItem` button captured via [MenuBarExtraAccess](https://github.com/orchetect/MenuBarExtraAccess); also owns the background-refresh lifecycle formerly restarted by the label's `.task(id:)`, and repaints on system wake.
- **Second bug found during live testing:** every dropdown open/close flips the `isPresented` binding, re-evaluates the scene, and SwiftUI wipes the AppKit-set button image (the item collapsed to a blank 1pt sliver). A synchronous KVO observer on `button.image` restores the owned image in the same runloop pass — no blank frame, no flash — with redraw dedupe and defensive repaints on dropdown appear/disappear.

Power cost is nil: rendering is a sub-millisecond image draw piggybacking on existing refresh events; no new timers or wakeups.

## Test plan

- [x] 883 tests in 72 suites pass (`xcodebuild test`, all three targets)
- [x] New `ObservationRenderSyncTests` suite (7 tests, Chicago-school)
- [x] Live: label renders, updates on refresh, survives dropdown open/close without flashing
- [x] Live: survives system sleep/wake and network disconnect/reconnect — the original repro no longer reproduces after extended real-world testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Menu-bar text no longer freezes or disappears after system sleep, ensuring quota information remains consistently accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->