### PR TITLE
fix(menubar): stop status item sticking on a lone session glyph after idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   went dead until relaunch). The menu-bar pixels and the background-refresh lifecycle are
   now driven imperatively (AppKit `NSStatusItem` via MenuBarExtraAccess + observation
   tracking), independent of SwiftUI view invalidation. (#192)
+- Menu-bar status item no longer sticks on a lone colored session glyph with no usage
+  number after long idle. Even with the imperative driver, the label only repainted when
+  SwiftUI observation fired, which can go quiet after idle while probes keep succeeding.
+  The status item is now repainted on every background-refresh tick, the Claude Code
+  session glyph is shown only while a session is actively working (not on the end-of-turn
+  "stopped" state, which previously stuck forever), and the last-known number is kept when
+  a quota window is briefly unavailable. Claude Code sessions also recover from "stopped"
+  on the next prompt via a new `UserPromptSubmit` hook so the indicator tracks real activity.
 
 ---
 

--- a/Sources/App/ClaudeBarApp.swift
+++ b/Sources/App/ClaudeBarApp.swift
@@ -149,6 +149,14 @@ struct ClaudeBarApp: App {
 
         // Start hook server if hooks are enabled
         if settingsRepository.isHookEnabled() {
+            // Reconcile installed hooks so newly-added events (e.g.
+            // UserPromptSubmit, which revives a stopped session) register for
+            // existing users without re-toggling the setting. install() is
+            // idempotent — it replaces only ClaudeBar's own matcher entries
+            // per event and preserves hooks from other tools.
+            if HookInstaller.isInstalled() {
+                try? HookInstaller.install()
+            }
             startHookServer()
         }
 

--- a/Sources/App/StatusItemLabelDriver.swift
+++ b/Sources/App/StatusItemLabelDriver.swift
@@ -111,21 +111,37 @@ final class StatusItemLabelDriver {
     }
 
     private func currentLabelContent() -> LabelContent {
-        LabelContent(
-            label: monitor.menuBarLabel(
-                providerId: settings.menuBarPercentageProviderId,
-                primaryQuotaKey: settings.menuBarPercentageQuotaKey,
-                secondaryQuotaKey: settings.menuBarSecondaryQuotaKey,
-                showPercentage: settings.menuBarPercentageEnabled,
-                showDuration: settings.menuBarDurationEnabled,
-                mode: settings.usageDisplayMode,
-                burnRateWarningEnabled: settings.burnRateWarningEnabled,
-                burnRateThreshold: settings.burnRateThreshold
-            ),
+        let freshLabel = monitor.menuBarLabel(
+            providerId: settings.menuBarPercentageProviderId,
+            primaryQuotaKey: settings.menuBarPercentageQuotaKey,
+            secondaryQuotaKey: settings.menuBarSecondaryQuotaKey,
+            showPercentage: settings.menuBarPercentageEnabled,
+            showDuration: settings.menuBarDurationEnabled,
+            mode: settings.usageDisplayMode,
+            burnRateWarningEnabled: settings.burnRateWarningEnabled,
+            burnRateThreshold: settings.burnRateThreshold
+        )
+
+        return LabelContent(
+            label: freshLabel ?? lastKnownLabel(whenFreshIsMissing: freshLabel),
             fallbackStatus: effectiveSelectedProviderStatus,
             sessionPhase: sessionMonitor.activeSession?.phase,
             themeModeId: settings.themeMode
         )
+    }
+
+    /// Bridges a momentarily-missing menu-bar label. The configured quota window
+    /// can briefly vanish from a snapshot (cold start before the first success, a
+    /// parse gap), which would otherwise collapse the menu bar to a lone icon. As
+    /// long as the menu-bar provider is enabled and still holds a snapshot, keep
+    /// the last value we showed instead of blanking the number. Returns nil when
+    /// we have nothing to fall back to, so the normal "no data yet" icon shows.
+    private func lastKnownLabel(whenFreshIsMissing freshLabel: MenuBarLabel?) -> MenuBarLabel? {
+        guard freshLabel == nil, let previous = lastContent?.label else { return nil }
+        let providerHasSnapshot = monitor.enabledProviders.contains {
+            $0.id == settings.menuBarPercentageProviderId && $0.snapshot != nil
+        }
+        return providerHasSnapshot ? previous : nil
     }
 
     /// Status of the selected provider, considering the burn-rate setting.
@@ -167,7 +183,11 @@ final class StatusItemLabelDriver {
     static func compose(_ content: LabelContent, theme: any AppThemeProvider) -> NSImage {
         var parts: [NSImage] = []
 
-        if let phase = content.sessionPhase {
+        // Only surface the session glyph while Claude is actively working. A
+        // finished/idle (.stopped) or .ended session must not leave a lone
+        // orange glyph sitting in the menu bar — that reads as a frozen crash
+        // (the user's report) since `Stop` fires at the end of every turn.
+        if let phase = content.sessionPhase, phase == .active || phase == .subagentsWorking {
             parts.append(symbolImage("terminal.fill", color: NSColor(phase.color)))
         }
 
@@ -290,9 +310,14 @@ final class StatusItemLabelDriver {
             providerIds: key.providerIds
         )
         streamConsumer = Task {
-            // QuotaMonitor updates provider snapshots; the label sync re-renders
-            // from observable state — nothing to do per event.
-            for await _ in stream {}
+            // Each refresh tick imperatively forces a repaint. We can't rely on
+            // the @Observable chain alone: after long idle it can stop delivering
+            // invalidations (issue #192), freezing the menu-bar image even while
+            // probes keep succeeding. renderNow() dedupes inside render(), so this
+            // is cheap and only repaints when the composed image actually changed.
+            for await _ in stream {
+                self.labelSync?.renderNow()
+            }
         }
     }
 }

--- a/Sources/Domain/Session/ClaudeSession.swift
+++ b/Sources/Domain/Session/ClaudeSession.swift
@@ -44,17 +44,27 @@ public struct ClaudeSession: Sendable, Equatable, Identifiable {
 
     // MARK: - Mutations
 
-    /// Records a subagent starting work
+    /// Records a subagent starting work. Subagent activity also revives a
+    /// `.stopped` session: a new turn is clearly underway, so the indicator
+    /// should reflect work rather than staying stuck on the previous turn's stop.
     public mutating func subagentStarted() {
-        guard phase != .stopped, phase != .ended else { return }
+        guard phase != .ended else { return }
         activeSubagentCount += 1
         updatePhase()
     }
 
     /// Records a subagent stopping work
     public mutating func subagentStopped() {
-        guard phase != .stopped, phase != .ended else { return }
+        guard phase != .ended else { return }
         activeSubagentCount = max(0, activeSubagentCount - 1)
+        updatePhase()
+    }
+
+    /// Revives a stopped/idle session when a new turn begins (UserPromptSubmit).
+    /// `Stop` fires at the end of every turn, so without this a session would be
+    /// stuck `.stopped` for the rest of its life. No-op once ended.
+    public mutating func resume() {
+        guard phase != .ended else { return }
         updatePhase()
     }
 

--- a/Sources/Domain/Session/SessionEvent.swift
+++ b/Sources/Domain/Session/SessionEvent.swift
@@ -48,5 +48,9 @@ public struct SessionEvent: Sendable, Equatable, Codable {
         case subagentStart = "SubagentStart"
         case subagentStop = "SubagentStop"
         case stop = "Stop"
+        /// Fires at the start of every turn (before Claude processes the prompt).
+        /// Used to revive a session out of `.stopped` so the indicator tracks
+        /// real activity instead of sticking on the end-of-turn `Stop`.
+        case userPromptSubmit = "UserPromptSubmit"
     }
 }

--- a/Sources/Domain/Session/SessionMonitor.swift
+++ b/Sources/Domain/Session/SessionMonitor.swift
@@ -37,6 +37,8 @@ public final class SessionMonitor {
             handleSubagentStop(event)
         case .stop:
             handleStop(event)
+        case .userPromptSubmit:
+            handleUserPromptSubmit(event)
         }
     }
 
@@ -84,6 +86,11 @@ public final class SessionMonitor {
     private func handleStop(_ event: SessionEvent) {
         guard activeSession?.id == event.sessionId else { return }
         activeSession?.stop()
+    }
+
+    private func handleUserPromptSubmit(_ event: SessionEvent) {
+        guard activeSession?.id == event.sessionId else { return }
+        activeSession?.resume()
     }
 
     private func endCurrentSession(at date: Date) {

--- a/Sources/Infrastructure/Hooks/HookInstaller.swift
+++ b/Sources/Infrastructure/Hooks/HookInstaller.swift
@@ -26,6 +26,7 @@ public enum HookInstaller {
         "SubagentStart",
         "SubagentStop",
         "Stop",
+        "UserPromptSubmit",
     ]
 
     /// Installs hooks into the Claude settings file.

--- a/Tests/DomainTests/Session/ClaudeSessionTests.swift
+++ b/Tests/DomainTests/Session/ClaudeSessionTests.swift
@@ -146,14 +146,46 @@ struct ClaudeSessionTests {
     // MARK: - Phase Guards
 
     @Test
-    func `subagentStarted is ignored after stopped`() {
+    func `subagentStarted revives a stopped session`() {
         var session = ClaudeSession(id: "test", cwd: "/tmp")
         session.stop()
 
         session.subagentStarted()
 
-        #expect(session.phase == .stopped)
+        #expect(session.phase == .subagentsWorking)
+        #expect(session.activeSubagentCount == 1)
+    }
+
+    @Test
+    func `resume returns a stopped session to active`() {
+        var session = ClaudeSession(id: "test", cwd: "/tmp")
+        session.stop()
+
+        session.resume()
+
+        #expect(session.phase == .active)
         #expect(session.activeSubagentCount == 0)
+    }
+
+    @Test
+    func `resume keeps subagentsWorking when subagents are active`() {
+        var session = ClaudeSession(id: "test", cwd: "/tmp")
+        session.subagentStarted()
+
+        session.resume()
+
+        #expect(session.phase == .subagentsWorking)
+        #expect(session.activeSubagentCount == 1)
+    }
+
+    @Test
+    func `resume is ignored after ended`() {
+        var session = ClaudeSession(id: "test", cwd: "/tmp")
+        session.end()
+
+        session.resume()
+
+        #expect(session.phase == .ended)
     }
 
     @Test

--- a/Tests/DomainTests/Session/SessionEventTests.swift
+++ b/Tests/DomainTests/Session/SessionEventTests.swift
@@ -110,5 +110,6 @@ struct SessionEventTests {
         #expect(SessionEvent.EventName.subagentStart.rawValue == "SubagentStart")
         #expect(SessionEvent.EventName.subagentStop.rawValue == "SubagentStop")
         #expect(SessionEvent.EventName.stop.rawValue == "Stop")
+        #expect(SessionEvent.EventName.userPromptSubmit.rawValue == "UserPromptSubmit")
     }
 }

--- a/Tests/DomainTests/Session/SessionMonitorTests.swift
+++ b/Tests/DomainTests/Session/SessionMonitorTests.swift
@@ -172,6 +172,28 @@ struct SessionMonitorTests {
         #expect(monitor.activeSession?.phase == .active)
     }
 
+    @Test
+    func `UserPromptSubmit revives a stopped session to active`() {
+        let monitor = SessionMonitor()
+
+        monitor.processEvent(makeEvent(eventName: .sessionStart))
+        monitor.processEvent(makeEvent(eventName: .stop))
+        monitor.processEvent(makeEvent(eventName: .userPromptSubmit))
+
+        #expect(monitor.activeSession?.phase == .active)
+    }
+
+    @Test
+    func `UserPromptSubmit for wrong session is ignored`() {
+        let monitor = SessionMonitor()
+
+        monitor.processEvent(makeEvent(sessionId: "session-1", eventName: .sessionStart))
+        monitor.processEvent(makeEvent(sessionId: "session-1", eventName: .stop))
+        monitor.processEvent(makeEvent(sessionId: "other", eventName: .userPromptSubmit))
+
+        #expect(monitor.activeSession?.phase == .stopped)
+    }
+
     // MARK: - Recent Sessions
 
     @Test

--- a/Tests/InfrastructureTests/Hooks/HookInstallerTests.swift
+++ b/Tests/InfrastructureTests/Hooks/HookInstallerTests.swift
@@ -31,7 +31,8 @@ struct HookInstallerTests {
         #expect(events.contains("SubagentStart"))
         #expect(events.contains("SubagentStop"))
         #expect(events.contains("Stop"))
-        #expect(events.count == 6)
+        #expect(events.contains("UserPromptSubmit"))
+        #expect(events.count == 7)
     }
 
     @Test

--- a/Tests/InfrastructureTests/Hooks/SessionEventParserTests.swift
+++ b/Tests/InfrastructureTests/Hooks/SessionEventParserTests.swift
@@ -75,6 +75,17 @@ struct SessionEventParserTests {
     }
 
     @Test
+    func `parses valid UserPromptSubmit event`() {
+        let json = """
+        {"session_id": "test", "hook_event_name": "UserPromptSubmit", "cwd": "/tmp"}
+        """
+
+        let event = SessionEventParser.parse(json.data(using: .utf8)!)
+
+        #expect(event?.eventName == .userPromptSubmit)
+    }
+
+    @Test
     func `returns nil for missing session_id`() {
         let json = """
         {"hook_event_name": "SessionStart", "cwd": "/tmp"}


### PR DESCRIPTION
## Problem

After long idle, the menu-bar status item could get stuck showing a lone colored Claude Code session glyph with **no usage number**, while the dropdown stayed fully live (fresh quota %, actively syncing). Confirmed in the wild via screenshot on a MAX account.

## Root cause

Two issues stacked on top of the #192 imperative driver:

1. **Repaint depended solely on SwiftUI observation.** `StatusItemLabelDriver` consumed the background-refresh stream but ignored it (`for await _ in stream {}`), so the menu-bar image only repainted when the `@Observable` chain fired. After long idle that chain can go quiet even though probes keep succeeding every ~5 min — freezing the image on a stale frame.
2. **`.stopped` was a one-way sink.** Claude Code's `Stop` hook fires at the end of *every* turn, and nothing moved the session back out of `.stopped` (subagent events were guarded; there was no `UserPromptSubmit` hook). So the session glyph stuck on "Stopped" — showing the last repo's name — until `SessionEnd`.

Combined, the frozen frame happened to be the "stopped" glyph with no number.

## Changes

- **Repaint on every refresh tick** — the stream consumer now calls `labelSync.renderNow()` per event, so the menu bar is force-repainted independent of SwiftUI invalidation (dedup in `render()` keeps it cheap/flicker-free).
- **Hide the session glyph unless actively working** — only drawn for `.active`/`.subagentsWorking`; `.stopped`/`.ended` no longer leave a glyph in the menu bar.
- **Recover from `.stopped`** — new `UserPromptSubmit` hook + `ClaudeSession.resume()`; subagent activity also revives a stopped session. Existing users get the new hook via an idempotent launch-time `HookInstaller.install()` reconcile.
- **Keep last-known number** — when the configured quota window is briefly unavailable (cold start / parse gap), keep the previous label instead of blanking, as long as the provider still holds a snapshot.

## Testing

- New/updated unit tests: phase transitions (`Stop → UserPromptSubmit → active`, subagent revive, `resume`), `UserPromptSubmit` parse + hook registration, event count.
- `tuist test` — full suite green (Domain + Infrastructure + AcceptanceTests).
- Ran the patched build live for several days — issue did not recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Menu bar now repaints on every background refresh and displays session glyph only during active work.
  * Last-known usage value is preserved when quota information is temporarily unavailable.
  * Claude Code sessions now recover from a stopped state when users submit a new prompt.
  * Hook events now automatically reconcile on startup for existing users without requiring manual settings changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->