### PR TITLE
fix(providers): isolate provider observable state to the main actor (fixes crash)

### DIFF
--- a/Sources/App/Views/MenuContentView.swift
+++ b/Sources/App/Views/MenuContentView.swift
@@ -714,9 +714,12 @@ struct MenuContentView: View {
     /// Refresh all enabled providers concurrently
     private func refreshAllEnabled() async {
         await withTaskGroup(of: Void.self) { group in
-            for provider in monitor.enabledProviders {
+            // The `isSyncing` guard reads main-actor provider state, so evaluate
+            // it here on the main actor (this closure inherits the caller's
+            // isolation). Each child task then awaits `refresh()`, whose heavy
+            // probe work still suspends off-main, keeping the refreshes concurrent.
+            for provider in monitor.enabledProviders where !provider.isSyncing {
                 group.addTask {
-                    guard !provider.isSyncing else { return }
                     do {
                         try await provider.refresh()
                     } catch {

--- a/Sources/App/Views/ProviderVisualIdentity.swift
+++ b/Sources/App/Views/ProviderVisualIdentity.swift
@@ -7,6 +7,10 @@ import Domain
 /// Each concrete provider implements this to own its visual representation.
 /// This keeps visual properties with the provider (rich domain) while
 /// separating SwiftUI dependencies from the Domain layer.
+///
+/// `@MainActor` because the conformers are now main-actor-isolated providers and every
+/// witness is SwiftUI-facing (`Color`/`LinearGradient`, read from views on the main actor).
+@MainActor
 public protocol ProviderVisualIdentity {
     /// SF Symbol icon name for this provider
     var symbolIcon: String { get }

--- a/Sources/Domain/Extension/ExtensionProvider.swift
+++ b/Sources/Domain/Extension/ExtensionProvider.swift
@@ -2,8 +2,9 @@ import Foundation
 
 /// An AIProvider backed by an extension manifest and script-based probes.
 /// Each section has its own probe; refresh runs all probes and merges results.
+@MainActor
 @Observable
-public final class ExtensionProvider: AIProvider, @unchecked Sendable {
+public final class ExtensionProvider: AIProvider {
     // MARK: - Identity
 
     public let id: String

--- a/Sources/Domain/Provider/AIProvider.swift
+++ b/Sources/Domain/Provider/AIProvider.swift
@@ -14,7 +14,13 @@ public enum RefreshKind: Sendable {
 /// Protocol defining what an AI provider is.
 /// Each provider (Claude, Codex, Gemini) is a rich domain model implementing this protocol.
 /// Providers are @Observable classes with their own state (isSyncing, snapshot, error).
-/// Providers must be Sendable (use @unchecked Sendable for @Observable classes).
+///
+/// `@MainActor` isolates the observable state (isSyncing/snapshot/lastError) to the main
+/// actor so its cheap writes land on the same thread the readers (QuotaMonitor, SwiftUI)
+/// run on. The heavy probe work stays off-main: `refresh()` suspends at the non-isolated
+/// `await probe.probe()`, which runs on the global executor. A `@MainActor` class is
+/// implicitly Sendable, so conformers no longer need `@unchecked Sendable`.
+@MainActor
 public protocol AIProvider: AnyObject, Sendable, Identifiable where ID == String {
     // MARK: - Identity
 

--- a/Sources/Domain/Provider/AIProviderRepository.swift
+++ b/Sources/Domain/Provider/AIProviderRepository.swift
@@ -3,7 +3,13 @@ import Mockable
 
 /// Repository protocol for AI providers.
 /// Defines the interface for managing a collection of providers.
+///
+/// `@MainActor`-isolated because its members vend/inspect `any AIProvider` (now
+/// main-actor-isolated): `enabled` reads each provider's `isEnabled`, `provider(id:)`
+/// reads `id`. The sole conformer (`AIProviders`) and sole holder (`QuotaMonitor`) are
+/// both already main-isolated.
 @Mockable
+@MainActor
 public protocol AIProviderRepository: AnyObject, Sendable {
     /// All registered providers
     var all: [any AIProvider] { get }

--- a/Sources/Domain/Provider/Alibaba/AlibabaProvider.swift
+++ b/Sources/Domain/Provider/Alibaba/AlibabaProvider.swift
@@ -3,8 +3,9 @@ import Observation
 
 /// Alibaba Coding Plan AI provider - a rich domain model.
 /// Observable class with its own state (isSyncing, snapshot, error).
+@MainActor
 @Observable
-public final class AlibabaProvider: AIProvider, @unchecked Sendable {
+public final class AlibabaProvider: AIProvider {
     // MARK: - Identity
 
     public let id: String = "alibaba"

--- a/Sources/Domain/Provider/AmpCode/AmpCodeProvider.swift
+++ b/Sources/Domain/Provider/AmpCode/AmpCodeProvider.swift
@@ -4,8 +4,9 @@ import Observation
 /// AmpCode AI provider (by Sourcegraph).
 /// Observable class with its own state (isSyncing, snapshot, error).
 /// Owns its probe and manages its own data lifecycle.
+@MainActor
 @Observable
-public final class AmpCodeProvider: AIProvider, @unchecked Sendable {
+public final class AmpCodeProvider: AIProvider {
 
     // MARK: - Identity
 

--- a/Sources/Domain/Provider/Antigravity/AntigravityProvider.swift
+++ b/Sources/Domain/Provider/Antigravity/AntigravityProvider.swift
@@ -4,8 +4,9 @@ import Observation
 /// Antigravity AI provider - a rich domain model.
 /// Observable class with its own state (isSyncing, snapshot, error).
 /// Owns its probe and manages its own data lifecycle.
+@MainActor
 @Observable
-public final class AntigravityProvider: AIProvider, @unchecked Sendable {
+public final class AntigravityProvider: AIProvider {
     // MARK: - Identity (Protocol Requirement)
 
     public let id: String = "antigravity"

--- a/Sources/Domain/Provider/Bedrock/BedrockProvider.swift
+++ b/Sources/Domain/Provider/Bedrock/BedrockProvider.swift
@@ -4,8 +4,9 @@ import Observation
 /// AWS Bedrock AI provider - a rich domain model.
 /// Observable class with its own state (isSyncing, snapshot, error).
 /// Monitors Bedrock usage via CloudWatch metrics and calculates costs.
+@MainActor
 @Observable
-public final class BedrockProvider: AIProvider, @unchecked Sendable {
+public final class BedrockProvider: AIProvider {
     // MARK: - Identity (Protocol Requirement)
 
     public let id: String = "bedrock"

--- a/Sources/Domain/Provider/Claude/ClaudeProvider.swift
+++ b/Sources/Domain/Provider/Claude/ClaudeProvider.swift
@@ -4,8 +4,9 @@ import Observation
 /// Claude AI provider - a rich domain model.
 /// Observable class with its own state (isSyncing, snapshot, error).
 /// Supports dual probe modes: CLI (default) and API.
+@MainActor
 @Observable
-public final class ClaudeProvider: AIProvider, @unchecked Sendable {
+public final class ClaudeProvider: AIProvider {
     // MARK: - Identity (Protocol Requirement)
 
     public let id: String = "claude"

--- a/Sources/Domain/Provider/Codex/CodexProvider.swift
+++ b/Sources/Domain/Provider/Codex/CodexProvider.swift
@@ -4,8 +4,9 @@ import Observation
 /// Codex AI provider - a rich domain model.
 /// Observable class with its own state (isSyncing, snapshot, error).
 /// Supports dual probe modes: RPC (default) and API.
+@MainActor
 @Observable
-public final class CodexProvider: AIProvider, @unchecked Sendable {
+public final class CodexProvider: AIProvider {
     // MARK: - Identity
 
     public let id: String = "codex"

--- a/Sources/Domain/Provider/Copilot/CopilotProvider.swift
+++ b/Sources/Domain/Provider/Copilot/CopilotProvider.swift
@@ -5,8 +5,9 @@ import Observation
 /// Observable class with its own state (isSyncing, snapshot, error).
 /// Supports dual probe modes: Billing API (default) and Copilot Internal API.
 /// Owns its probe, credentials, and manages its own data lifecycle.
+@MainActor
 @Observable
-public final class CopilotProvider: AIProvider, @unchecked Sendable {
+public final class CopilotProvider: AIProvider {
     // MARK: - Identity (Protocol Requirement)
 
     public let id: String = "copilot"

--- a/Sources/Domain/Provider/Cursor/CursorProvider.swift
+++ b/Sources/Domain/Provider/Cursor/CursorProvider.swift
@@ -3,8 +3,9 @@ import Observation
 
 /// Cursor AI provider - a rich domain model.
 /// Observable class with its own state (isSyncing, snapshot, error).
+@MainActor
 @Observable
-public final class CursorProvider: AIProvider, @unchecked Sendable {
+public final class CursorProvider: AIProvider {
     // MARK: - Identity (Protocol Requirement)
 
     public let id: String = "cursor"

--- a/Sources/Domain/Provider/Gemini/GeminiProvider.swift
+++ b/Sources/Domain/Provider/Gemini/GeminiProvider.swift
@@ -3,8 +3,9 @@ import Observation
 
 /// Gemini AI provider - a rich domain model.
 /// Observable class with its own state (isSyncing, snapshot, error).
+@MainActor
 @Observable
-public final class GeminiProvider: AIProvider, @unchecked Sendable {
+public final class GeminiProvider: AIProvider {
     // MARK: - Identity
 
     public let id: String = "gemini"

--- a/Sources/Domain/Provider/Kimi/KimiProvider.swift
+++ b/Sources/Domain/Provider/Kimi/KimiProvider.swift
@@ -4,8 +4,9 @@ import Observation
 /// Kimi AI provider - a rich domain model.
 /// Observable class with its own state (isSyncing, snapshot, error).
 /// Supports dual probe modes: CLI (default) and API.
+@MainActor
 @Observable
-public final class KimiProvider: AIProvider, @unchecked Sendable {
+public final class KimiProvider: AIProvider {
     // MARK: - Identity (Protocol Requirement)
 
     public let id: String = "kimi"

--- a/Sources/Domain/Provider/Kiro/KiroProvider.swift
+++ b/Sources/Domain/Provider/Kiro/KiroProvider.swift
@@ -3,8 +3,9 @@ import Observation
 
 /// Kiro AI provider - a rich domain model.
 /// Observable class with its own state (isSyncing, snapshot, error).
+@MainActor
 @Observable
-public final class KiroProvider: AIProvider, @unchecked Sendable {
+public final class KiroProvider: AIProvider {
     // MARK: - Identity (Protocol Requirement)
 
     public let id: String = "kiro"

--- a/Sources/Domain/Provider/MiniMax/MiniMaxProvider.swift
+++ b/Sources/Domain/Provider/MiniMax/MiniMaxProvider.swift
@@ -4,8 +4,9 @@ import Observation
 /// MiniMax AI provider - a rich domain model.
 /// Observable class with its own state (isSyncing, snapshot, error).
 /// Owns its probe and manages its own data lifecycle.
+@MainActor
 @Observable
-public final class MiniMaxProvider: AIProvider, @unchecked Sendable {
+public final class MiniMaxProvider: AIProvider {
     // MARK: - Identity (Protocol Requirement)
 
     public let id: String = "minimax"

--- a/Sources/Domain/Provider/Mistral/MistralProvider.swift
+++ b/Sources/Domain/Provider/Mistral/MistralProvider.swift
@@ -4,8 +4,9 @@ import Observation
 /// Mistral AI provider - a rich domain model.
 /// Observable class with its own state (isSyncing, snapshot, error).
 /// Owns its probe and manages its own data lifecycle.
+@MainActor
 @Observable
-public final class MistralProvider: AIProvider, @unchecked Sendable {
+public final class MistralProvider: AIProvider {
     // MARK: - Identity (Protocol Requirement)
 
     public let id: String = "mistral"

--- a/Sources/Domain/Provider/OpenCode/OpenCodeProvider.swift
+++ b/Sources/Domain/Provider/OpenCode/OpenCodeProvider.swift
@@ -2,8 +2,9 @@ import Foundation
 import Observation
 
 /// OpenCode Go — monitors 5h ($12), weekly ($30), monthly ($60) usage from local opencode DB.
+@MainActor
 @Observable
-public final class OpenCodeProvider: AIProvider, @unchecked Sendable {
+public final class OpenCodeProvider: AIProvider {
     // MARK: - Identity
 
     public let id: String = "opencode-go"

--- a/Sources/Domain/Provider/Zai/ZaiProvider.swift
+++ b/Sources/Domain/Provider/Zai/ZaiProvider.swift
@@ -4,8 +4,9 @@ import Observation
 /// Z.ai (GLM Coding Plan) provider - a rich domain model.
 /// Z.ai provides an API-compatible replacement for Anthropic's API,
 /// offering GLM-4.7 models with generous usage quotas.
+@MainActor
 @Observable
-public final class ZaiProvider: AIProvider, @unchecked Sendable {
+public final class ZaiProvider: AIProvider {
     // MARK: - Identity (Protocol Requirement)
 
     public let id: String = "zai"

--- a/Sources/Infrastructure/Storage/AIProviders.swift
+++ b/Sources/Infrastructure/Storage/AIProviders.swift
@@ -4,8 +4,14 @@ import Domain
 
 /// Repository of AI providers.
 /// Observable class that provides access to all providers and filters by enabled state.
+///
+/// `@MainActor`-isolated to match the now main-actor-isolated `AIProviderRepository` /
+/// `AIProvider`: `enabled` reads each provider's `isEnabled` and `provider(id:)`/`add`
+/// read `id`. Every call site (`QuotaMonitor`, `App.init`, SwiftUI previews) is already on
+/// the main actor, so this adds no hops. A `@MainActor` class is implicitly `Sendable`.
+@MainActor
 @Observable
-public final class AIProviders: AIProviderRepository, @unchecked Sendable {
+public final class AIProviders: AIProviderRepository {
     // MARK: - All Providers
 
     /// All registered providers

--- a/Tests/AcceptanceTests/ActionBarSpec.swift
+++ b/Tests/AcceptanceTests/ActionBarSpec.swift
@@ -17,6 +17,7 @@ struct ActionBarSpec {
     // MARK: - #24: Dashboard URLs
 
     @Suite("Scenario: Dashboard opens correct URL per provider")
+    @MainActor
     struct DashboardURLs {
 
         private static func makeSettings() -> MockProviderSettingsRepository {
@@ -76,6 +77,7 @@ struct ActionBarSpec {
     // MARK: - #25: Claude guest passes
 
     @Suite("Scenario: Share Claude Code guest passes")
+    @MainActor
     struct GuestPasses {
 
         @Test

--- a/Tests/AcceptanceTests/BedrockConfigSpec.swift
+++ b/Tests/AcceptanceTests/BedrockConfigSpec.swift
@@ -109,6 +109,7 @@ struct BedrockConfigSpec {
     // MARK: - Provider defaults to disabled
 
     @Suite("Scenario: Bedrock provider defaults")
+    @MainActor
     struct ProviderDefaults {
 
         @Test

--- a/Tests/AcceptanceTests/CopilotConfigSpec.swift
+++ b/Tests/AcceptanceTests/CopilotConfigSpec.swift
@@ -42,6 +42,7 @@ struct CopilotConfigSpec {
     // MARK: - #35: Authentication and credential management
 
     @Suite("Scenario: Copilot authentication")
+    @MainActor
     struct Authentication {
 
         @Test

--- a/Tests/AcceptanceTests/ThemesSpec.swift
+++ b/Tests/AcceptanceTests/ThemesSpec.swift
@@ -23,6 +23,7 @@ struct ThemesSpec {
     // MARK: - #49: Each provider has distinct identity for themed display
 
     @Suite("Scenario: Provider identity for themed display")
+    @MainActor
     struct ProviderIdentity {
 
         private static func makeSettings() -> MockProviderSettingsRepository {

--- a/Tests/AcceptanceTests/UpdatesSpec.swift
+++ b/Tests/AcceptanceTests/UpdatesSpec.swift
@@ -23,6 +23,7 @@ struct UpdatesSpec {
     // MARK: - Placeholder for App-layer update tests
 
     @Suite("Scenario: Update infrastructure")
+    @MainActor
     struct UpdateInfrastructure {
 
         @Test

--- a/Tests/AcceptanceTests/ZaiConfigSpec.swift
+++ b/Tests/AcceptanceTests/ZaiConfigSpec.swift
@@ -41,6 +41,7 @@ struct ZaiConfigSpec {
     // MARK: - #42: Environment variable fallback
 
     @Suite("Scenario: Environment variable fallback")
+    @MainActor
     struct EnvVarFallback {
 
         @Test

--- a/Tests/DomainTests/Extension/ExtensionProviderTests.swift
+++ b/Tests/DomainTests/Extension/ExtensionProviderTests.swift
@@ -4,6 +4,7 @@ import Mockable
 @testable import Domain
 
 @Suite
+@MainActor
 struct ExtensionProviderTests {
     // MARK: - Identity
 

--- a/Tests/DomainTests/Provider/AIProviderProtocolTests.swift
+++ b/Tests/DomainTests/Provider/AIProviderProtocolTests.swift
@@ -5,6 +5,7 @@ import Mockable
 
 /// Cross-provider tests that verify the AIProvider protocol contract across all providers.
 @Suite("AIProvider Cross-Provider Tests")
+@MainActor
 struct AIProviderProtocolTests {
 
     private func makeSettingsRepository() -> MockProviderSettingsRepository {

--- a/Tests/DomainTests/Provider/AIProvidersTests.swift
+++ b/Tests/DomainTests/Provider/AIProvidersTests.swift
@@ -5,6 +5,7 @@ import Mockable
 @testable import Infrastructure
 
 @Suite
+@MainActor
 struct AIProvidersTests {
 
     /// Creates a mock settings repository that returns true for all providers

--- a/Tests/DomainTests/Provider/Antigravity/AntigravityProviderTests.swift
+++ b/Tests/DomainTests/Provider/Antigravity/AntigravityProviderTests.swift
@@ -5,6 +5,7 @@ import Mockable
 @testable import Infrastructure
 
 @Suite("AntigravityProvider Tests")
+@MainActor
 struct AntigravityProviderTests {
 
     /// Creates a mock settings repository that returns true for all providers

--- a/Tests/DomainTests/Provider/Claude/ClaudeProviderDailyUsageTests.swift
+++ b/Tests/DomainTests/Provider/Claude/ClaudeProviderDailyUsageTests.swift
@@ -4,6 +4,7 @@ import Mockable
 @testable import Domain
 
 @Suite
+@MainActor
 struct ClaudeProviderDailyUsageTests {
 
     private func makeSettingsRepository() -> MockProviderSettingsRepository {

--- a/Tests/DomainTests/Provider/Claude/ClaudeProviderPassTests.swift
+++ b/Tests/DomainTests/Provider/Claude/ClaudeProviderPassTests.swift
@@ -4,6 +4,7 @@ import Mockable
 @testable import Domain
 
 @Suite
+@MainActor
 struct ClaudeProviderPassTests {
 
     /// Creates a mock settings repository that returns true for all providers

--- a/Tests/DomainTests/Provider/Claude/ClaudeProviderTests.swift
+++ b/Tests/DomainTests/Provider/Claude/ClaudeProviderTests.swift
@@ -4,6 +4,7 @@ import Mockable
 @testable import Domain
 
 @Suite("ClaudeProvider Tests")
+@MainActor
 struct ClaudeProviderTests {
 
     private func makeSettingsRepository() -> MockProviderSettingsRepository {

--- a/Tests/DomainTests/Provider/Codex/CodexProviderTests.swift
+++ b/Tests/DomainTests/Provider/Codex/CodexProviderTests.swift
@@ -4,6 +4,7 @@ import Mockable
 @testable import Domain
 
 @Suite("CodexProvider Tests")
+@MainActor
 struct CodexProviderTests {
 
     private func makeSettingsRepository() -> MockProviderSettingsRepository {

--- a/Tests/DomainTests/Provider/Copilot/CopilotProviderTests.swift
+++ b/Tests/DomainTests/Provider/Copilot/CopilotProviderTests.swift
@@ -5,6 +5,7 @@ import Mockable
 @testable import Infrastructure
 
 @Suite("CopilotProvider Tests")
+@MainActor
 struct CopilotProviderTests {
 
     // MARK: - Test Helper

--- a/Tests/DomainTests/Provider/Gemini/GeminiProviderTests.swift
+++ b/Tests/DomainTests/Provider/Gemini/GeminiProviderTests.swift
@@ -4,6 +4,7 @@ import Mockable
 @testable import Domain
 
 @Suite("GeminiProvider Tests")
+@MainActor
 struct GeminiProviderTests {
 
     private func makeSettingsRepository() -> MockProviderSettingsRepository {

--- a/Tests/DomainTests/Provider/Kimi/KimiProviderTests.swift
+++ b/Tests/DomainTests/Provider/Kimi/KimiProviderTests.swift
@@ -5,6 +5,7 @@ import Mockable
 @testable import Infrastructure
 
 @Suite("KimiProvider Tests")
+@MainActor
 struct KimiProviderTests {
 
     /// Creates a mock settings repository that returns true for all providers

--- a/Tests/DomainTests/Provider/Zai/ZaiProviderTests.swift
+++ b/Tests/DomainTests/Provider/Zai/ZaiProviderTests.swift
@@ -5,6 +5,7 @@ import Mockable
 @testable import Infrastructure
 
 @Suite("ZaiProvider Tests")
+@MainActor
 struct ZaiProviderTests {
 
     // MARK: - Identity Tests

--- a/Tests/InfrastructureTests/Alibaba/AlibabaProviderTests.swift
+++ b/Tests/InfrastructureTests/Alibaba/AlibabaProviderTests.swift
@@ -5,6 +5,7 @@ import Mockable
 @testable import Domain
 
 @Suite
+@MainActor
 struct AlibabaProviderTests {
 
     private func makeSettingsRepository() -> UserDefaultsProviderSettingsRepository {


### PR DESCRIPTION
## Problem

ClaudeBar crashed with `EXC_BREAKPOINT` / `SIGTRAP` — an **over-release of a `UsageSnapshot`** on the main thread (crash backtrace: `_CFRelease` → `destroy for UsageSnapshot` → `QuotaMonitor.quota` → `menuBarLabel` → `StatusItemLabelDriver.currentLabelContent` → `ObservationRenderSync.sync`). It was intermittent (once after days of uptime) — the signature of a **data race**.

## Root cause

All providers were `final class XProvider: AIProvider, @unchecked Sendable` with unsynchronized observable state. Their `refresh(_:)` writes `isSyncing` / `snapshot` / `lastError` **off the main thread**, while `QuotaMonitor` (`@MainActor`), the menu-bar label, and SwiftUI read `snapshot` **on the main thread**. Concurrent read/release of the snapshot struct's reference-counted storage corrupts the retain count → over-release. The `@unchecked Sendable` annotation hid the missing synchronization.

## Fix

Isolate provider observable state to the main actor:

- `@MainActor` on `AIProvider`, `AIProviderRepository`, `AIProviders`, `ExtensionProvider`, and all 16 conformers; dropped `@unchecked Sendable` (a `@MainActor` class is implicitly `Sendable`).
- **Heavy work stays off-main:** `refresh()` suspends at the non-isolated `await probe.probe()` — `UsageProbe` and `DailyUsageAnalyzing` remain `Sendable`/non-isolated, so the CLI/HTTP/JSONL work runs on the global executor; only the cheap state assignment resumes on main. No regression to the #182/#204 keep-work-off-main goal.
- `@MainActor` on `ProviderVisualIdentity` (the SwiftUI protocol providers conform to).
- `MenuContentView.refreshAllEnabled`: moved the `isSyncing` guard into the `for … where` clause so the `withTaskGroup` child task stays a plain `await provider.refresh()` (no main-actor capture inside the task).

## Tests

Added `@MainActor` to the provider Swift Testing suites and the nested Acceptance scenario structs that construct providers (`@MainActor` does not propagate to nested types).

## Verification

- `tuist build ClaudeBar` — green.
- Full `tuist test ClaudeBar` — green.
- Thread Sanitizer — clean run validated on this exact change set (no data races).

## Notes

Follow-up to #213 / #214 (already merged). This race pre-dates #213; #213's repaint-on-every-tick likely increased its frequency but did not create it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved refresh handling to avoid duplicate concurrent updates and keep refreshes running safely in parallel.
  * Tightened actor isolation across provider-related components for more reliable UI and state updates.

* **Tests**
  * Updated provider and acceptance test suites to run on the main actor for better consistency.

* **Refactor**
  * Standardized concurrency annotations across provider and repository types, simplifying thread-safety behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->