### PR TITLE
feat(menubar): opt-in stacked rendering for dual quota windows, with S/M/L size

### DIFF
--- a/Sources/App/Settings/AppSettings.swift
+++ b/Sources/App/Settings/AppSettings.swift
@@ -68,6 +68,16 @@ public final class AppSettings {
         }
     }
 
+    /// Text size for the stacked menu bar lines. Small is the original 9pt
+    /// rendering and the default; Medium (10pt) and Large (11pt) trade some of
+    /// the inter-line breathing room for legibility. Only consulted while
+    /// `menuBarStackedEnabled` is actually rendering two lines.
+    public var menuBarStackedSize: MenuBarStackedSize {
+        didSet {
+            repository.setMenuBarStackedSize(menuBarStackedSize.rawValue)
+        }
+    }
+
     /// Provider used for the menu bar percentage label.
     public var menuBarPercentageProviderId: String {
         didSet {
@@ -228,6 +238,10 @@ public final class AppSettings {
         self.menuBarPercentageEnabled = repository.menuBarPercentageEnabled()
         self.menuBarDurationEnabled = repository.menuBarDurationEnabled()
         self.menuBarStackedEnabled = repository.menuBarStackedEnabled()
+        // The stored size decodes through the Domain fallback so an unknown
+        // raw value (from a newer build's settings file) renders small
+        // instead of crashing or dropping the label.
+        self.menuBarStackedSize = MenuBarStackedSize(storedRawValue: repository.menuBarStackedSize())
         self.menuBarPercentageProviderId = repository.menuBarPercentageProviderId()
         self.menuBarPercentageQuotaKey = repository.menuBarPercentageQuotaKey()
         self.menuBarSecondaryQuotaKey = repository.menuBarSecondaryQuotaKey()

--- a/Sources/App/Settings/AppSettings.swift
+++ b/Sources/App/Settings/AppSettings.swift
@@ -58,6 +58,16 @@ public final class AppSettings {
         }
     }
 
+    /// Whether a dual-window menu bar label should render as two stacked
+    /// smaller lines (one per quota window) instead of one long "A | B" line,
+    /// roughly halving the menu bar width it occupies. Opt-in, default off;
+    /// has no effect while only a single quota window is shown.
+    public var menuBarStackedEnabled: Bool {
+        didSet {
+            repository.setMenuBarStackedEnabled(menuBarStackedEnabled)
+        }
+    }
+
     /// Provider used for the menu bar percentage label.
     public var menuBarPercentageProviderId: String {
         didSet {
@@ -217,6 +227,7 @@ public final class AppSettings {
         self.backgroundSyncInterval = repository.backgroundSyncInterval()
         self.menuBarPercentageEnabled = repository.menuBarPercentageEnabled()
         self.menuBarDurationEnabled = repository.menuBarDurationEnabled()
+        self.menuBarStackedEnabled = repository.menuBarStackedEnabled()
         self.menuBarPercentageProviderId = repository.menuBarPercentageProviderId()
         self.menuBarPercentageQuotaKey = repository.menuBarPercentageQuotaKey()
         self.menuBarSecondaryQuotaKey = repository.menuBarSecondaryQuotaKey()

--- a/Sources/App/StatusItemLabelDriver.swift
+++ b/Sources/App/StatusItemLabelDriver.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CoreText
 import SwiftUI
 import Domain
 import Infrastructure
@@ -61,6 +62,10 @@ final class StatusItemLabelDriver {
         /// Whether a dual-window label should render as two stacked smaller
         /// lines instead of one long "A | B" line (opt-in setting).
         var stacked: Bool = false
+        /// The user-selected text size for the stacked lines. Carried in the
+        /// content (not read at draw time) so changing the size in Settings
+        /// invalidates the observation sync and repaints the label.
+        var stackedSize: MenuBarStackedSize = .default
     }
 
     /// Attaches to the `NSStatusItem` exposed by MenuBarExtraAccess and starts
@@ -130,7 +135,8 @@ final class StatusItemLabelDriver {
             fallbackStatus: effectiveSelectedProviderStatus,
             sessionPhase: sessionMonitor.activeSession?.phase,
             themeModeId: settings.themeMode,
-            stacked: settings.menuBarStackedEnabled
+            stacked: settings.menuBarStackedEnabled,
+            stackedSize: settings.menuBarStackedSize
         )
     }
 
@@ -204,7 +210,8 @@ final class StatusItemLabelDriver {
             if content.stacked, label.segments.count == 2 {
                 parts.append(StatusBarStackedImageRenderer.image(
                     top: (label.segments[0].text, theme.statusColor(for: label.segments[0].status)),
-                    bottom: (label.segments[1].text, theme.statusColor(for: label.segments[1].status))
+                    bottom: (label.segments[1].text, theme.statusColor(for: label.segments[1].status)),
+                    size: content.stackedSize
                 ))
             } else {
                 parts.append(StatusBarPercentageImageRenderer.image(
@@ -367,6 +374,12 @@ enum StatusBarPercentageImageRenderer {
 /// rationale (macOS can ignore `Text.foregroundStyle` in a menu bar item, and
 /// each line must keep its own window's status color), but a smaller font so
 /// both lines fit inside the menu bar's usable height.
+///
+/// The line size is user-selectable (`MenuBarStackedSize`): Small keeps the
+/// original 9pt look, Medium and Large render 10pt and 11pt. At those larger
+/// sizes the two natural line boxes no longer fit inside the 22pt clamp, so
+/// the renderer verifies the two lines' measured glyph ink cannot collide and
+/// switches anchoring strategies when it would (see `image(top:bottom:size:)`).
 enum StatusBarStackedImageRenderer {
     /// The menu bar's usable content height. Status-item images taller than
     /// this get clipped or scaled by the system, so the stack never exceeds it.
@@ -378,12 +391,20 @@ enum StatusBarStackedImageRenderer {
     /// fonts' descender space instead of clipping a line.
     private static let lineSpacing: CGFloat = 1
 
+    /// Safety inset above the image's bottom edge when ink anchoring engages.
+    /// AppKit's string drawing rounds baselines to pixel boundaries, which can
+    /// land actual glyph pixels up to ~0.4pt below the analytic glyph-path
+    /// bounds (measured), so pinning ink to exactly y = 0 could shave the
+    /// bottom row off descenders.
+    private static let bottomInkInset: CGFloat = 0.5
+
     @MainActor
     static func image(
         top: (text: String, color: Color),
-        bottom: (text: String, color: Color)
+        bottom: (text: String, color: Color),
+        size: MenuBarStackedSize = .default
     ) -> NSImage {
-        let font = NSFont.monospacedDigitSystemFont(ofSize: 9, weight: .semibold)
+        let font = NSFont.monospacedDigitSystemFont(ofSize: size.stackedLinePointSize, weight: .semibold)
         func attributedLine(_ line: (text: String, color: Color)) -> NSAttributedString {
             NSAttributedString(string: line.text, attributes: [
                 .font: font,
@@ -399,15 +420,68 @@ enum StatusBarStackedImageRenderer {
         let naturalHeight = topLine.size().height + lineSpacing + bottomLine.size().height
         let height = min(maxHeight, ceil(naturalHeight))
 
-        // flipped: false, so y grows upward: the bottom line sits at y = 0 and
-        // the top line is anchored to the image's top edge.
+        // Default layout: line boxes anchored to the image edges, bottom line
+        // at y = 0 and the top line's box against the top edge, with any clamp
+        // deficit absorbed by the gap and the fonts' descender space. This is
+        // the original Small rendering, byte-identical when no collision.
+        var topOriginY = height - topLine.size().height
+        var bottomOriginY: CGFloat = 0
+
+        // Collision check: at 10pt a descender-bearing top line, and at 11pt
+        // every realistic pairing, would let the glyphs themselves overlap
+        // under box anchoring (measured -0.3 to -2.2pt of ink clearance).
+        // When the measured glyph ink of the two lines would touch, switch to
+        // INK anchoring: pin the bottom line's lowest ink just above y = 0 and
+        // the top line's highest ink to the top edge. Line boxes may then
+        // overflow the image, but a line box is mostly empty ascender and
+        // descender allowance; reclaiming that padding restores over +3pt of
+        // clearance at 11pt for realistic labels while nothing clips. Small
+        // (9pt) always measures positive clearance here, so its rendering is
+        // untouched. A line drawn at origin y has its baseline at
+        // y + boxHeight - font.ascender, and ink bounds are baseline-relative.
+        let topInk = inkBounds(of: topLine)
+        let bottomInk = inkBounds(of: bottomLine)
+        if !topInk.isNull, !bottomInk.isNull {
+            let topInkBottom = topOriginY + topLine.size().height - font.ascender + topInk.minY
+            let bottomInkTop = bottomOriginY + bottomLine.size().height - font.ascender + bottomInk.maxY
+            if topInkBottom - bottomInkTop < 0 {
+                bottomOriginY = bottomInkInset - (bottomLine.size().height - font.ascender) - bottomInk.minY
+                topOriginY = height - (topLine.size().height - font.ascender) - topInk.maxY
+            }
+        }
+
+        // flipped: false, so y grows upward: the bottom line sits at the
+        // bottom and the top line is anchored to the image's top edge.
         let image = NSImage(size: NSSize(width: width, height: height), flipped: false) { _ in
-            bottomLine.draw(at: .zero)
-            topLine.draw(at: NSPoint(x: 0, y: height - topLine.size().height))
+            bottomLine.draw(at: NSPoint(x: 0, y: bottomOriginY))
+            topLine.draw(at: NSPoint(x: 0, y: topOriginY))
             return true
         }
         image.isTemplate = false
 
         return image
+    }
+
+    /// Tight glyph-path bounds of the line's ink, relative to its baseline
+    /// origin (CoreText convention: y = 0 is the baseline, descenders are
+    /// negative). Null for a line with no ink, e.g. all whitespace.
+    private static func inkBounds(of line: NSAttributedString) -> CGRect {
+        CTLineGetBoundsWithOptions(CTLineCreateWithAttributedString(line), [.useGlyphPathBounds])
+    }
+}
+
+extension MenuBarStackedSize {
+    /// The point size each stacked line renders at. This mapping lives in the
+    /// App layer (not Domain) because it is a rendering concern: Domain models
+    /// the user's choice, the renderer decides what it means in points. The
+    /// values are capped at 11pt because two lines of measured glyph ink must
+    /// still fit inside the menu bar's 22pt content height (see
+    /// `StatusBarStackedImageRenderer`).
+    var stackedLinePointSize: CGFloat {
+        switch self {
+        case .small: 9
+        case .medium: 10
+        case .large: 11
+        }
     }
 }

--- a/Sources/App/StatusItemLabelDriver.swift
+++ b/Sources/App/StatusItemLabelDriver.swift
@@ -484,4 +484,14 @@ extension MenuBarStackedSize {
         case .large: 11
         }
     }
+
+    /// SF Symbol for the settings choice chip. Every chip in the menu bar
+    /// section carries a leading icon, so the size options do too.
+    var choiceIconName: String {
+        switch self {
+        case .small: "textformat.size.smaller"
+        case .medium: "textformat.size"
+        case .large: "textformat.size.larger"
+        }
+    }
 }

--- a/Sources/App/StatusItemLabelDriver.swift
+++ b/Sources/App/StatusItemLabelDriver.swift
@@ -58,6 +58,9 @@ final class StatusItemLabelDriver {
         var fallbackStatus: QuotaStatus
         var sessionPhase: ClaudeSession.Phase?
         var themeModeId: String
+        /// Whether a dual-window label should render as two stacked smaller
+        /// lines instead of one long "A | B" line (opt-in setting).
+        var stacked: Bool = false
     }
 
     /// Attaches to the `NSStatusItem` exposed by MenuBarExtraAccess and starts
@@ -126,7 +129,8 @@ final class StatusItemLabelDriver {
             label: freshLabel ?? lastKnownLabel(whenFreshIsMissing: freshLabel),
             fallbackStatus: effectiveSelectedProviderStatus,
             sessionPhase: sessionMonitor.activeSession?.phase,
-            themeModeId: settings.themeMode
+            themeModeId: settings.themeMode,
+            stacked: settings.menuBarStackedEnabled
         )
     }
 
@@ -192,10 +196,22 @@ final class StatusItemLabelDriver {
         }
 
         if let label = content.label {
-            parts.append(StatusBarPercentageImageRenderer.image(
-                text: label.text,
-                color: theme.statusColor(for: label.status)
-            ))
+            // Stacked mode only applies to a dual-window label: two windows
+            // become two smaller lines (halving the width the label needs).
+            // Anything else, including a dual label with stacking off, keeps
+            // the classic single-line rendering. The tooltip always stays the
+            // full joined text, so no information is lost either way.
+            if content.stacked, label.segments.count == 2 {
+                parts.append(StatusBarStackedImageRenderer.image(
+                    top: (label.segments[0].text, theme.statusColor(for: label.segments[0].status)),
+                    bottom: (label.segments[1].text, theme.statusColor(for: label.segments[1].status))
+                ))
+            } else {
+                parts.append(StatusBarPercentageImageRenderer.image(
+                    text: label.text,
+                    color: theme.statusColor(for: label.status)
+                ))
+            }
         } else {
             let symbolName = theme.statusBarIconName ?? fallbackIconName(for: content.fallbackStatus)
             parts.append(symbolImage(
@@ -337,6 +353,57 @@ enum StatusBarPercentageImageRenderer {
         let imageSize = NSSize(width: ceil(textSize.width), height: ceil(textSize.height))
         let image = NSImage(size: imageSize, flipped: false) { _ in
             attributedText.draw(at: .zero)
+            return true
+        }
+        image.isTemplate = false
+
+        return image
+    }
+}
+
+/// Renders a dual-window label as two vertically stacked lines in one image,
+/// so the label takes roughly half the menu bar width of the joined "A | B"
+/// form. Sibling of `StatusBarPercentageImageRenderer`: same original-color
+/// rationale (macOS can ignore `Text.foregroundStyle` in a menu bar item, and
+/// each line must keep its own window's status color), but a smaller font so
+/// both lines fit inside the menu bar's usable height.
+enum StatusBarStackedImageRenderer {
+    /// The menu bar's usable content height. Status-item images taller than
+    /// this get clipped or scaled by the system, so the stack never exceeds it.
+    private static let maxHeight: CGFloat = 22
+
+    /// Vertical breathing room between the two lines. When the two natural
+    /// line heights plus this gap overflow `maxHeight`, the lines keep their
+    /// top/bottom anchors and the overflow is absorbed by the gap and the
+    /// fonts' descender space instead of clipping a line.
+    private static let lineSpacing: CGFloat = 1
+
+    @MainActor
+    static func image(
+        top: (text: String, color: Color),
+        bottom: (text: String, color: Color)
+    ) -> NSImage {
+        let font = NSFont.monospacedDigitSystemFont(ofSize: 9, weight: .semibold)
+        func attributedLine(_ line: (text: String, color: Color)) -> NSAttributedString {
+            NSAttributedString(string: line.text, attributes: [
+                .font: font,
+                .foregroundColor: NSColor(line.color),
+            ])
+        }
+        let topLine = attributedLine(top)
+        let bottomLine = attributedLine(bottom)
+
+        // Lines stay left-aligned: the image is as wide as the wider line and
+        // both draw from x = 0, matching how the two windows read as a list.
+        let width = ceil(max(topLine.size().width, bottomLine.size().width))
+        let naturalHeight = topLine.size().height + lineSpacing + bottomLine.size().height
+        let height = min(maxHeight, ceil(naturalHeight))
+
+        // flipped: false, so y grows upward: the bottom line sits at y = 0 and
+        // the top line is anchored to the image's top edge.
+        let image = NSImage(size: NSSize(width: width, height: height), flipped: false) { _ in
+            bottomLine.draw(at: .zero)
+            topLine.draw(at: NSPoint(x: 0, y: height - topLine.size().height))
             return true
         }
         image.isTemplate = false

--- a/Sources/App/Views/SettingsView.swift
+++ b/Sources/App/Views/SettingsView.swift
@@ -384,22 +384,27 @@ struct SettingsContentView: View {
     /// Size selector for the stacked lines. Small is the original 9pt
     /// rendering; Medium and Large enlarge both lines to 10pt and 11pt while
     /// the renderer keeps their ink inside the menu bar's height limit.
+    /// Rendered as a labelled chip row (like PROVIDER and QUOTA above) so the
+    /// control speaks the section's choice-button language instead of a
+    /// system segmented picker.
     private var menuBarStackedSizePicker: some View {
-        HStack {
-            Text("Stacked Text Size")
-                .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
+        VStack(alignment: .leading, spacing: 6) {
+            Text("STACKED TEXT SIZE")
+                .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
                 .foregroundStyle(theme.textSecondary)
+                .tracking(0.5)
 
-            Spacer()
-
-            Picker("", selection: $settings.menuBarStackedSize) {
+            HStack(spacing: 8) {
                 ForEach(MenuBarStackedSize.allCases, id: \.self) { size in
-                    Text(size.displayLabel).tag(size)
+                    MenuBarChoiceButton(
+                        iconName: size.choiceIconName,
+                        label: size.displayLabel,
+                        isSelected: settings.menuBarStackedSize == size
+                    ) {
+                        settings.menuBarStackedSize = size
+                    }
                 }
             }
-            .pickerStyle(.segmented)
-            .labelsHidden()
-            .fixedSize()
         }
     }
 

--- a/Sources/App/Views/SettingsView.swift
+++ b/Sources/App/Views/SettingsView.swift
@@ -532,7 +532,12 @@ struct SettingsContentView: View {
     /// becomes equal to the primary, or the chosen provider's quotas no longer include it.
     private func normalizeSecondaryMenuBarSelection() {
         guard !settings.menuBarSecondaryQuotaKey.isEmpty else { return }
+        // An empty options list means quota data has not loaded yet (cold
+        // start, provider still syncing), not that the stored selection is
+        // invalid. Clearing here would silently discard the user's secondary
+        // window on any settings interaction during a sync.
         let validKeys = Set(secondaryMenuBarQuotaOptions.map(\.quotaType.quotaKey))
+        guard !validKeys.isEmpty else { return }
         if !validKeys.contains(settings.menuBarSecondaryQuotaKey) {
             settings.menuBarSecondaryQuotaKey = ""
         }

--- a/Sources/App/Views/SettingsView.swift
+++ b/Sources/App/Views/SettingsView.swift
@@ -381,6 +381,28 @@ struct SettingsContentView: View {
         }
     }
 
+    /// Size selector for the stacked lines. Small is the original 9pt
+    /// rendering; Medium and Large enlarge both lines to 10pt and 11pt while
+    /// the renderer keeps their ink inside the menu bar's height limit.
+    private var menuBarStackedSizePicker: some View {
+        HStack {
+            Text("Stacked Text Size")
+                .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
+                .foregroundStyle(theme.textSecondary)
+
+            Spacer()
+
+            Picker("", selection: $settings.menuBarStackedSize) {
+                ForEach(MenuBarStackedSize.allCases, id: \.self) { size in
+                    Text(size.displayLabel).tag(size)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .fixedSize()
+        }
+    }
+
     private var menuBarControls: some View {
         VStack(alignment: .leading, spacing: 10) {
             VStack(alignment: .leading, spacing: 6) {
@@ -477,6 +499,12 @@ struct SettingsContentView: View {
                     // toggle appears once a secondary window is selected.
                     if !settings.menuBarSecondaryQuotaKey.isEmpty {
                         menuBarStackedToggle
+
+                        // The size only matters while stacking is actually
+                        // rendering, so it appears with the toggle on.
+                        if settings.menuBarStackedEnabled {
+                            menuBarStackedSizePicker
+                        }
                     }
                 }
             }

--- a/Sources/App/Views/SettingsView.swift
+++ b/Sources/App/Views/SettingsView.swift
@@ -357,6 +357,30 @@ struct SettingsContentView: View {
         }
     }
 
+    /// Opt-in stacked rendering for the dual-window label: the two windows
+    /// draw as two smaller lines instead of one long "A | B" line, roughly
+    /// halving the menu bar width the label occupies.
+    private var menuBarStackedToggle: some View {
+        HStack {
+            Text("Stack in Menu Bar")
+                .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
+                .foregroundStyle(theme.textSecondary)
+
+            Spacer()
+
+            Toggle("", isOn: Binding(
+                get: { settings.menuBarStackedEnabled },
+                set: { enabled in
+                    settings.menuBarStackedEnabled = enabled
+                }
+            ))
+            .toggleStyle(.switch)
+            .tint(theme.accentPrimary)
+            .scaleEffect(0.8)
+            .labelsHidden()
+        }
+    }
+
     private var menuBarControls: some View {
         VStack(alignment: .leading, spacing: 10) {
             VStack(alignment: .leading, spacing: 6) {
@@ -447,6 +471,12 @@ struct SettingsContentView: View {
                                 }
                             }
                         }
+                    }
+
+                    // Stacking only changes how two windows render, so the
+                    // toggle appears once a secondary window is selected.
+                    if !settings.menuBarSecondaryQuotaKey.isEmpty {
+                        menuBarStackedToggle
                     }
                 }
             }

--- a/Sources/Domain/Monitor/QuotaMonitor.swift
+++ b/Sources/Domain/Monitor/QuotaMonitor.swift
@@ -237,7 +237,8 @@ public final class QuotaMonitor {
     /// non-empty and differs from the primary, a second window is appended: each
     /// window is prefixed with its `QuotaType.shortLabel` and the two are joined
     /// by " | ", e.g. "5h 12% | 7d 34%". The status is the most severe of the
-    /// shown windows.
+    /// shown windows, and each window is also exposed individually via
+    /// `MenuBarLabel.segments` for renderers that draw them on separate lines.
     ///
     /// Returns nil when neither percentage nor duration is enabled, or when no
     /// quota data is available for the requested windows.
@@ -291,9 +292,22 @@ public final class QuotaMonitor {
         case let (.some(primary), .some(secondary)):
             let primaryLabel = QuotaType(quotaKey: primaryQuotaKey)?.shortLabel ?? primaryQuotaKey
             let secondaryLabel = QuotaType(quotaKey: secondaryQuotaKey)?.shortLabel ?? secondaryQuotaKey
+            // Each window becomes its own segment (prefixed text + that
+            // window's status) so stacked rendering can draw and tint them
+            // independently; the joined text stays the canonical single-line
+            // form and doubles as the tooltip.
+            let primarySegment = MenuBarLabel.Segment(
+                text: "\(primaryLabel) \(primary.text)",
+                status: primary.status
+            )
+            let secondarySegment = MenuBarLabel.Segment(
+                text: "\(secondaryLabel) \(secondary.text)",
+                status: secondary.status
+            )
             return MenuBarLabel(
-                text: "\(primaryLabel) \(primary.text) | \(secondaryLabel) \(secondary.text)",
-                status: max(primary.status, secondary.status)
+                text: "\(primarySegment.text) | \(secondarySegment.text)",
+                status: max(primary.status, secondary.status),
+                segments: [primarySegment, secondarySegment]
             )
         case let (.some(primary), .none):
             return MenuBarLabel(text: primary.text, status: primary.status)

--- a/Sources/Domain/Provider/MenuBarLabel.swift
+++ b/Sources/Domain/Provider/MenuBarLabel.swift
@@ -6,13 +6,37 @@ import Foundation
 /// Built by `QuotaMonitor.menuBarLabel(...)`. When two quota windows are shown
 /// together (e.g. session + weekly), each window is prefixed with its
 /// `QuotaType.shortLabel` so the numbers stay distinguishable, and the overall
-/// status is the most severe of the shown windows.
+/// status is the most severe of the shown windows. The per-window breakdown is
+/// also kept in `segments` so renderers that draw the windows individually
+/// (the stacked menu bar mode) can tint each one by its own status.
 public struct MenuBarLabel: Sendable, Equatable {
+    /// One quota window's slice of the label: its rendered text (including the
+    /// `QuotaType.shortLabel` prefix when two windows are shown) and that
+    /// window's own status, before the worst-case merge that produces the
+    /// label-level `status`.
+    public struct Segment: Sendable, Equatable {
+        public let text: String
+        public let status: QuotaStatus
+
+        public init(text: String, status: QuotaStatus) {
+            self.text = text
+            self.status = status
+        }
+    }
+
     public let text: String
     public let status: QuotaStatus
 
-    public init(text: String, status: QuotaStatus) {
+    /// The per-window segments behind `text`, in display order. Always holds
+    /// at least one entry: single-window labels carry one segment mirroring
+    /// `text` and `status` exactly, dual-window labels carry one per window.
+    public let segments: [Segment]
+
+    /// `segments` defaults to a single segment mirroring `text`/`status`, so
+    /// pre-existing call sites (and single-window labels) need no changes.
+    public init(text: String, status: QuotaStatus, segments: [Segment]? = nil) {
         self.text = text
         self.status = status
+        self.segments = segments ?? [Segment(text: text, status: status)]
     }
 }

--- a/Sources/Domain/Provider/MenuBarStackedSize.swift
+++ b/Sources/Domain/Provider/MenuBarStackedSize.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// The user-selectable text size for the stacked dual-window menu bar label.
+///
+/// Stacked rendering draws two quota windows inside the menu bar's fixed
+/// content height, so the size choice is a readability trade-off: bigger text
+/// is easier to glance, smaller text leaves more breathing room between the
+/// two lines.
+///
+/// - `.small`: the original stacked size, and the default.
+/// - `.medium` / `.large`: progressively bigger lines.
+///
+/// The concrete point sizes are a rendering concern and live in the App layer
+/// next to the stacked renderer; Domain only models the user's choice.
+public enum MenuBarStackedSize: String, Sendable, Equatable, CaseIterable {
+    case small
+    case medium
+    case large
+
+    /// The size used when the user has never chosen one, and the fallback for
+    /// raw values this build does not recognize.
+    public static let `default`: MenuBarStackedSize = .small
+
+    /// Decodes a persisted raw value, falling back to `.default` for unknown
+    /// strings, so a settings file written by a newer build (or edited by
+    /// hand) never breaks an older build: it quietly renders small instead.
+    public init(storedRawValue: String) {
+        self = MenuBarStackedSize(rawValue: storedRawValue) ?? .default
+    }
+
+    /// Short label for the settings picker.
+    public var displayLabel: String {
+        switch self {
+        case .small: "Small"
+        case .medium: "Medium"
+        case .large: "Large"
+        }
+    }
+}

--- a/Sources/Domain/Settings/AppSettingsRepository.swift
+++ b/Sources/Domain/Settings/AppSettingsRepository.swift
@@ -27,6 +27,9 @@ public protocol AppSettingsRepository: Sendable {
     func menuBarDurationEnabled() -> Bool
     func setMenuBarDurationEnabled(_ enabled: Bool)
 
+    func menuBarStackedEnabled() -> Bool
+    func setMenuBarStackedEnabled(_ enabled: Bool)
+
     func menuBarPercentageProviderId() -> String
     func setMenuBarPercentageProviderId(_ providerId: String)
 

--- a/Sources/Domain/Settings/AppSettingsRepository.swift
+++ b/Sources/Domain/Settings/AppSettingsRepository.swift
@@ -30,6 +30,9 @@ public protocol AppSettingsRepository: Sendable {
     func menuBarStackedEnabled() -> Bool
     func setMenuBarStackedEnabled(_ enabled: Bool)
 
+    func menuBarStackedSize() -> String
+    func setMenuBarStackedSize(_ size: String)
+
     func menuBarPercentageProviderId() -> String
     func setMenuBarPercentageProviderId(_ providerId: String)
 

--- a/Sources/Infrastructure/Storage/JSONSettingsRepository.swift
+++ b/Sources/Infrastructure/Storage/JSONSettingsRepository.swift
@@ -81,6 +81,14 @@ public final class JSONSettingsRepository:
         store.write(value: enabled, key: "app.menuBarStackedEnabled")
     }
 
+    public func menuBarStackedSize() -> String {
+        store.read(key: "app.menuBarStackedSize") ?? "small"
+    }
+
+    public func setMenuBarStackedSize(_ size: String) {
+        store.write(value: size, key: "app.menuBarStackedSize")
+    }
+
     public func menuBarPercentageProviderId() -> String {
         store.read(key: "app.menuBarPercentageProviderId") ?? "claude"
     }

--- a/Sources/Infrastructure/Storage/JSONSettingsRepository.swift
+++ b/Sources/Infrastructure/Storage/JSONSettingsRepository.swift
@@ -73,6 +73,14 @@ public final class JSONSettingsRepository:
         store.write(value: enabled, key: "app.menuBarDurationEnabled")
     }
 
+    public func menuBarStackedEnabled() -> Bool {
+        store.read(key: "app.menuBarStackedEnabled") ?? false
+    }
+
+    public func setMenuBarStackedEnabled(_ enabled: Bool) {
+        store.write(value: enabled, key: "app.menuBarStackedEnabled")
+    }
+
     public func menuBarPercentageProviderId() -> String {
         store.read(key: "app.menuBarPercentageProviderId") ?? "claude"
     }

--- a/Tests/DomainTests/Monitor/QuotaMonitorTests.swift
+++ b/Tests/DomainTests/Monitor/QuotaMonitorTests.swift
@@ -374,6 +374,121 @@ struct QuotaMonitorTests {
     }
 
     @Test
+    func `menu bar label carries a single segment when secondary empty`() async {
+        // Given
+        let monitor = await makeRefreshedClaudeMonitor(quotas: [
+            UsageQuota(percentRemaining: 75, quotaType: .session, providerId: "claude"),
+        ])
+
+        // When
+        let label = monitor.menuBarLabel(
+            providerId: "claude",
+            primaryQuotaKey: "session",
+            secondaryQuotaKey: "",
+            showPercentage: true,
+            showDuration: false,
+            mode: .remaining
+        )
+
+        // Then: one segment mirroring the joined text, so segment-based
+        // renderers read the same source as the single-line label
+        #expect(label?.segments == [
+            MenuBarLabel.Segment(text: "75%", status: .healthy),
+        ])
+    }
+
+    @Test
+    func `menu bar label carries both windows as separate segments`() async {
+        // Given: session 75% (healthy), weekly 35% (warning)
+        let monitor = await makeRefreshedClaudeMonitor(quotas: [
+            UsageQuota(percentRemaining: 75, quotaType: .session, providerId: "claude"),
+            UsageQuota(percentRemaining: 35, quotaType: .weekly, providerId: "claude"),
+        ])
+
+        // When
+        let label = monitor.menuBarLabel(
+            providerId: "claude",
+            primaryQuotaKey: "session",
+            secondaryQuotaKey: "weekly",
+            showPercentage: true,
+            showDuration: false,
+            mode: .remaining
+        )
+
+        // Then: joined text stays byte-identical (it doubles as the tooltip),
+        // while each segment keeps its own prefixed text and per-window status
+        // so a stacked renderer can tint the two lines independently
+        #expect(label?.text == "5h 75% | 7d 35%")
+        #expect(label?.status == .warning)
+        #expect(label?.segments == [
+            MenuBarLabel.Segment(text: "5h 75%", status: .healthy),
+            MenuBarLabel.Segment(text: "7d 35%", status: .warning),
+        ])
+    }
+
+    @Test
+    func `menu bar label segments cover the duration-only variant`() async {
+        // Given: session quota with reset ~3h away
+        let monitor = await makeRefreshedClaudeMonitor(quotas: [
+            UsageQuota(
+                percentRemaining: 75,
+                quotaType: .session,
+                providerId: "claude",
+                resetsAt: Date().addingTimeInterval(3.0 * 3600 + 30)
+            ),
+        ])
+
+        // When: duration only, no percentage
+        let label = monitor.menuBarLabel(
+            providerId: "claude",
+            primaryQuotaKey: "session",
+            secondaryQuotaKey: "",
+            showPercentage: false,
+            showDuration: true,
+            mode: .remaining
+        )
+
+        // Then
+        #expect(label?.text == "3h")
+        #expect(label?.segments == [
+            MenuBarLabel.Segment(text: "3h", status: .healthy),
+        ])
+    }
+
+    @Test
+    func `menu bar label segments cover percentage plus duration windows`() async {
+        // Given: both windows carry reset times
+        let monitor = await makeRefreshedClaudeMonitor(quotas: [
+            UsageQuota(
+                percentRemaining: 75,
+                quotaType: .session,
+                providerId: "claude",
+                resetsAt: Date().addingTimeInterval(3.0 * 3600 + 30)
+            ),
+            UsageQuota(
+                percentRemaining: 35,
+                quotaType: .weekly,
+                providerId: "claude",
+                resetsAt: Date().addingTimeInterval(6.0 * 86400 + 30)
+            ),
+        ])
+
+        // When: percentage and duration together
+        let label = monitor.menuBarLabel(
+            providerId: "claude",
+            primaryQuotaKey: "session",
+            secondaryQuotaKey: "weekly",
+            showPercentage: true,
+            showDuration: true,
+            mode: .remaining
+        )
+
+        // Then: segments carry the full "percentage · duration" window texts
+        #expect(label?.text == "5h 75% · 3h | 7d 35% · 6d")
+        #expect(label?.segments.map(\.text) == ["5h 75% · 3h", "7d 35% · 6d"])
+    }
+
+    @Test
     func `monitor skips unavailable providers`() async {
         // Given
         let settings = makeSettingsRepository()

--- a/Tests/DomainTests/Monitor/QuotaMonitorTests.swift
+++ b/Tests/DomainTests/Monitor/QuotaMonitorTests.swift
@@ -483,9 +483,14 @@ struct QuotaMonitorTests {
             mode: .remaining
         )
 
-        // Then: segments carry the full "percentage · duration" window texts
+        // Then: segments carry the full "percentage · duration" window texts,
+        // each with its own per-window status (matching the dual-window test)
         #expect(label?.text == "5h 75% · 3h | 7d 35% · 6d")
-        #expect(label?.segments.map(\.text) == ["5h 75% · 3h", "7d 35% · 6d"])
+        #expect(label?.status == .warning)
+        #expect(label?.segments == [
+            MenuBarLabel.Segment(text: "5h 75% · 3h", status: .healthy),
+            MenuBarLabel.Segment(text: "7d 35% · 6d", status: .warning),
+        ])
     }
 
     @Test

--- a/Tests/DomainTests/Provider/MenuBarStackedSizeTests.swift
+++ b/Tests/DomainTests/Provider/MenuBarStackedSizeTests.swift
@@ -1,0 +1,62 @@
+import Testing
+@testable import Domain
+
+@Suite
+struct MenuBarStackedSizeTests {
+
+    // MARK: - Raw Value Persistence
+
+    @Test
+    func `small size has small raw value`() {
+        #expect(MenuBarStackedSize.small.rawValue == "small")
+    }
+
+    @Test
+    func `medium size has medium raw value`() {
+        #expect(MenuBarStackedSize.medium.rawValue == "medium")
+    }
+
+    @Test
+    func `large size has large raw value`() {
+        #expect(MenuBarStackedSize.large.rawValue == "large")
+    }
+
+    @Test
+    func `can be created from raw value`() {
+        #expect(MenuBarStackedSize(rawValue: "small") == .small)
+        #expect(MenuBarStackedSize(rawValue: "medium") == .medium)
+        #expect(MenuBarStackedSize(rawValue: "large") == .large)
+        #expect(MenuBarStackedSize(rawValue: "invalid") == nil)
+    }
+
+    // MARK: - Fallback Decoding
+
+    @Test
+    func `default is small`() {
+        #expect(MenuBarStackedSize.default == .small)
+    }
+
+    @Test
+    func `known stored values decode to their case`() {
+        #expect(MenuBarStackedSize(storedRawValue: "small") == .small)
+        #expect(MenuBarStackedSize(storedRawValue: "medium") == .medium)
+        #expect(MenuBarStackedSize(storedRawValue: "large") == .large)
+    }
+
+    @Test
+    func `unknown stored value falls back to small`() {
+        // A settings file written by a newer build (or edited by hand) must
+        // never break this build: unrecognized sizes quietly render small.
+        #expect(MenuBarStackedSize(storedRawValue: "extra-large") == .small)
+        #expect(MenuBarStackedSize(storedRawValue: "") == .small)
+    }
+
+    // MARK: - Display Label
+
+    @Test
+    func `display labels read Small Medium Large`() {
+        #expect(MenuBarStackedSize.small.displayLabel == "Small")
+        #expect(MenuBarStackedSize.medium.displayLabel == "Medium")
+        #expect(MenuBarStackedSize.large.displayLabel == "Large")
+    }
+}

--- a/Tests/InfrastructureTests/Settings/JSONSettingsRepositoryAppTests.swift
+++ b/Tests/InfrastructureTests/Settings/JSONSettingsRepositoryAppTests.swift
@@ -153,6 +153,29 @@ struct JSONSettingsRepositoryAppTests {
     }
 
     @Test
+    func `menuBarStackedEnabled defaults to false`() {
+        let (repo, dir) = makeRepository()
+        defer { cleanup(dir) }
+
+        #expect(repo.menuBarStackedEnabled() == false)
+    }
+
+    @Test
+    func `setMenuBarStackedEnabled persists value`() {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claudebar-test-\(UUID().uuidString)")
+        let fileURL = tempDir.appendingPathComponent("settings.json")
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let store = JSONSettingsStore(fileURL: fileURL)
+        let repo1 = JSONSettingsRepository(store: store)
+        repo1.setMenuBarStackedEnabled(true)
+
+        let repo2 = JSONSettingsRepository(store: store)
+        #expect(repo2.menuBarStackedEnabled() == true)
+    }
+
+    @Test
     func `showDailyUsageCards defaults to true`() {
         let (repo, dir) = makeRepository()
         defer { cleanup(dir) }

--- a/Tests/InfrastructureTests/Settings/JSONSettingsRepositoryAppTests.swift
+++ b/Tests/InfrastructureTests/Settings/JSONSettingsRepositoryAppTests.swift
@@ -176,6 +176,29 @@ struct JSONSettingsRepositoryAppTests {
     }
 
     @Test
+    func `menuBarStackedSize defaults to small`() {
+        let (repo, dir) = makeRepository()
+        defer { cleanup(dir) }
+
+        #expect(repo.menuBarStackedSize() == "small")
+    }
+
+    @Test
+    func `setMenuBarStackedSize persists value`() {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claudebar-test-\(UUID().uuidString)")
+        let fileURL = tempDir.appendingPathComponent("settings.json")
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let store = JSONSettingsStore(fileURL: fileURL)
+        let repo1 = JSONSettingsRepository(store: store)
+        repo1.setMenuBarStackedSize("large")
+
+        let repo2 = JSONSettingsRepository(store: store)
+        #expect(repo2.menuBarStackedSize() == "large")
+    }
+
+    @Test
     func `showDailyUsageCards defaults to true`() {
         let (repo, dir) = makeRepository()
         defer { cleanup(dir) }


### PR DESCRIPTION
## What

Adds an opt-in **stacked** rendering mode for the dual-window menu bar label, plus a Small / Medium / Large size choice for it. When a secondary quota window is configured, the label can render as two smaller stacked lines instead of one long line, taking roughly half the menu bar width.

| Before (one line) | After (stacked, Small) |
|---|---|
| ![single line](https://raw.githubusercontent.com/jeffscottmtl/ClaudeBar/assets/stacked-menu-bar-preview/pr-before.png) | ![stacked](https://raw.githubusercontent.com/jeffscottmtl/ClaudeBar/assets/stacked-menu-bar-preview/pr-after.png) |

Size options (9 / 10 / 11 pt, default Small):

| Small | Medium | Large |
|---|---|---|
| ![small](https://raw.githubusercontent.com/jeffscottmtl/ClaudeBar/assets/stacked-menu-bar-preview/render-small.png) | ![medium](https://raw.githubusercontent.com/jeffscottmtl/ClaudeBar/assets/stacked-menu-bar-preview/render-medium.png) | ![large](https://raw.githubusercontent.com/jeffscottmtl/ClaudeBar/assets/stacked-menu-bar-preview/render-large.png) |

Each line keeps its own window's status colour. Today the joined line is tinted with the worst status of both windows, so a healthy session window turns orange when the weekly window is warning; stacked rendering tints each window independently.

## How

Commit 1, stacked mode:

- `MenuBarLabel` gains a `segments: [Segment]` breakdown (additive; a defaulting init keeps every existing call site source-compatible). `QuotaMonitor.menuBarLabel(...)` populates one segment per window; the joined `text` stays byte-identical and still serves as the tooltip.
- New `menuBarStackedEnabled` setting (default **off**), wired through `AppSettingsRepository` / `JSONSettingsRepository` (`app.menuBarStackedEnabled`) / `AppSettings`, mirroring `menuBarDurationEnabled` exactly.
- `StatusItemLabelDriver`: `LabelContent` carries a `stacked` flag; `compose` routes a dual-segment label to a new `StatusBarStackedImageRenderer` only when the setting is on. Every other case, including dual labels with the setting off, is unchanged.
- Settings UI: a "Stack in Menu Bar" toggle in the secondary-quota block, shown only when a secondary window is selected, following the existing toggle pattern.

Commit 2, sizes:

- `MenuBarStackedSize` Domain enum (raw String, unknown stored values fall back to `small`), persisted as `app.menuBarStackedSize`, mirroring `usageDisplayMode`. Point-size mapping lives in the App layer next to the renderer.
- Because two 10 or 11 pt line boxes no longer fit the menu bar's 22 pt envelope, the renderer measures each line's glyph ink with CoreText (`CTLineGetBoundsWithOptions(.useGlyphPathBounds)`) and switches to ink-anchored layout when the lines would collide, reclaiming the mostly empty ascender/descender allowance instead of letting glyphs overlap. Small always takes the original path and renders identically to commit 1. Measured ink clearance stays at or above +2.75 pt at Large, +1.25 pt at Medium, including descender-bearing labels; nothing draws outside the image bounds.
- Settings UI: a "STACKED TEXT SIZE" chip row using the same `MenuBarChoiceButton` component and section-label style as the PROVIDER and QUOTA rows, visible only when stacking is on.

Commit 4, drive-by fix found while testing:

- `normalizeSecondaryMenuBarSelection()` cleared the stored secondary quota whenever the quota-options list was empty, which is also the state during a cold start while the provider is still syncing; any Settings interaction in that window silently discarded the user's secondary selection. It now only clears when quota data is present and the key is genuinely invalid.

## Behaviour when off

No change: both settings default off/Small, the joined label text is byte-identical to before, and the single-line renderer is untouched.

## Tests

TDD, red first then green; full suite passes via `tuist test` (1590 tests).

- `QuotaMonitorTests`: dual-window labels expose two correctly prefixed segments with per-window statuses while the joined text stays unchanged; single-window, duration-only, and percentage-plus-duration variants covered.
- `MenuBarStackedSizeTests`: raw values, default, and unknown-value fallback to Small.
- `JSONSettingsRepositoryAppTests`: both new keys default correctly and round-trip.

No test target currently imports the App module, so the renderers have no unit tests; the geometry was verified with a CoreText/AppKit measurement harness at all three sizes and the result checked on a live menu bar in light and dark appearance. Happy to add an App-level test target, or a CHANGELOG entry, if you want either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdEQQ9aMGu6ep4CPW56Hn2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an opt-in stacked layout for dual-window menu-bar quota labels, rendering two vertically arranged lines in a single status item.
  - Introduced stacked size options (Small, Medium, Large) with localized picker text, plus persistent enablement and size settings.
  - Updated label data to expose per-window segments for stacked rendering.

- **Bug Fixes**
  - Prevented the secondary menu-bar selection from being cleared when quota options aren’t available yet.

- **Tests**
  - Added coverage for stacked label segments, stacked size decoding/display, and JSON settings defaults/persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->