### PR TITLE
Fix menu bar reset duration fallback

### DIFF
--- a/Sources/Domain/Provider/MenuBarDurationDisplay.swift
+++ b/Sources/Domain/Provider/MenuBarDurationDisplay.swift
@@ -10,7 +10,11 @@ public struct MenuBarDurationDisplay: Sendable, Equatable {
     /// Computed (not stored) so the countdown reflects the current wall clock
     /// every time SwiftUI evaluates the menu bar label, instead of freezing at
     /// the value captured when this display was constructed.
-    public var text: String { quota.compactResetTime ?? "—" }
+    public var text: String {
+        quota.compactResetTime
+            ?? Self.compactResetText(quota.resetText)
+            ?? "—"
+    }
 
     public init(
         quota: UsageQuota,
@@ -21,5 +25,29 @@ public struct MenuBarDurationDisplay: Sendable, Equatable {
         self.status = burnRateWarningEnabled
             ? quota.paceAwareStatus(burnRateThreshold: burnRateThreshold)
             : quota.status
+    }
+
+    private static func compactResetText(_ resetText: String?) -> String? {
+        guard let resetText else { return nil }
+        let lower = resetText.lowercased()
+        guard lower.contains("reset") else { return nil }
+
+        let pattern = #"(\d+)\s*([dhm])"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+            return nil
+        }
+
+        let range = NSRange(resetText.startIndex..<resetText.endIndex, in: resetText)
+        let matches = regex.matches(in: resetText, options: [], range: range)
+        let parts = matches.compactMap { match -> String? in
+            guard match.numberOfRanges >= 3,
+                  let valueRange = Range(match.range(at: 1), in: resetText),
+                  let unitRange = Range(match.range(at: 2), in: resetText) else {
+                return nil
+            }
+            return "\(resetText[valueRange])\(resetText[unitRange].lowercased())"
+        }
+
+        return parts.isEmpty ? nil : parts.prefix(2).joined(separator: " ")
     }
 }


### PR DESCRIPTION
## Summary

- Fall back to parsing compact reset durations from quota reset text when `resetsAt` is unavailable.
- Prevent menu bar duration labels from showing `-` while quota cards can already show strings like `Resets in 4h 55m`.

## Root Cause

Codex RPC quota mapping can provide reset timing as `resetText` without populating `resetsAt`. The quota cards already fall back through `resetTimestampDescription`, `resetText`, and `resetDescription`, but `MenuBarDurationDisplay` only used `compactResetTime`, which depends on `resetsAt`.

## Validation

- `git diff --check`
- Built a local Release `ClaudeBar.app` with `xcodebuild -workspace ClaudeBar.xcworkspace -scheme ClaudeBar -configuration Release -destination 'platform=macOS,arch=arm64' build`
- Verified locally that the patched app launches and the menu bar duration no longer renders as `-` for Codex reset text.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the menu bar duration display to show a clearer fallback time when the primary reset-time value is unavailable.
  * When a detailed reset message is present, it now condenses that information into a shorter, more readable format.
  * If no usable time information is available, the display now shows an em dash instead of leaving the field blank or unclear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->