### PR TITLE
feat(claude): show the Fable weekly limit and fix /usage parsing for tall screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Claude Fable 5 weekly limit is now parsed from both the CLI `/usage` output
+  ("Current week (Fable)") and the OAuth usage API's new `limits` array, shown as a
+  quota card in the window and selectable as a menu-bar metric. The API-side parsing
+  is generic over model-scoped limits, so future scoped models appear automatically.
+
+### Fixed
+- Claude CLI probe no longer fails on every tick with recent Claude CLI versions.
+  The `/usage` screen grew taller than the probe's 50-row terminal (usage-contribution
+  report), scrolling the quota sections off the visible screen; the terminal renderer
+  now includes scrollback, so all sections are parsed again.
+
 ---
 
 ## [0.4.69] - 2026-06-25

--- a/Sources/Infrastructure/Claude/ClaudeAPIUsageProbe.swift
+++ b/Sources/Infrastructure/Claude/ClaudeAPIUsageProbe.swift
@@ -471,6 +471,38 @@ public struct ClaudeAPIUsageProbe: UsageProbe, @unchecked Sendable {
             ))
         }
 
+        // Parse model-scoped limits from the generic `limits` array (e.g. Fable).
+        // Session/weekly entries there mirror `five_hour`/`seven_day` and are
+        // skipped; a model already covered by a legacy field is not duplicated.
+        // If the legacy `five_hour`/`seven_day` fields ever go null (as
+        // `seven_day_opus`/`seven_day_sonnet` did), extend this loop to the
+        // `session`/`weekly_all` kinds.
+        for entry in response.limits ?? [] {
+            guard entry.kind == "weekly_scoped",
+                  // Key on the first word of the display name ("Fable 5" -> "fable")
+                  // — must stay in sync with the key the CLI probe hardcodes so a
+                  // persisted "model:<name>" menu-bar selection survives switching
+                  // probe modes.
+                  let modelName = entry.scope?.model?.displayName?
+                      .split(separator: " ").first.map({ $0.lowercased() }),
+                  !modelName.isEmpty,
+                  let percent = entry.percent else {
+                continue
+            }
+            let quotaType = QuotaType.modelSpecific(modelName)
+            guard !quotas.contains(where: { $0.quotaType == quotaType }) else {
+                continue
+            }
+            let resetsAt = parseISODate(entry.resetsAt)
+            quotas.append(UsageQuota(
+                percentRemaining: 100.0 - percent,
+                quotaType: quotaType,
+                providerId: "claude",
+                resetsAt: resetsAt,
+                resetText: formatResetText(resetsAt)
+            ))
+        }
+
         // Parse extra usage
         // API returns used_credits and monthly_limit in cents, convert to dollars
         var costUsage: CostUsage?
@@ -586,6 +618,7 @@ private struct UsageResponse: Decodable {
     let sevenDaySonnet: UsageQuotaData?
     let sevenDayOpus: UsageQuotaData?
     let extraUsage: ExtraUsageData?
+    let limits: [LimitEntry]?
 
     enum CodingKeys: String, CodingKey {
         case fiveHour = "five_hour"
@@ -593,6 +626,36 @@ private struct UsageResponse: Decodable {
         case sevenDaySonnet = "seven_day_sonnet"
         case sevenDayOpus = "seven_day_opus"
         case extraUsage = "extra_usage"
+        case limits
+    }
+}
+
+/// Entry in the newer generic `limits` array. Model-scoped limits (e.g. Fable)
+/// are reported here as `kind: "weekly_scoped"` with the model in `scope`,
+/// instead of dedicated `seven_day_<model>` fields.
+private struct LimitEntry: Decodable {
+    let kind: String?
+    let percent: Double?
+    let resetsAt: String?
+    let scope: LimitScope?
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case percent
+        case resetsAt = "resets_at"
+        case scope
+    }
+}
+
+private struct LimitScope: Decodable {
+    let model: LimitScopeModel?
+}
+
+private struct LimitScopeModel: Decodable {
+    let displayName: String?
+
+    enum CodingKeys: String, CodingKey {
+        case displayName = "display_name"
     }
 }
 

