### PR TITLE
ci: fix Build/Release by using the runner's bundled Xcode toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,6 @@ on:
     branches: [main, develop]
 
 
-env:
-  SWIFT_VERSION: "6.2"
-
 jobs:
   build:
     name: Build and Verify
@@ -19,10 +16,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Swift
-        uses: SwiftyLab/setup-swift@latest
-        with:
-          swift-version: ${{ env.SWIFT_VERSION }}
+      # No explicit Swift toolchain setup: use the runner's bundled Xcode, the
+      # same toolchain Tuist builds its macro prebuilts (SwiftSyntax) against.
+      # Installing a separate toolchain via SwiftyLab/setup-swift drifted out of
+      # sync with those prebuilts and broke the Release build ("SwiftSyntax was
+      # created for incompatible target"). Mirrors the passing tests.yml.
 
       - name: Install Tuist
         run: brew install --cask tuist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,6 @@ permissions:
 env:
   APP_NAME: ClaudeBar
   BUNDLE_ID: com.tddworks.claudebar
-  SWIFT_VERSION: "6.2"
 
 jobs:
   release:
@@ -42,10 +41,11 @@ jobs:
         with:
           fetch-depth: 0  # Full history for accurate build number
 
-      - name: Setup Swift
-        uses: SwiftyLab/setup-swift@latest
-        with:
-          swift-version: ${{ env.SWIFT_VERSION }}
+      # No explicit Swift toolchain setup: use the runner's bundled Xcode, the
+      # same toolchain Tuist builds its macro prebuilts (SwiftSyntax) against.
+      # Installing a separate toolchain via SwiftyLab/setup-swift drifted out of
+      # sync with those prebuilts and broke the build ("SwiftSyntax was created
+      # for incompatible target").
 
       - name: Install Tuist
         run: brew install tuist


### PR DESCRIPTION
## Problem

The **Build and Verify** job has been failing on `main` for every push and PR since 2026-06-13, with:

```
error: module 'SwiftSyntax' was created for incompatible target aarch64-apple-macosx10.15:
…/Tuist/.build/prebuilts/swift-syntax/602.0.0/swiftlang-6.2.4.1.4-MacroSupport-macos_aarch64/…
```

It is **not caused by any source change** — the same commit passed as a PR on 06-12 and failed as a `main` push on 06-13 (identical tree, ~24h apart). The variable is the CI toolchain.

## Root cause

`build.yml` and `release.yml` install a *separate* Swift toolchain via `SwiftyLab/setup-swift@latest` pinned to `"6.2"`. When that resolves to a 6.2.x build different from the one Tuist's cached `SwiftSyntax` macro prebuilt (used by `Mockable`) was built with (`swiftlang-6.2.4.1.4`), `xcodebuild` rejects the module as an incompatible target.

The already-green **`tests.yml`** does **not** use `setup-swift` — it builds with the runner's bundled Xcode, which matches the toolchain Tuist's prebuilts expect. That's why Unit Tests pass while Build/Release fail on the same commit.

## Fix

Remove the `Setup Swift` step (and the now-unused `SWIFT_VERSION` env) from `build.yml` and `release.yml` so they use the runner's bundled Xcode — mirroring the passing `tests.yml`. Minimal, no source changes.

## Verification

- YAML validated locally.
- This PR's own **Build and Verify** run is the test: if it goes green, the fix is confirmed.
- Unblocks #213 (and all other PRs) once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified build and release workflows to use the system's default Swift toolchain instead of installing a separate version, improving workflow efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->