### PR TITLE
fix(omp): drop duplicate account rows for reporting accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Oh My Pi no longer shows duplicate "No usage reported" account rows when
+  org-less stale credentials share an email with an account that already
+  reported usage; organization-scoped failures remain visible.
+
 ---
 
 ## [0.4.71] - 2026-07-13

--- a/Sources/Infrastructure/Omp/OmpUsageProbe.swift
+++ b/Sources/Infrastructure/Omp/OmpUsageProbe.swift
@@ -205,10 +205,36 @@ public struct OmpUsageProbe: UsageProbe {
 
         // Credentials the harness holds for usage-capable providers that
         // produced no attributable report (expired session, fetch failure).
-        // Surface them as explicit "No usage reported" rows — never as fake
-        // quotas — so the card covers the full credential pool, matching
-        // `omp usage`'s own account listing.
+        // Surface genuinely unmatched credentials as explicit
+        // "No usage reported" rows — never as fake quotas.
+        var emittedUnreportedAccounts: [UnreportedAccount] = []
         for account in payload.accountsWithoutUsage ?? [] {
+            let matchesReport = payload.reports.contains { report in
+                Self.emailOrAccountIdMatch(
+                    provider: account.provider,
+                    email: account.email,
+                    accountId: account.accountId,
+                    orgId: account.orgId,
+                    otherProvider: report.provider,
+                    otherEmail: report.metadata?.email,
+                    otherAccountId: report.matchableAccountId
+                )
+            }
+            let duplicatesRow = emittedUnreportedAccounts.contains { emitted in
+                guard !Self.hasOrganization(emitted.orgId) else { return false }
+                return Self.emailOrAccountIdMatch(
+                    provider: account.provider,
+                    email: account.email,
+                    accountId: account.accountId,
+                    orgId: account.orgId,
+                    otherProvider: emitted.provider,
+                    otherEmail: emitted.email,
+                    otherAccountId: emitted.accountId
+                )
+            }
+            guard !matchesReport, !duplicatesRow else { continue }
+
+            emittedUnreportedAccounts.append(account)
             let providerName = Self.upstreamDisplayName(account.provider)
             accountRows.append(Self.accountRow(
                 label: Self.uniqueLabel(
@@ -221,7 +247,6 @@ public struct OmpUsageProbe: UsageProbe {
                 )
             ))
         }
-
         guard !quotas.isEmpty || !accountRows.isEmpty else {
             throw ProbeError.noData
         }
@@ -233,6 +258,46 @@ public struct OmpUsageProbe: UsageProbe {
             accountEmail: Self.singleDistinctEmail(in: payload),
             extensionMetrics: accountRows.isEmpty ? nil : accountRows
         )
+    }
+
+    /// Provider-scoped identity match for defensively omitting only org-less
+    /// stale credential rows. Org-scoped credentials represent distinct limit
+    /// pools and remain visible even when an email or account id matches.
+    /// For org-less rows, normalized email is authoritative when both sides
+    /// have one; exact account id is the fallback when either email is absent.
+    private static func emailOrAccountIdMatch(
+        provider: String,
+        email: String?,
+        accountId: String?,
+        orgId: String?,
+        otherProvider: String,
+        otherEmail: String?,
+        otherAccountId: String?
+    ) -> Bool {
+        guard provider == otherProvider else { return false }
+        guard !Self.hasOrganization(orgId) else { return false }
+
+        if let email = Self.normalizedEmail(email),
+           let otherEmail = Self.normalizedEmail(otherEmail) {
+            return email == otherEmail
+        }
+
+        guard let accountId, !accountId.isEmpty,
+              let otherAccountId, !otherAccountId.isEmpty else {
+            return false
+        }
+        return accountId == otherAccountId
+    }
+
+    private static func normalizedEmail(_ email: String?) -> String? {
+        guard let email else { return nil }
+        let normalized = email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized.isEmpty ? nil : normalized
+    }
+
+    private static func hasOrganization(_ orgId: String?) -> Bool {
+        guard let orgId else { return false }
+        return !orgId.isEmpty
     }
 
     /// Returns `label`, suffixed if needed so it is unique within `seen`.
@@ -356,6 +421,7 @@ public struct OmpUsageProbe: UsageProbe {
         let type: String?
         let email: String?
         let accountId: String?
+        let orgId: String?
         let projectId: String?
         let enterpriseUrl: String?
 
@@ -373,6 +439,20 @@ public struct OmpUsageProbe: UsageProbe {
         let provider: String
         let limits: [UsageLimit]
         let metadata: ReportMetadata?
+
+        /// Account identity used for exact matching. Some providers place it
+        /// on limit scopes; project ids remain deliberately excluded.
+        var matchableAccountId: String? {
+            if let accountId = metadata?.accountId, !accountId.isEmpty {
+                return accountId
+            }
+            for limit in limits {
+                if let accountId = limit.scope?.accountId, !accountId.isEmpty {
+                    return accountId
+                }
+            }
+            return nil
+        }
 
         /// Full identity of this account, mirroring `omp usage`'s own
         /// `reportAccountLabel`: metadata email → accountId → projectId,

--- a/Tests/InfrastructureTests/Omp/OmpUsageProbeParsingTests.swift
+++ b/Tests/InfrastructureTests/Omp/OmpUsageProbeParsingTests.swift
@@ -327,6 +327,544 @@ struct OmpUsageProbeParsingTests {
         #expect(snapshot.accountEmail == "solo@example.com")
     }
 
+    @Test
+    func `suppresses unreported account with matching account id`() throws {
+        let json = """
+        { "reports": [ {
+            "provider": "anthropic",
+            "limits": [ {
+              "scope": { "windowId": "5h" },
+              "window": { "id": "5h" },
+              "amount": { "remainingFraction": 0.9 }
+            } ],
+            "metadata": { "accountId": "account-123" }
+        } ],
+          "accountsWithoutUsage": [
+            { "provider": "anthropic", "type": "oauth", "accountId": "account-123" }
+          ] }
+        """
+        let snapshot = try OmpUsageProbe.parse(json)
+
+        #expect(snapshot.quotas.count == 1)
+        #expect(snapshot.extensionMetrics == nil)
+    }
+
+    @Test
+    func `suppresses unreported account matching scoped account id`() throws {
+        let json = """
+        { "reports": [ {
+            "provider": "google-gemini-cli",
+            "limits": [ {
+              "scope": {
+                "windowId": "1d",
+                "accountId": "scoped-account-123"
+              },
+              "window": { "id": "1d" },
+              "amount": { "remainingFraction": 0.9 }
+            } ]
+        } ],
+          "accountsWithoutUsage": [
+            {
+              "provider": "google-gemini-cli",
+              "type": "oauth",
+              "accountId": "scoped-account-123"
+            }
+          ] }
+        """
+        let snapshot = try OmpUsageProbe.parse(json)
+
+        #expect(snapshot.quotas.count == 1)
+        #expect(snapshot.extensionMetrics == nil)
+    }
+
+    @Test
+    func `matching account id on different provider does not suppress unreported account`() throws {
+        let json = """
+        { "reports": [ {
+            "provider": "anthropic",
+            "limits": [ {
+              "scope": { "windowId": "5h" },
+              "window": { "id": "5h" },
+              "amount": { "remainingFraction": 0.9 }
+            } ],
+            "metadata": { "accountId": "shared-account-id" }
+        } ],
+          "accountsWithoutUsage": [
+            {
+              "provider": "github-copilot",
+              "type": "oauth",
+              "accountId": "shared-account-id"
+            }
+          ] }
+        """
+        let snapshot = try OmpUsageProbe.parse(json)
+
+        #expect(snapshot.extensionMetrics?.map(\.label) == ["Copilot · shared-account-id"])
+    }
+
+    @Test
+    func `suppresses unreported account with normalized matching email`() throws {
+        let json = """
+        { "reports": [ {
+            "provider": "anthropic",
+            "limits": [ {
+              "scope": { "windowId": "5h" },
+              "window": { "id": "5h" },
+              "amount": { "remainingFraction": 0.9 }
+            } ],
+            "metadata": { "email": " Alice@Example.COM " }
+        } ],
+          "accountsWithoutUsage": [
+            { "provider": "anthropic", "type": "oauth", "email": "alice@example.com" }
+          ] }
+        """
+        let snapshot = try OmpUsageProbe.parse(json)
+
+        #expect(snapshot.extensionMetrics == nil)
+    }
+
+    @Test
+    func `matching email overrides different credential account ids`() throws {
+        let json = """
+        { "reports": [ {
+            "provider": "anthropic",
+            "limits": [ {
+              "scope": { "windowId": "5h" },
+              "window": { "id": "5h" },
+              "amount": { "remainingFraction": 0.9 }
+            } ],
+            "metadata": {
+              "email": "alice@example.com",
+              "accountId": "report-credential-id"
+            }
+        } ],
+          "accountsWithoutUsage": [ {
+            "provider": "anthropic",
+            "type": "oauth",
+            "email": "alice@example.com",
+            "accountId": "stale-credential-id"
+          } ] }
+        """
+        let snapshot = try OmpUsageProbe.parse(json)
+
+        #expect(snapshot.extensionMetrics == nil)
+    }
+
+    @Test
+    func `same email with differing organization keeps unreported account visible`() throws {
+        let json = """
+        { "reports": [ {
+            "provider": "anthropic",
+            "limits": [ {
+              "scope": { "windowId": "5h" },
+              "window": { "id": "5h" },
+              "amount": { "remainingFraction": 0.9 }
+            } ],
+            "metadata": {
+              "email": "alice@example.com",
+              "orgId": "reported-org"
+            }
+        } ],
+          "accountsWithoutUsage": [ {
+            "provider": "anthropic",
+            "type": "oauth",
+            "email": "alice@example.com",
+            "orgId": "unreported-org"
+          } ] }
+        """
+        let snapshot = try OmpUsageProbe.parse(json)
+
+        #expect(snapshot.extensionMetrics?.map(\.label) == ["Claude · alice@example.com"])
+    }
+
+    @Test
+    func `same email and organization keeps upstream unreported account visible`() throws {
+        // omp's org gate normally absorbs this identity into the same-org
+        // report. If it still reaches ClaudeBar, preserve omp's decision to
+        // surface the failed fetch instead of second-guessing it by email.
+        let json = """
+        { "reports": [ {
+            "provider": "anthropic",
+            "limits": [ {
+              "scope": { "windowId": "5h" },
+              "window": { "id": "5h" },
+              "amount": { "remainingFraction": 0.9 }
+            } ],
+            "metadata": {
+              "email": "alice@example.com",
+              "orgId": "same-org"
+            }
+        } ],
+          "accountsWithoutUsage": [ {
+            "provider": "anthropic",
+            "type": "oauth",
+            "email": "alice@example.com",
+            "orgId": "same-org"
+          } ] }
+        """
+        let snapshot = try OmpUsageProbe.parse(json)
+
+        #expect(snapshot.extensionMetrics?.map(\.label) == ["Claude · alice@example.com"])
+    }
+
+    @Test
+    func `organization-scoped account id match keeps unreported account visible`() throws {
+        let json = """
+        { "reports": [ {
+            "provider": "anthropic",
+            "limits": [ {
+              "scope": { "windowId": "5h" },
+              "window": { "id": "5h" },
+              "amount": { "remainingFraction": 0.9 }
+            } ],
+            "metadata": { "accountId": "shared-account-id" }
+        } ],
+          "accountsWithoutUsage": [ {
+            "provider": "anthropic",
+            "type": "oauth",
+            "accountId": "shared-account-id",
+            "orgId": "unreported-org"
+          } ] }
+        """
+        let snapshot = try OmpUsageProbe.parse(json)
+
+        #expect(snapshot.extensionMetrics?.map(\.label) == ["Claude · shared-account-id"])
+    }
+
+    @Test
+    func `same email on different provider does not suppress unreported account`() throws {
+        let json = """
+        { "reports": [ {
+            "provider": "anthropic",
+            "limits": [ {
+              "scope": { "windowId": "5h" },
+              "window": { "id": "5h" },
+              "amount": { "remainingFraction": 0.9 }
+            } ],
+            "metadata": { "email": "shared@example.com" }
+        } ],
+          "accountsWithoutUsage": [
+            { "provider": "github-copilot", "type": "oauth", "email": "shared@example.com" }
+          ] }
+        """
+        let snapshot = try OmpUsageProbe.parse(json)
+
+        #expect(snapshot.extensionMetrics?.map(\.label) == ["Copilot · shared@example.com"])
+    }
+
+    @Test
+    func `different identities on one provider both render`() throws {
+        let json = """
+        { "reports": [ {
+            "provider": "anthropic",
+            "limits": [ {
+              "scope": { "windowId": "5h" },
+              "window": { "id": "5h" },
+              "amount": { "remainingFraction": 0.9 }
+            } ],
+            "metadata": {
+              "email": "alice@example.com",
+              "accountId": "alice-credential"
+            }
+        } ],
+          "accountsWithoutUsage": [ {
+            "provider": "anthropic",
+            "type": "oauth",
+            "email": "bob@example.com",
+            "accountId": "bob-credential"
+          } ] }
+        """
+        let snapshot = try OmpUsageProbe.parse(json)
+
+        #expect(snapshot.quotas.count == 1)
+        #expect(snapshot.extensionMetrics?.map(\.label) == ["Claude · bob@example.com"])
+        #expect(snapshot.quotaGroups.map(\.title) == ["Claude", "Claude · bob"])
+    }
+
+    @Test
+    func `different emails do not fall back to matching account id`() throws {
+        let json = """
+        { "reports": [ {
+            "provider": "anthropic",
+            "limits": [ {
+              "scope": { "windowId": "5h" },
+              "window": { "id": "5h" },
+              "amount": { "remainingFraction": 0.9 }
+            } ],
+            "metadata": {
+              "email": "alice@example.com",
+              "accountId": "shared-credential-id"
+            }
+        } ],
+          "accountsWithoutUsage": [ {
+            "provider": "anthropic",
+            "type": "oauth",
+            "email": "bob@example.com",
+            "accountId": "shared-credential-id"
+          } ] }
+        """
+        let snapshot = try OmpUsageProbe.parse(json)
+
+        #expect(snapshot.extensionMetrics?.map(\.label) == ["Claude · bob@example.com"])
+    }
+
+    @Test
+    func `shared project id does not suppress unreported account`() throws {
+        let json = """
+        { "reports": [ {
+            "provider": "google-gemini-cli",
+            "limits": [ {
+              "scope": { "windowId": "1d" },
+              "window": { "id": "1d" },
+              "amount": { "remainingFraction": 0.9 }
+            } ],
+            "metadata": { "projectId": "shared-project" }
+        } ],
+          "accountsWithoutUsage": [ {
+            "provider": "google-gemini-cli",
+            "type": "oauth",
+            "projectId": "shared-project"
+          } ] }
+        """
+        let snapshot = try OmpUsageProbe.parse(json)
+
+        #expect(snapshot.extensionMetrics?.map(\.label) == ["Gemini · shared-project"])
+    }
+
+    @Test
+    func `identical whitespace emails with different account ids stay distinct`() throws {
+        let json = """
+        { "reports": [],
+          "accountsWithoutUsage": [
+            {
+              "provider": "anthropic",
+              "type": "oauth",
+              "email": " ",
+              "accountId": "first-credential"
+            },
+            {
+              "provider": "anthropic",
+              "type": "oauth",
+              "email": " ",
+              "accountId": "second-credential"
+            }
+          ] }
+        """
+        let snapshot = try OmpUsageProbe.parse(json)
+
+        #expect(snapshot.extensionMetrics?.count == 2)
+    }
+
+    @Test
+    func `identical whitespace emails fall back to identical account ids`() throws {
+        let json = """
+        { "reports": [],
+          "accountsWithoutUsage": [
+            {
+              "provider": "anthropic",
+              "type": "oauth",
+              "email": " ",
+              "accountId": "same-credential"
+            },
+            {
+              "provider": "anthropic",
+              "type": "oauth",
+              "email": " ",
+              "accountId": "same-credential"
+            }
+          ] }
+        """
+        let snapshot = try OmpUsageProbe.parse(json)
+
+        #expect(snapshot.extensionMetrics?.count == 1)
+    }
+
+    @Test
+    func `duplicate identified unreported accounts collapse to one row`() throws {
+        let json = """
+        { "reports": [],
+          "accountsWithoutUsage": [
+            {
+              "provider": "anthropic",
+              "type": "oauth",
+              "email": "alice@example.com",
+              "accountId": "first-credential"
+            },
+            {
+              "provider": "anthropic",
+              "type": "oauth",
+              "email": " ALICE@example.com ",
+              "accountId": "second-credential"
+            }
+          ] }
+        """
+        let snapshot = try OmpUsageProbe.parse(json)
+        let metrics = try #require(snapshot.extensionMetrics)
+
+        #expect(metrics.count == 1)
+        #expect(metrics[0].label == "Claude · alice@example.com")
+    }
+
+    @Test
+    func `organization-scoped unreported accounts with same email both render`() throws {
+        let json = """
+        { "reports": [],
+          "accountsWithoutUsage": [
+            {
+              "provider": "anthropic",
+              "type": "oauth",
+              "email": "alice@example.com",
+              "accountId": "first-credential",
+              "orgId": "first-org"
+            },
+            {
+              "provider": "anthropic",
+              "type": "oauth",
+              "email": "alice@example.com",
+              "accountId": "second-credential",
+              "orgId": "second-org"
+            }
+          ] }
+        """
+        let snapshot = try OmpUsageProbe.parse(json)
+
+        #expect(snapshot.extensionMetrics?.count == 2)
+    }
+
+    @Test
+    func `mixed organization and legacy unreported accounts stay distinct regardless of order`() throws {
+        let organizationFirst = """
+        { "reports": [],
+          "accountsWithoutUsage": [
+            {
+              "provider": "anthropic",
+              "type": "oauth",
+              "email": "alice@example.com",
+              "accountId": "organization-credential",
+              "orgId": "organization"
+            },
+            {
+              "provider": "anthropic",
+              "type": "oauth",
+              "email": "alice@example.com",
+              "accountId": "legacy-credential"
+            }
+          ] }
+        """
+        let legacyFirst = """
+        { "reports": [],
+          "accountsWithoutUsage": [
+            {
+              "provider": "anthropic",
+              "type": "oauth",
+              "email": "alice@example.com",
+              "accountId": "legacy-credential"
+            },
+            {
+              "provider": "anthropic",
+              "type": "oauth",
+              "email": "alice@example.com",
+              "accountId": "organization-credential",
+              "orgId": "organization"
+            }
+          ] }
+        """
+
+        let organizationFirstSnapshot = try OmpUsageProbe.parse(organizationFirst)
+        let legacyFirstSnapshot = try OmpUsageProbe.parse(legacyFirst)
+
+        #expect(organizationFirstSnapshot.extensionMetrics?.count == 2)
+        #expect(legacyFirstSnapshot.extensionMetrics?.count == 2)
+    }
+
+    @Test
+    func `zero-limit report identity suppresses matching unreported account`() throws {
+        let json = """
+        { "reports": [ {
+            "provider": "ollama",
+            "limits": [],
+            "metadata": { "email": "local@ollama.dev" }
+        } ],
+          "accountsWithoutUsage": [
+            { "provider": "ollama", "type": "oauth", "email": "LOCAL@OLLAMA.DEV" }
+          ] }
+        """
+        let snapshot = try OmpUsageProbe.parse(json)
+
+        #expect(snapshot.extensionMetrics?.map(\.label) == ["Ollama · local@ollama.dev"])
+        #expect(snapshot.quotaGroups.map(\.title) == ["Ollama · local"])
+    }
+
+    @Test
+    func `anonymous unreported account never matches anonymous report`() throws {
+        let json = """
+        { "reports": [ {
+            "provider": "ollama",
+            "limits": []
+        } ],
+          "accountsWithoutUsage": [
+            { "provider": "ollama", "type": "oauth" }
+          ] }
+        """
+        let snapshot = try OmpUsageProbe.parse(json)
+
+        #expect(snapshot.extensionMetrics?.map(\.label) == [
+            "Ollama · account 1",
+            "Ollama · OAuth account",
+        ])
+    }
+
+    @Test
+    func `live duplicate shape keeps two quota groups and drops stale rows`() throws {
+        let json = """
+        { "reports": [
+          {
+            "provider": "anthropic",
+            "limits": [ {
+              "scope": { "windowId": "5h" },
+              "window": { "id": "5h" },
+              "amount": { "remainingFraction": 0.9 }
+            } ],
+            "metadata": {
+              "email": "alice@example.com",
+              "accountId": "alice-report-credential"
+            }
+          },
+          {
+            "provider": "anthropic",
+            "limits": [ {
+              "scope": { "windowId": "5h" },
+              "window": { "id": "5h" },
+              "amount": { "remainingFraction": 0.4 }
+            } ],
+            "metadata": {
+              "email": "bob@example.com",
+              "accountId": "bob-report-credential"
+            }
+          }
+        ],
+          "accountsWithoutUsage": [
+            {
+              "provider": "anthropic",
+              "type": "oauth",
+              "email": "alice@example.com",
+              "accountId": "alice-stale-credential"
+            },
+            {
+              "provider": "anthropic",
+              "type": "oauth",
+              "email": "bob@example.com",
+              "accountId": "bob-stale-credential"
+            }
+          ] }
+        """
+        let snapshot = try OmpUsageProbe.parse(json)
+
+        #expect(snapshot.quotas.count == 2)
+        #expect(snapshot.quotaGroups.map(\.title) == ["Claude · alice", "Claude · bob"])
+        #expect(snapshot.extensionMetrics == nil)
+    }
+
     // MARK: - Reports Without Usable Limits
 
     @Test


### PR DESCRIPTION
## Summary

Defensively suppresses duplicate display rows in the Oh My Pi card when `omp usage --json` reports usage for an account and also lists an org-less stale sibling credential in `accountsWithoutUsage`.

The visible symptom is a quota-bearing section such as `Claude · alice` followed by a note-only `Claude · alice (2) — No usage reported`. In the live omp 16.5.1 payload, each stale entry had a byte-equal email to a reporting account, a different `accountId`, and no `orgId`, while the corresponding report carried an `orgId`. ClaudeBar previously rendered every retained entry. The `(2)` comes from ClaudeBar's `uniqueLabel` collision guard after the stale row derives the same shortened group title as the quota section; it prevents a UI identifier collision, but is not itself evidence of full-identity equality.

This is intentionally a defensive display fix, not a claim that ClaudeBar can repair omp's stored credentials or attribution.

## The rule

Suppression is provider-scoped and deliberately limited to org-less unreported identities ClaudeBar can attribute safely:

- an unreported entry carrying a non-empty `orgId` is never suppressed by email or `accountId`; distinct Anthropic organizations have distinct limit pools, and a failed fetch for an org-scoped credential must remain visible
- for an org-less entry, normalized email (trimmed and case-insensitive) is primary; an exact normalized match suppresses the stale row even when both payload `accountId` values are present and different
- exact non-empty `accountId` is the fallback only when either side has no usable email
- two different present emails do not match, even if their account ids agree
- provider boundaries, `projectId`, and shortened display labels never match accounts

The same rule applies within `accountsWithoutUsage`: only two org-less entries can collapse. Mixed org-scoped and org-less entries remain visible regardless of order. A same-email, same-org entry would normally be absorbed by omp's own org gate; if one still reaches ClaudeBar, ClaudeBar preserves omp's decision to surface it instead of second-guessing it by email.

The payload `accountId` is the provider's account UUID, not omp's credential-row id. omp's `AuthStorage.getAll()` projects `entry.credential`, and `usage-cli.ts` copies `credential.accountId` into `accountsWithoutUsage`; the SQLite row id is a separate numeric `StoredAuthCredential.id`.

## Tradeoffs and non-goals

- An org-less credential that actually represents a distinct same-email limit pool is indistinguishable from an org-less stale sibling and will be suppressed when a reporting identity matches. An orgId-bearing credential is never suppressed for that reason.
- This does not fix omp's underlying credential accumulation or usage attribution. That root fix belongs in omp's auth storage and `usage-cli` org gate. omp 16.5.1 explicitly documents the supported multi-org shape in `auth-storage.ts`:

  > One Anthropic account email can hold several organizations ... each with its own org-scoped token and limit pools.

  Its `collectUnreportedAccounts` gate then deliberately retains legacy org-less rows when any sibling report is org-attributed:

  ```ts
  if (accountOrg || sawReportOrg) {
      if (!accountOrg || sameOrgReports.length === 0) return true;
      // same-org base-identity attribution follows
  }
  ```

## Test plan

- `tuist test ClaudeBar --no-selective-testing --result-bundle-path /tmp/ClaudeBarOmpDedupFinal.xcresult`
  - `xcresulttool`: **1,668 passed, 0 failed, 0 skipped** (**1,687 expanded executions** including dynamic parameters)
- `OmpUsageProbeParsingTests` cover:
  - accountId-only and normalized-email matches, including same email with different payload account ids (the live-observed stale shape)
  - org-scoped entries with differing and equal report org ids remaining visible
  - accountId fallback respecting the org-less guard and using report metadata or scoped account ids (never project ids)
  - org-scoped, org-less, and mixed within-list entries, including both input orders
  - provider isolation for both email and accountId paths
  - identical whitespace-only emails falling back to differing or identical account ids
  - differing identities, shared project ids, anonymous identities, zero-limit reports, and the two-report live duplicate fixture
- Live smoke against installed omp 16.5.1: the real payload contained four reports plus two org-less same-provider/email stale entries and no org-bearing unreported entries. Relaunching the built app showed the Oh My Pi card with four quota collections and zero `No usage reported` rows. The local screenshot contains account identities and remains outside the repository; it is not attached to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate “No usage reported” account rows in Oh My Pi when stale credentials share an email or account ID with an account that already has usage; org-scoped failures remain visible.
* **Tests**
  * Expanded parsing tests for identity matching, including email normalization, provider separation, org vs org-less handling, deduping, anonymous behavior, and zero-limit report scenarios.
* **Documentation**
  * Updated the Unreleased changelog entry to describe the duplicate-row fix behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->