--- a/Sources/Infrastructure/Claude/ClaudeUsageProbe.swift
+++ b/Sources/Infrastructure/Claude/ClaudeUsageProbe.swift
@@ -290,12 +290,14 @@ public final class ClaudeUsageProbe: UsageProbe, @unchecked Sendable {
         // Extract percentages
         let sessionPct = extractPercent(labelSubstring: "Current session", text: clean)
         let weeklyPct = extractPercent(labelSubstring: "Current week (all models)", text: clean)
-        // Check for model-specific quota (Opus or Sonnet)
+        // Check for model-specific quota (Opus, Sonnet, or Fable)
         let opusPct = extractPercent(labelSubstring: "Current week (Opus)", text: clean)
         let sonnetPct = extractPercent(labelSubstrings: [
             "Current week (Sonnet only)",
             "Current week (Sonnet)",
         ], text: clean)
+        // Paren-open anchor also matches a future "Current week (Fable 5)" label
+        let fablePct = extractPercent(labelSubstring: "Current week (Fable", text: clean)
 
         guard let sessionPct else {
             AppLog.probes.error("Claude parse failed: could not find 'Current session' percentage in output")
@@ -346,6 +348,21 @@ public final class ClaudeUsageProbe: UsageProbe, @unchecked Sendable {
                 providerId: "claude",
                 resetsAt: parseResetDate(weeklyReset),
                 resetText: cleanResetText(weeklyReset)
+            ))
+        }
+
+        if let fablePct {
+            // Promotional Fable window can reset at a different time than the
+            // all-models weekly, so anchor on its own section before falling back.
+            // The model key must match what the API probe derives from the scoped
+            // limit's display name ("fable").
+            let fableReset = extractReset(labelSubstring: "Current week (Fable", text: clean) ?? weeklyReset
+            quotas.append(UsageQuota(
+                percentRemaining: Double(fablePct),
+                quotaType: .modelSpecific("fable"),
+                providerId: "claude",
+                resetsAt: parseResetDate(fableReset),
+                resetText: cleanResetText(fableReset)
             ))
         }
 

--- a/Sources/Infrastructure/Shared/TerminalRenderer.swift
+++ b/Sources/Infrastructure/Shared/TerminalRenderer.swift
@@ -25,6 +25,11 @@ public final class TerminalRenderer {
     private let cols: Int
     private let rows: Int
 
+    /// Scrollback capacity in lines. Output longer than `rows + scrollback`
+    /// loses its OLDEST lines — for `claude /usage` that's the quota sections
+    /// at the top, so keep this comfortably above the tallest known screen.
+    private let scrollback = 2000
+
     /// Creates a terminal renderer with the specified dimensions.
     /// - Parameters:
     ///   - cols: Number of columns (default: 160)
@@ -41,7 +46,7 @@ public final class TerminalRenderer {
     public func render(_ raw: String) -> String {
         let delegate = RenderDelegate()
         // Enable convertEol to handle \n as \r\n (newline + carriage return)
-        let options = TerminalOptions(cols: cols, rows: rows, convertEol: true)
+        let options = TerminalOptions(cols: cols, rows: rows, convertEol: true, scrollback: scrollback)
         let terminal = Terminal(delegate: delegate, options: options)
 
         // Feed the raw output to the terminal emulator
@@ -51,14 +56,19 @@ public final class TerminalRenderer {
         return extractScreenText(from: terminal)
     }
 
-    /// Extracts text content from the terminal buffer.
+    /// Extracts text content from the terminal buffer, including scrollback.
+    ///
+    /// Output taller than the terminal (e.g. `claude /usage`'s usage-contribution
+    /// report) scrolls its earlier lines off the visible screen into scrollback;
+    /// reading only the visible rows would silently drop them.
     private func extractScreenText(from terminal: Terminal) -> String {
         var lines: [String] = []
 
-        // Iterate through all lines in the terminal buffer
-        for row in 0..<rows {
-            guard let line = terminal.getLine(row: row) else {
-                lines.append("")
+        // Iterate the whole buffer (scrollback + visible screen).
+        // getScrollInvariantLine returns nil past the end of the buffer, and
+        // for rows trimmed off the front when scrollback overflows.
+        for row in 0..<(rows + scrollback) {
+            guard let line = terminal.getScrollInvariantLine(row: row) else {
                 continue
             }
 

--- a/Tests/DomainTests/Provider/QuotaTypeTests.swift
+++ b/Tests/DomainTests/Provider/QuotaTypeTests.swift
@@ -25,6 +25,15 @@ struct QuotaTypeTests {
     }
 
     @Test
+    func `fable quota key round trips through persistence`() {
+        let fable = QuotaType.modelSpecific("fable")
+        #expect(fable.displayName == "Fable")
+        #expect(fable.shortLabel == "Fable")
+        #expect(fable.quotaKey == "model:fable")
+        #expect(QuotaType(quotaKey: "model:fable") == fable)
+    }
+
+    @Test
     func `model specific quota handles multi-word names`() {
         // .capitalized capitalizes each word
         #expect(QuotaType.modelSpecific("claude-3-opus").displayName == "Claude-3-Opus")

--- a/Tests/InfrastructureTests/Claude/ClaudeAPIUsageProbeTests.swift
+++ b/Tests/InfrastructureTests/Claude/ClaudeAPIUsageProbeTests.swift
@@ -426,6 +426,148 @@ struct ClaudeAPIUsageProbeTests {
     }
 
     @Test
+    func `probe parses fable quota from scoped limits array`() async throws {
+        let tempDir = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let futureExpiry = Date().addingTimeInterval(3600).timeIntervalSince1970 * 1000
+        try createCredentialsFile(at: tempDir, expiresAt: futureExpiry)
+
+        let mockNetwork = MockNetworkClient()
+        // Newer API responses report model limits via a generic "limits" array
+        // (kind "weekly_scoped" + scope.model.display_name) instead of
+        // dedicated seven_day_<model> fields.
+        let responseJSON = """
+        {
+          "five_hour": { "utilization": 23.0, "resets_at": "2026-07-02T07:09:59Z" },
+          "seven_day": { "utilization": 10.0, "resets_at": "2026-07-02T10:59:59Z" },
+          "seven_day_opus": null,
+          "seven_day_sonnet": null,
+          "limits": [
+            { "kind": "session", "group": "session", "percent": 23, "resets_at": "2026-07-02T07:09:59Z", "scope": null },
+            { "kind": "weekly_all", "group": "weekly", "percent": 10, "resets_at": "2026-07-02T10:59:59Z", "scope": null },
+            { "kind": "weekly_scoped", "group": "weekly", "percent": 17, "resets_at": "2026-07-02T11:00:00Z",
+              "scope": { "model": { "id": null, "display_name": "Fable" }, "surface": null } }
+          ]
+        }
+        """.data(using: .utf8)!
+
+        let response = HTTPURLResponse(
+            url: URL(string: "https://api.anthropic.com")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+
+        given(mockNetwork).request(.any).willReturn((responseJSON, response))
+
+        let loader = ClaudeCredentialLoader(homeDirectory: tempDir.path, useKeychain: false)
+        let probe = ClaudeAPIUsageProbe(credentialLoader: loader, networkClient: mockNetwork)
+
+        let snapshot = try await probe.probe()
+
+        let fableQuota = snapshot.quotas.first { $0.quotaType == .modelSpecific("fable") }
+        #expect(fableQuota != nil)
+        #expect(fableQuota?.percentRemaining == 83.0)  // 100 - 17
+        #expect(fableQuota?.resetsAt != nil)
+
+        // Unscoped session/weekly entries in the limits array must not create duplicates
+        #expect(snapshot.quotas.filter { $0.quotaType == .session }.count == 1)
+        #expect(snapshot.quotas.filter { $0.quotaType == .weekly }.count == 1)
+    }
+
+    @Test
+    func `probe skips malformed limits entries and keeps over-quota negative remaining`() async throws {
+        let tempDir = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let futureExpiry = Date().addingTimeInterval(3600).timeIntervalSince1970 * 1000
+        try createCredentialsFile(at: tempDir, expiresAt: futureExpiry)
+
+        let mockNetwork = MockNetworkClient()
+        // Malformed scoped entries (no scope, no model, empty name, no percent) are
+        // skipped; duplicate scoped entries yield one quota; a multi-word display
+        // name keys on its first word; 105% used stays negative (over-quota signal).
+        let responseJSON = """
+        {
+          "five_hour": { "utilization": 10.0, "resets_at": "2025-01-15T10:00:00Z" },
+          "limits": [
+            { "kind": "weekly_scoped", "group": "weekly", "percent": 50, "resets_at": "2025-01-20T00:00:00Z", "scope": null },
+            { "kind": "weekly_scoped", "group": "weekly", "percent": 50, "resets_at": "2025-01-20T00:00:00Z", "scope": { "model": null } },
+            { "kind": "weekly_scoped", "group": "weekly", "percent": 50, "resets_at": "2025-01-20T00:00:00Z",
+              "scope": { "model": { "id": null, "display_name": "" } } },
+            { "kind": "weekly_scoped", "group": "weekly", "resets_at": "2025-01-20T00:00:00Z",
+              "scope": { "model": { "id": null, "display_name": "Opus" } } },
+            { "kind": "weekly_scoped", "group": "weekly", "percent": 105, "resets_at": "2025-01-20T00:00:00Z",
+              "scope": { "model": { "id": null, "display_name": "Fable 5" } } },
+            { "kind": "weekly_scoped", "group": "weekly", "percent": 40, "resets_at": "2025-01-20T00:00:00Z",
+              "scope": { "model": { "id": null, "display_name": "Fable" } } }
+          ]
+        }
+        """.data(using: .utf8)!
+
+        let response = HTTPURLResponse(
+            url: URL(string: "https://api.anthropic.com")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+
+        given(mockNetwork).request(.any).willReturn((responseJSON, response))
+
+        let loader = ClaudeCredentialLoader(homeDirectory: tempDir.path, useKeychain: false)
+        let probe = ClaudeAPIUsageProbe(credentialLoader: loader, networkClient: mockNetwork)
+
+        let snapshot = try await probe.probe()
+
+        let fableQuotas = snapshot.quotas.filter { $0.quotaType == .modelSpecific("fable") }
+        #expect(fableQuotas.count == 1)
+        #expect(fableQuotas.first?.percentRemaining == -5.0)  // 100 - 105, first entry wins
+
+        // Malformed entries produce no quotas: session (legacy) + fable only
+        #expect(snapshot.quotas.count == 2)
+    }
+
+    @Test
+    func `probe does not duplicate model quota reported in both legacy field and limits array`() async throws {
+        let tempDir = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let futureExpiry = Date().addingTimeInterval(3600).timeIntervalSince1970 * 1000
+        try createCredentialsFile(at: tempDir, expiresAt: futureExpiry)
+
+        let mockNetwork = MockNetworkClient()
+        let responseJSON = """
+        {
+          "five_hour": { "utilization": 10.0, "resets_at": "2025-01-15T10:00:00Z" },
+          "seven_day_opus": { "utilization": 60.0, "resets_at": "2025-01-20T00:00:00Z" },
+          "limits": [
+            { "kind": "weekly_scoped", "group": "weekly", "percent": 60, "resets_at": "2025-01-20T00:00:00Z",
+              "scope": { "model": { "id": null, "display_name": "Opus" }, "surface": null } }
+          ]
+        }
+        """.data(using: .utf8)!
+
+        let response = HTTPURLResponse(
+            url: URL(string: "https://api.anthropic.com")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+
+        given(mockNetwork).request(.any).willReturn((responseJSON, response))
+
+        let loader = ClaudeCredentialLoader(homeDirectory: tempDir.path, useKeychain: false)
+        let probe = ClaudeAPIUsageProbe(credentialLoader: loader, networkClient: mockNetwork)
+
+        let snapshot = try await probe.probe()
+
+        let opusQuotas = snapshot.quotas.filter { $0.quotaType == .modelSpecific("opus") }
+        #expect(opusQuotas.count == 1)
+        #expect(opusQuotas.first?.percentRemaining == 40.0)  // 100 - 60
+    }
+
+    @Test
     func `probe parses extra usage correctly converting cents to dollars`() async throws {
         let tempDir = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: tempDir) }

--- a/Tests/InfrastructureTests/Claude/ClaudeUsageProbeParsingTests.swift
+++ b/Tests/InfrastructureTests/Claude/ClaudeUsageProbeParsingTests.swift
@@ -49,6 +49,22 @@ struct ClaudeUsageProbeParsingTests {
     ████████████░░░░░░░░ 60% used
     """
 
+    static let fableQuotaOutput = """
+    Claude Code v2.1.198
+
+    Current session
+    ██████████░░░░░░░░░░ 23% used
+    Resets 1:09am (America/Chicago)
+
+    Current week (all models)
+    ██░░░░░░░░░░░░░░░░░░ 10% used
+    Resets Jul 2 at 4:59am (America/Chicago)
+
+    Current week (Fable)
+    ████░░░░░░░░░░░░░░░░ 17% used
+    Resets Jul 2 at 5:59am (America/Chicago)
+    """
+
     // MARK: - Parsing Percentages
 
     @Test
@@ -89,6 +105,60 @@ struct ClaudeUsageProbeParsingTests {
         let opusQuota = snapshot.quota(for: .modelSpecific("opus"))
         #expect(opusQuota?.percentRemaining == 80)
         #expect(opusQuota?.status == .healthy)
+    }
+
+    @Test
+    func `parses fable weekly quota with its own reset time`() throws {
+        // Given
+        let output = Self.fableQuotaOutput
+
+        // When
+        let snapshot = try simulateParse(text: output)
+
+        // Then - 17% used = 83% remaining, reset from the Fable section (not all-models)
+        let fableQuota = snapshot.quota(for: .modelSpecific("fable"))
+        #expect(fableQuota?.percentRemaining == 83)
+        #expect(fableQuota?.status == .healthy)
+        #expect(fableQuota?.resetText?.contains("5:59am") == true)
+    }
+
+    static let fableQuotaWithoutOwnResetOutput = """
+    Current session
+    ██████████░░░░░░░░░░ 23% used
+    Resets 1:09am (America/Chicago)
+
+    Current week (all models)
+    ██░░░░░░░░░░░░░░░░░░ 10% used
+    Resets Jul 2 at 4:59am (America/Chicago)
+
+    Current week (Fable)
+    ████░░░░░░░░░░░░░░░░ 17% used
+    """
+
+    @Test
+    func `fable quota falls back to weekly reset when its section has none`() throws {
+        // Given
+        let output = Self.fableQuotaWithoutOwnResetOutput
+
+        // When
+        let snapshot = try simulateParse(text: output)
+
+        // Then - inherits the all-models weekly reset
+        let fableQuota = snapshot.quota(for: .modelSpecific("fable"))
+        #expect(fableQuota?.percentRemaining == 83)
+        #expect(fableQuota?.resetText?.contains("4:59am") == true)
+    }
+
+    @Test
+    func `no fable quota when section absent`() throws {
+        // Given
+        let output = Self.sampleClaudeOutput
+
+        // When
+        let snapshot = try simulateParse(text: output)
+
+        // Then
+        #expect(snapshot.quota(for: .modelSpecific("fable")) == nil)
     }
 
     @Test
@@ -880,6 +950,52 @@ struct ClaudeUsageProbeParsingTests {
 
         // Then - colors are stripped, text is preserved
         #expect(rendered.contains("Green") && rendered.contains("Normal"))
+    }
+
+    @Test
+    func `TerminalRenderer includes content scrolled into scrollback`() throws {
+        // Given - more lines than the terminal is tall (50 rows), so early
+        // lines scroll out of the visible screen into scrollback
+        let renderer = TerminalRenderer()
+        let input = (1...80).map { "line \($0)" }.joined(separator: "\n")
+
+        // When
+        let rendered = renderer.render(input)
+
+        // Then - both the scrolled-off top and the visible bottom survive
+        #expect(rendered.contains("line 1\n"))
+        #expect(rendered.contains("line 80"))
+    }
+
+    @Test
+    func `parses usage sections that scrolled off the visible screen`() throws {
+        // Given - the CLI /usage screen grew past 50 rows (usage-contribution
+        // report), pushing the quota sections above the visible screen
+        let filler = (1...60).map { "contributing insight line \($0)" }.joined(separator: "\n")
+        let output = """
+        Current session
+        ██████████████████████████████▌                    61% used
+        Resets 1:09am (America/Chicago)
+
+        Current week (all models)
+        █████████                                          18% used
+        Resets Jul 2 at 4:59am (America/Chicago)
+
+        Current week (Fable)
+        ████████████████                                   32% used
+        Resets Jul 2 at 5:59am (America/Chicago)
+
+        What's contributing to your limits usage?
+        \(filler)
+        """
+
+        // When
+        let snapshot = try simulateParse(text: output)
+
+        // Then
+        #expect(snapshot.sessionQuota?.percentRemaining == 39)
+        #expect(snapshot.weeklyQuota?.percentRemaining == 82)
+        #expect(snapshot.quota(for: .modelSpecific("fable"))?.percentRemaining == 68)
     }
 
     @Test


### PR DESCRIPTION
## Summary

The Claude CLI and OAuth usage API now report a **Fable 5 weekly limit** that ClaudeBar ignored. This PR parses it from both probes so it appears as a quota card in the window and as a selectable menu-bar metric. It also fixes a bug where the CLI probe **failed on every tick** with recent Claude CLI versions.

### Fable weekly limit
- **CLI probe**: parses the `Current week (Fable)` section (paren-open anchor so a future `(Fable 5)` label still matches), with its own reset time and fallback to the all-models weekly reset.
- **API probe**: the OAuth usage endpoint now reports model limits via a generic `limits` array (`kind: "weekly_scoped"` + `scope.model.display_name`) instead of the legacy `seven_day_<model>` fields, which are now `null` (verified against the live endpoint). Parsing is generic — any future model-scoped limit appears automatically — keyed on the first word of the display name to stay in sync with the CLI probe's key, deduped against legacy fields, and preserving negative `percentRemaining` as the over-quota signal per the `UsageQuota` contract.
- **No UI changes needed**: everything downstream (`QuotaType.modelSpecific`, quota cards, the menu-bar quota picker, quota keys like `model:fable`) is already generic.

### Parse-failure fix (blocks Fable in CLI mode)
Recent Claude CLI versions render a `/usage` screen ~81 lines tall (new usage-contribution report). On the probe's 50-row PTY the quota sections scroll into scrollback, which `TerminalRenderer.extractScreenText` never read — so parsing failed with "could not find 'Current session'" on **every tick**. The renderer now reads the whole buffer (visible rows + scrollback, capacity raised to 2000 lines).

## Verification
- 8 new tests (CLI fixtures incl. tall-screen and fallback-reset cases, API `limits` array incl. dedupe/malformed/over-quota cases, QuotaType round-trip); full Domain + Infrastructure suites pass.
- Verified against a real `/usage` PTY capture (160×50 raw bytes) and a live app run: probe succeeds with `quotas=3` — Session 35% / Weekly 82% / **Fable 67% remaining** — matching the CLI exactly.

## Follow-up (not in this PR)
- Label scanners take the *first* occurrence of a section label in the buffer; with in-place TUI repaints a stale intermediate frame could in theory win. Benign today (repainted frames carry identical values); switching to last-occurrence with a two-frame fixture is a good follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for showing the Fable weekly limit as a selectable quota metric/card.
  * Expanded usage detection so newer Claude usage responses are parsed correctly, including model-specific limits.

* **Bug Fixes**
  * Fixed usage parsing when CLI output is taller than the visible terminal area, so quota sections are no longer missed.
  * Improved fallback handling for Fable reset times when a dedicated reset value isn’t available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
