### PR TITLE
feat: render Claude Extra-usage spend and omp USD limits as monetary meters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Claude Extra Usage now reads the current OAuth `spend` payload (with the
+  legacy `extra_usage` shape as a tolerant fallback), converts minor units with
+  exponent-aware decimal math, and renders spend as a distinct "EXTRA USAGE"
+  card with capped remaining budget or an explicit "No monthly cap" state.
+- Oh My Pi (`omp`) USD limits now render as monetary spend meters: capped rows
+  show "$X of $Y" while preserving their percentage-driven status and progress,
+  and uncapped rows become account notes such as "$X spent · no cap" instead of
+  being dropped or assigned a fabricated percentage.
+
+### Fixed
+- Grouped provider notes now accumulate in source order rather than overwriting
+  one another, so spend notes and other account notes remain visible together.
+- Claude's configured API budget now applies only to API-cost cards; it no
+  longer supplies a misleading cap for uncapped Extra Usage.
+
 ---
 
 ## [0.4.71] - 2026-07-13

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ A macOS menu bar application that monitors AI coding assistant usage quotas. Kee
   - [Kiro](https://kiro.dev) (`kiro-cli`) - Requires kiro-cli installation (see below)
   - [Amp](https://ampcode.com) (`amp`) - Auto-detected when CLI is installed
   - [OpenCode Go](https://opencode.ai/go) (`opencode`) - Tracks OpenCode Go usage windows (5hr/$12, weekly/$30, monthly/$60) via local SQLite DB
-  - [Oh My Pi](https://omp.sh) (`omp`) - Shows the rate-limit windows of every account the harness is signed into (Claude, Codex, Z.ai, ...) via `omp usage --json`
+  - [Oh My Pi](https://omp.sh) (`omp`) - Aggregates account usage via `omp usage --json`, showing rate-limit windows and, where reported, capped USD money cards or uncapped spend notes
 
 ### Kimi Setup
 

--- a/Sources/App/Views/CostStatCard.swift
+++ b/Sources/App/Views/CostStatCard.swift
@@ -222,6 +222,7 @@ struct CostStatCard: View {
         let formatter = NumberFormatter()
         formatter.numberStyle = .currency
         formatter.currencyCode = "USD"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.minimumFractionDigits = 0
         formatter.maximumFractionDigits = 2
         return formatter.string(from: budget as NSDecimalNumber) ?? "$\(budget)"

--- a/Sources/App/Views/CostStatCard.swift
+++ b/Sources/App/Views/CostStatCard.swift
@@ -19,10 +19,32 @@ struct CostStatCard: View {
         self.delay = delay
     }
 
-    /// The effective budget - prefer built-in budget from CostUsage (Pro Extra usage),
-    /// fall back to external budget (API account settings)
+    /// Extra usage uses only its server-provided monthly cap. API cost can
+    /// fall back to the budget configured in settings.
     private var effectiveBudget: Decimal? {
-        costUsage.budget ?? externalBudget
+        switch costUsage.kind {
+        case .extraUsage:
+            costUsage.budget
+        case .apiCost:
+            costUsage.budget ?? externalBudget
+        }
+    }
+
+    private var effectiveBudgetRemaining: Decimal? {
+        if let remaining = costUsage.budgetRemaining {
+            return remaining
+        }
+        guard let externalBudget else { return nil }
+        return max(0, externalBudget - costUsage.totalCost)
+    }
+
+    private var headerTitle: String {
+        switch costUsage.kind {
+        case .apiCost:
+            "API COST"
+        case .extraUsage:
+            "EXTRA USAGE"
+        }
     }
 
     private var budgetStatus: BudgetStatus? {
@@ -45,7 +67,7 @@ struct CostStatCard: View {
                         .font(.system(size: 9, weight: .bold))
                         .foregroundStyle(budgetStatusColor)
 
-                    Text("API COST")
+                    Text(headerTitle)
                         .font(.system(size: 8, weight: .semibold, design: theme.fontDesign))
                         .foregroundStyle(theme.textSecondary)
                         .tracking(0.3)
@@ -66,11 +88,21 @@ struct CostStatCard: View {
                     .font(.system(size: 28, weight: .heavy, design: theme.fontDesign))
                     .foregroundStyle(theme.textPrimary)
                     .contentTransition(.numericText())
+
+                if let budget = effectiveBudget {
+                    Text("of \(formatBudget(budget))")
+                        .font(.system(size: 12, weight: .semibold, design: theme.fontDesign))
+                        .foregroundStyle(theme.textSecondary)
+                }
             }
 
             // Budget progress bar (if budget is set)
             if let budget = effectiveBudget, budget > 0 {
                 budgetProgressBar(budget: budget)
+            } else if costUsage.kind == .extraUsage, effectiveBudget == nil {
+                Text("No monthly cap")
+                    .font(.system(size: 8, weight: .semibold, design: theme.fontDesign))
+                    .foregroundStyle(theme.textTertiary)
             }
 
             // Show API Duration if > 0, or reset time for Pro Extra usage
@@ -143,12 +175,14 @@ struct CostStatCard: View {
             .frame(height: 5)
 
             // Budget label
-            HStack {
-                Text("\(Int(budgetPercentUsed))% of \(formatBudget(budget)) budget")
-                    .font(.system(size: 8, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(theme.textTertiary)
+            if let remaining = effectiveBudgetRemaining {
+                HStack {
+                    Text("\(Int(budgetPercentUsed))% used · \(formatBudget(remaining)) left")
+                        .font(.system(size: 8, weight: .semibold, design: theme.fontDesign))
+                        .foregroundStyle(theme.textTertiary)
 
-                Spacer()
+                    Spacer()
+                }
             }
         }
     }
@@ -196,41 +230,38 @@ struct CostStatCard: View {
 
 // MARK: - Preview
 
-#Preview("Cost Card - Dark") {
+#Preview("Extra Usage - Capped Zero") {
     ZStack {
         DarkTheme().backgroundGradient
 
         CostStatCard(
             costUsage: CostUsage(
-                totalCost: 0.55,
-                apiDuration: 379.7,
-                wallDuration: 23590.2,
-                linesAdded: 150,
-                linesRemoved: 42,
-                providerId: "claude"
-            ),
-            budget: 10.00
+                totalCost: 0,
+                budget: 500,
+                apiDuration: 0,
+                providerId: "claude",
+                kind: .extraUsage
+            )
         )
         .padding()
     }
-    .frame(width: 380, height: 200)
+    .frame(width: 380, height: 180)
     .preferredColorScheme(.dark)
 }
 
-#Preview("Cost Card - Light") {
+#Preview("Extra Usage - Capped Partial") {
     ZStack {
         LightTheme().backgroundGradient
 
         CostStatCard(
             costUsage: CostUsage(
-                totalCost: 8.50,
-                apiDuration: 3600,
-                wallDuration: 7200,
-                linesAdded: 500,
-                linesRemoved: 200,
-                providerId: "claude"
-            ),
-            budget: 10.00
+                totalCost: 5.41,
+                budget: 20,
+                apiDuration: 0,
+                providerId: "claude",
+                kind: .extraUsage,
+                resetText: "Resets Jan 1, 2026"
+            )
         )
         .padding()
     }
@@ -238,22 +269,38 @@ struct CostStatCard: View {
     .preferredColorScheme(.light)
 }
 
-#Preview("Cost Card - No Budget") {
+#Preview("Extra Usage - Uncapped Spent") {
     ZStack {
         DarkTheme().backgroundGradient
 
         CostStatCard(
             costUsage: CostUsage(
-                totalCost: 2.35,
-                apiDuration: 600,
-                wallDuration: 1800,
-                linesAdded: 50,
-                linesRemoved: 10,
-                providerId: "claude"
+                totalCost: Decimal(string: "1234.56")!,
+                apiDuration: 0,
+                providerId: "claude",
+                kind: .extraUsage
             )
         )
         .padding()
     }
-    .frame(width: 380, height: 180)
+    .frame(width: 380, height: 160)
+    .preferredColorScheme(.dark)
+}
+
+#Preview("API Cost") {
+    ZStack {
+        DarkTheme().backgroundGradient
+
+        CostStatCard(
+            costUsage: CostUsage(
+                totalCost: 0.55,
+                apiDuration: 379.7,
+                providerId: "claude"
+            ),
+            budget: 10
+        )
+        .padding()
+    }
+    .frame(width: 380, height: 200)
     .preferredColorScheme(.dark)
 }

--- a/Sources/App/Views/MenuContentView.swift
+++ b/Sources/App/Views/MenuContentView.swift
@@ -1004,14 +1004,17 @@ struct WrappedStatCard: View {
                    let dollarCap = quota.formattedDollarCap {
                     HStack(alignment: .firstTextBaseline, spacing: 2) {
                         Text(dollarUsed)
-                            .font(.system(size: 28, weight: .heavy, design: theme.fontDesign))
+                            .font(.system(size: 20, weight: .heavy, design: theme.fontDesign))
                             .foregroundStyle(theme.textPrimary)
                             .contentTransition(.numericText())
 
                         Text("of \(dollarCap)")
-                            .font(.system(size: 12, weight: .semibold, design: theme.fontDesign))
+                            .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
                             .foregroundStyle(theme.textSecondary)
                     }
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+                    .layoutPriority(1)
                 } else if let dollarText = quota.formattedDollarRemaining {
                     Text(dollarText)
                         .font(.system(size: 18, weight: .bold, design: theme.fontDesign))
@@ -1030,10 +1033,11 @@ struct WrappedStatCard: View {
                     }
                 }
 
-                Spacer()
+                Spacer(minLength: 4)
 
                 Text(valueCaption)
-                    .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
+                    .font(.system(size: isCappedSpend ? 10 : 12, weight: .medium, design: theme.fontDesign))
+                    .fixedSize()
                     .foregroundStyle(effectiveDisplayMode == .pace ? paceColor.opacity(0.8) : theme.textTertiary)
             }
 

--- a/Sources/App/Views/MenuContentView.swift
+++ b/Sources/App/Views/MenuContentView.swift
@@ -955,6 +955,16 @@ struct WrappedStatCard: View {
         theme.statusColor(for: quota.status)
     }
 
+    private var isCappedSpend: Bool {
+        quota.dollarUsed != nil && quota.dollarCap != nil
+    }
+
+    private var valueCaption: String {
+        if isCappedSpend { return "Spent" }
+        if quota.isDollarBased { return "Remaining" }
+        return effectiveDisplayMode.displayLabel
+    }
+
     /// The color used for the pace label/number
     private var paceColor: Color {
         quota.pace.displayColor
@@ -990,7 +1000,19 @@ struct WrappedStatCard: View {
 
             // Large value display with label (end-aligned)
             HStack(alignment: .firstTextBaseline) {
-                if let dollarText = quota.formattedDollarRemaining {
+                if let dollarUsed = quota.formattedDollarUsed,
+                   let dollarCap = quota.formattedDollarCap {
+                    HStack(alignment: .firstTextBaseline, spacing: 2) {
+                        Text(dollarUsed)
+                            .font(.system(size: 28, weight: .heavy, design: theme.fontDesign))
+                            .foregroundStyle(theme.textPrimary)
+                            .contentTransition(.numericText())
+
+                        Text("of \(dollarCap)")
+                            .font(.system(size: 12, weight: .semibold, design: theme.fontDesign))
+                            .foregroundStyle(theme.textSecondary)
+                    }
+                } else if let dollarText = quota.formattedDollarRemaining {
                     Text(dollarText)
                         .font(.system(size: 18, weight: .bold, design: theme.fontDesign))
                         .foregroundStyle(theme.textPrimary)
@@ -1010,7 +1032,7 @@ struct WrappedStatCard: View {
 
                 Spacer()
 
-                Text(quota.isDollarBased ? "Remaining" : effectiveDisplayMode.displayLabel)
+                Text(valueCaption)
                     .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
                     .foregroundStyle(effectiveDisplayMode == .pace ? paceColor.opacity(0.8) : theme.textTertiary)
             }

--- a/Sources/Domain/Provider/CostUsage.swift
+++ b/Sources/Domain/Provider/CostUsage.swift
@@ -3,6 +3,14 @@ import Foundation
 /// Represents cost-based usage data for Claude accounts.
 /// Used for API accounts (pay-per-use) and Pro accounts with Extra usage enabled.
 public struct CostUsage: Sendable, Equatable, Hashable {
+    public enum Kind: Sendable, Equatable, Hashable {
+        case apiCost
+        case extraUsage
+    }
+
+    /// Whether this represents general API cost or subscription Extra usage.
+    public let kind: Kind
+
     /// The total cost/spent amount in dollars
     public let totalCost: Decimal
 
@@ -44,10 +52,12 @@ public struct CostUsage: Sendable, Equatable, Hashable {
         linesAdded: Int = 0,
         linesRemoved: Int = 0,
         providerId: String,
+        kind: Kind = .apiCost,
         capturedAt: Date = Date(),
         resetsAt: Date? = nil,
         resetText: String? = nil
     ) {
+        self.kind = kind
         self.totalCost = totalCost
         self.budget = budget
         self.apiDuration = apiDuration
@@ -112,6 +122,12 @@ public struct CostUsage: Sendable, Equatable, Hashable {
     public var budgetPercentUsedFromBuiltIn: Double? {
         guard let budget else { return nil }
         return budgetPercentUsed(budget: budget)
+    }
+
+    /// The unspent built-in budget, floored at zero.
+    public var budgetRemaining: Decimal? {
+        guard let budget else { return nil }
+        return max(0, budget - totalCost)
     }
 
     /// Formatted budget string (e.g., "$20.00")

--- a/Sources/Domain/Provider/UsageQuota.swift
+++ b/Sources/Domain/Provider/UsageQuota.swift
@@ -27,6 +27,14 @@ public struct UsageQuota: Sendable, Equatable, Hashable, Comparable {
     /// nil for percentage-based quotas that have a known total.
     public let dollarRemaining: Decimal?
 
+    /// Dollars spent for a capped spend meter.
+    /// Co-occurs with `dollarCap`; nil for percentage and balance meters.
+    public let dollarUsed: Decimal?
+
+    /// Dollar cap for a capped spend meter.
+    /// Co-occurs with `dollarUsed`; nil for percentage and balance meters.
+    public let dollarCap: Decimal?
+
     /// Section this quota belongs to when an aggregating provider spans
     /// several upstream accounts (e.g. "Claude", "Claude · work").
     /// nil for providers whose quotas render as one flat list.
@@ -48,6 +56,8 @@ public struct UsageQuota: Sendable, Equatable, Hashable, Comparable {
         resetText: String? = nil,
         windowDuration: TimeInterval? = nil,
         dollarRemaining: Decimal? = nil,
+        dollarUsed: Decimal? = nil,
+        dollarCap: Decimal? = nil,
         group: String? = nil,
         compactTitle: String? = nil
     ) {
@@ -58,6 +68,8 @@ public struct UsageQuota: Sendable, Equatable, Hashable, Comparable {
         self.resetText = resetText
         self.windowDuration = windowDuration
         self.dollarRemaining = dollarRemaining
+        self.dollarUsed = dollarUsed
+        self.dollarCap = dollarCap
         self.group = group
         self.compactTitle = compactTitle
     }

--- a/Sources/Domain/Provider/UsageQuota.swift
+++ b/Sources/Domain/Provider/UsageQuota.swift
@@ -104,6 +104,30 @@ public struct UsageQuota: Sendable, Equatable, Hashable, Comparable {
         return String(format: "$%.2f", amount)
     }
 
+    /// Formatted spend amount for capped monetary quotas (e.g. "$1,234.56").
+    public var formattedDollarUsed: String? {
+        formatDollars(dollarUsed, minimumFractionDigits: 2)
+    }
+
+    /// Formatted cap for capped monetary quotas (e.g. "$500").
+    public var formattedDollarCap: String? {
+        formatDollars(dollarCap, minimumFractionDigits: 0)
+    }
+
+    private func formatDollars(_ amount: Decimal?, minimumFractionDigits: Int) -> String? {
+        guard let amount else { return nil }
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.usesGroupingSeparator = true
+        formatter.groupingSeparator = ","
+        formatter.decimalSeparator = "."
+        formatter.minimumFractionDigits = minimumFractionDigits
+        formatter.maximumFractionDigits = 2
+        let value = formatter.string(from: amount as NSDecimalNumber) ?? "\(amount)"
+        return "$\(value)"
+    }
+
     /// Whether this quota needs attention (warning, critical, or depleted)
     public var needsAttention: Bool {
         status.needsAttention

--- a/Sources/Domain/Provider/UsageSnapshot.swift
+++ b/Sources/Domain/Provider/UsageSnapshot.swift
@@ -117,7 +117,11 @@ public struct UsageSnapshot: Sendable, Equatable {
         for metric in extensionMetrics ?? [] {
             guard let group = metric.group else { continue }
             if buckets[group] == nil, notes[group] == nil { order.append(group) }
-            notes[group] = metric.value
+            if let existing = notes[group] {
+                notes[group] = "\(existing)\n\(metric.value)"
+            } else {
+                notes[group] = metric.value
+            }
         }
 
         return order.map { key in

--- a/Sources/Infrastructure/Claude/ClaudeAPIUsageProbe.swift
+++ b/Sources/Infrastructure/Claude/ClaudeAPIUsageProbe.swift
@@ -695,8 +695,10 @@ private struct MoneyData: Decodable {
     let currency: String?
     let exponent: Int?
 
+    /// Negative spend is not a valid payload state; reject the row rather
+    /// than silently flipping the sign.
     var amount: Decimal? {
-        guard let amountMinor, let exponent, exponent >= 0 else { return nil }
+        guard let amountMinor, amountMinor >= 0, let exponent, exponent >= 0 else { return nil }
         return Decimal(sign: .plus, exponent: -exponent, significand: amountMinor)
     }
 
@@ -722,7 +724,7 @@ private struct ExtraUsageData: Decodable {
     }
 
     private func scaledAmount(_ amount: Decimal?) -> Decimal? {
-        guard let amount else { return nil }
+        guard let amount, amount >= 0 else { return nil }
         let places = decimalPlaces ?? 2
         guard places >= 0 else { return nil }
         return Decimal(sign: .plus, exponent: -places, significand: amount)

--- a/Sources/Infrastructure/Claude/ClaudeAPIUsageProbe.swift
+++ b/Sources/Infrastructure/Claude/ClaudeAPIUsageProbe.swift
@@ -503,13 +503,14 @@ public struct ClaudeAPIUsageProbe: UsageProbe, @unchecked Sendable {
             ))
         }
 
-        // Prefer the current spend payload, then fall back to legacy extra_usage.
+        // Prefer the current spend payload, then fall back to legacy
+        // extra_usage. A shape with a present-but-invalid cap is dropped
+        // (falls through) rather than reclassified as uncapped.
         let costUsage: CostUsage?
-        if response.spend?.enabled == true,
-           let used = response.spend?.used?.amount {
+        if let pair = response.spend?.costPair {
             costUsage = CostUsage(
-                totalCost: used,
-                budget: response.spend?.limit?.amount,
+                totalCost: pair.used,
+                budget: pair.cap,
                 apiDuration: 0,
                 providerId: "claude",
                 kind: .extraUsage,
@@ -517,11 +518,10 @@ public struct ClaudeAPIUsageProbe: UsageProbe, @unchecked Sendable {
                 resetsAt: nil,
                 resetText: nil
             )
-        } else if response.extraUsage?.isEnabled == true,
-                  let used = response.extraUsage?.usedAmount {
+        } else if let pair = response.extraUsage?.costPair {
             costUsage = CostUsage(
-                totalCost: used,
-                budget: response.extraUsage?.monthlyLimitAmount,
+                totalCost: pair.used,
+                budget: pair.cap,
                 apiDuration: 0,
                 providerId: "claude",
                 kind: .extraUsage,
@@ -688,6 +688,17 @@ private struct SpendData: Decodable {
     let used: MoneyData?
     let limit: MoneyData?
     let enabled: Bool?
+
+    /// The decoded (used, cap) pair, or `nil` when the shape is disabled or
+    /// invalid. A `nil` cap inside the pair means genuinely uncapped
+    /// (`limit` absent or JSON null). A present-but-invalid `limit` poisons
+    /// the whole shape instead of silently reading as "no monthly cap".
+    var costPair: (used: Decimal, cap: Decimal?)? {
+        guard enabled == true, let used = used?.amount else { return nil }
+        guard let limit else { return (used, nil) }
+        guard let cap = limit.amount else { return nil }
+        return (used, cap)
+    }
 }
 
 private struct MoneyData: Decodable {
@@ -714,6 +725,15 @@ private struct ExtraUsageData: Decodable {
     let usedCredits: Decimal?
     let monthlyLimit: Decimal?
     let decimalPlaces: Int?
+
+    /// Same cap semantics as `SpendData.costPair`: absent/null limit means
+    /// uncapped; a present-but-invalid limit invalidates the shape.
+    var costPair: (used: Decimal, cap: Decimal?)? {
+        guard isEnabled == true, let used = usedAmount else { return nil }
+        guard monthlyLimit != nil else { return (used, nil) }
+        guard let cap = monthlyLimitAmount else { return nil }
+        return (used, cap)
+    }
 
     var usedAmount: Decimal? {
         scaledAmount(usedCredits)

--- a/Sources/Infrastructure/Claude/ClaudeAPIUsageProbe.swift
+++ b/Sources/Infrastructure/Claude/ClaudeAPIUsageProbe.swift
@@ -503,21 +503,34 @@ public struct ClaudeAPIUsageProbe: UsageProbe, @unchecked Sendable {
             ))
         }
 
-        // Parse extra usage
-        // API returns used_credits and monthly_limit in cents, convert to dollars
-        var costUsage: CostUsage?
-        if let extra = response.extraUsage, extra.isEnabled == true {
-            if let used = extra.usedCredits {
-                costUsage = CostUsage(
-                    totalCost: Decimal(used) / 100,
-                    budget: extra.monthlyLimit.map { Decimal($0) / 100 },
-                    apiDuration: 0,
-                    providerId: "claude",
-                    capturedAt: Date(),
-                    resetsAt: nil,
-                    resetText: nil
-                )
-            }
+        // Prefer the current spend payload, then fall back to legacy extra_usage.
+        let costUsage: CostUsage?
+        if response.spend?.enabled == true,
+           let used = response.spend?.used?.amount {
+            costUsage = CostUsage(
+                totalCost: used,
+                budget: response.spend?.limit?.amount,
+                apiDuration: 0,
+                providerId: "claude",
+                kind: .extraUsage,
+                capturedAt: Date(),
+                resetsAt: nil,
+                resetText: nil
+            )
+        } else if response.extraUsage?.isEnabled == true,
+                  let used = response.extraUsage?.usedAmount {
+            costUsage = CostUsage(
+                totalCost: used,
+                budget: response.extraUsage?.monthlyLimitAmount,
+                apiDuration: 0,
+                providerId: "claude",
+                kind: .extraUsage,
+                capturedAt: Date(),
+                resetsAt: nil,
+                resetText: nil
+            )
+        } else {
+            costUsage = nil
         }
 
         // Determine account tier from subscription type
@@ -618,6 +631,7 @@ private struct UsageResponse: Decodable {
     let sevenDaySonnet: UsageQuotaData?
     let sevenDayOpus: UsageQuotaData?
     let extraUsage: ExtraUsageData?
+    let spend: SpendData?
     let limits: [LimitEntry]?
 
     enum CodingKeys: String, CodingKey {
@@ -626,6 +640,7 @@ private struct UsageResponse: Decodable {
         case sevenDaySonnet = "seven_day_sonnet"
         case sevenDayOpus = "seven_day_opus"
         case extraUsage = "extra_usage"
+        case spend
         case limits
     }
 }
@@ -669,15 +684,55 @@ private struct UsageQuotaData: Decodable {
     }
 }
 
+private struct SpendData: Decodable {
+    let used: MoneyData?
+    let limit: MoneyData?
+    let enabled: Bool?
+}
+
+private struct MoneyData: Decodable {
+    let amountMinor: Decimal?
+    let currency: String?
+    let exponent: Int?
+
+    var amount: Decimal? {
+        guard let amountMinor, let exponent, exponent >= 0 else { return nil }
+        return Decimal(sign: .plus, exponent: -exponent, significand: amountMinor)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case amountMinor = "amount_minor"
+        case currency
+        case exponent
+    }
+}
+
 private struct ExtraUsageData: Decodable {
     let isEnabled: Bool?
-    let usedCredits: Double?
-    let monthlyLimit: Double?
+    let usedCredits: Decimal?
+    let monthlyLimit: Decimal?
+    let decimalPlaces: Int?
+
+    var usedAmount: Decimal? {
+        scaledAmount(usedCredits)
+    }
+
+    var monthlyLimitAmount: Decimal? {
+        scaledAmount(monthlyLimit)
+    }
+
+    private func scaledAmount(_ amount: Decimal?) -> Decimal? {
+        guard let amount else { return nil }
+        let places = decimalPlaces ?? 2
+        guard places >= 0 else { return nil }
+        return Decimal(sign: .plus, exponent: -places, significand: amount)
+    }
 
     enum CodingKeys: String, CodingKey {
         case isEnabled = "is_enabled"
         case usedCredits = "used_credits"
         case monthlyLimit = "monthly_limit"
+        case decimalPlaces = "decimal_places"
     }
 }
 

--- a/Sources/Infrastructure/Claude/ClaudeUsageProbe.swift
+++ b/Sources/Infrastructure/Claude/ClaudeUsageProbe.swift
@@ -463,6 +463,7 @@ public final class ClaudeUsageProbe: UsageProbe, @unchecked Sendable {
                     budget: costInfo.budget,
                     apiDuration: 0,
                     providerId: "claude",
+                    kind: .extraUsage,
                     capturedAt: Date(),
                     resetsAt: resetDate,
                     resetText: cleanResetText(resetText)

--- a/Sources/Infrastructure/Omp/OmpUsageProbe.swift
+++ b/Sources/Infrastructure/Omp/OmpUsageProbe.swift
@@ -508,7 +508,8 @@ public struct OmpUsageProbe: UsageProbe {
                 return (1 - used) * 100
             }
             if let used = amount?.used, let limit = amount?.limit, limit > 0 {
-                return (limit - used) / limit * 100
+                let fraction = (limit - used) / limit * 100
+                return NSDecimalNumber(decimal: fraction).doubleValue
             }
             return nil
         }
@@ -563,8 +564,11 @@ public struct OmpUsageProbe: UsageProbe {
     }
 
     struct LimitAmount: Decodable {
-        let used: Double?
-        let limit: Double?
+        /// Monetary fields decode as `Decimal` straight from the JSON number
+        /// token, so cent-boundary values like 1.005 never pick up binary
+        /// floating-point error before rounding.
+        let used: Decimal?
+        let limit: Decimal?
         let remaining: Double?
         let usedFraction: Double?
         let remainingFraction: Double?
@@ -578,9 +582,8 @@ public struct OmpUsageProbe: UsageProbe {
             Self.roundedMoney(limit)
         }
 
-        private static func roundedMoney(_ value: Double?) -> Decimal? {
-            guard let value else { return nil }
-            var decimal = Decimal(value)
+        private static func roundedMoney(_ value: Decimal?) -> Decimal? {
+            guard var decimal = value else { return nil }
             var rounded = Decimal()
             NSDecimalRound(&rounded, &decimal, 2, .plain)
             return rounded

--- a/Sources/Infrastructure/Omp/OmpUsageProbe.swift
+++ b/Sources/Infrastructure/Omp/OmpUsageProbe.swift
@@ -145,11 +145,28 @@ public struct OmpUsageProbe: UsageProbe {
                 .mapValues(\.count)
 
             let quotaCountBefore = quotas.count
+            let accountRowCountBefore = accountRows.count
 
             let providerName = Self.upstreamDisplayName(report.provider)
             let group = discriminator.map { "\(providerName) · \($0)" } ?? providerName
 
             for limit in report.limits {
+                if let dollarUsed = limit.uncappedMonetaryUsed {
+                    accountRows.append(Self.uncappedSpendRow(
+                        upstreamProvider: report.provider,
+                        limit: limit,
+                        dollarUsed: dollarUsed,
+                        discriminator: discriminator,
+                        group: group,
+                        seenLabels: &seenRowLabels
+                    ))
+                    continue
+                }
+
+                let monetaryAmounts = limit.cappedMonetaryAmounts
+                if limit.isMonetary, monetaryAmounts == nil {
+                    continue
+                }
                 guard let percentRemaining = limit.percentRemaining else { continue }
 
                 let needsMeter = windowGroupCounts[limit.windowGroupKey, default: 0] > 1
@@ -175,13 +192,15 @@ public struct OmpUsageProbe: UsageProbe {
                         providerId: providerId,
                         resetsAt: limit.resetDate,
                         windowDuration: limit.windowDurationSeconds,
+                        dollarUsed: monetaryAmounts?.used,
+                        dollarCap: monetaryAmounts?.cap,
                         group: group,
                         compactTitle: Self.compactTitle(limit: limit, meter: meter)
                     )
                 )
             }
 
-            if quotas.count > quotaCountBefore {
+            if quotas.count > quotaCountBefore || accountRows.count > accountRowCountBefore {
                 // Reserve the emitted quota-group title so a later note
                 // section can never silently collide with it.
                 seenGroupTitles.insert(group)
@@ -260,6 +279,43 @@ public struct OmpUsageProbe: UsageProbe {
         )
     }
 
+    /// A note row for an uncapped monetary meter. It intentionally does not
+    /// fabricate a percentage-based quota.
+    private static func uncappedSpendRow(
+        upstreamProvider: String,
+        limit: UsageLimit,
+        dollarUsed: Decimal,
+        discriminator: String?,
+        group: String,
+        seenLabels: inout Set<String>
+    ) -> ExtensionMetric {
+        var labelParts = [upstreamDisplayName(upstreamProvider), limit.labelToken, "Usage"]
+        if let discriminator, !discriminator.isEmpty {
+            labelParts.append("· \(discriminator)")
+        }
+
+        return ExtensionMetric(
+            label: uniqueLabel(labelParts.joined(separator: " "), seen: &seenLabels),
+            value: "\(limit.labelToken) usage \(formatMoney(dollarUsed)) spent · no cap",
+            unit: "",
+            icon: "dollarsign.circle",
+            group: group
+        )
+    }
+
+    private static func formatMoney(_ amount: Decimal) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.usesGroupingSeparator = true
+        formatter.groupingSeparator = ","
+        formatter.decimalSeparator = "."
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 2
+        let value = formatter.string(from: amount as NSDecimalNumber) ?? "\(amount)"
+        return "$\(value)"
+    }
+
     /// Shortens an account identity for section headers: the email local
     /// part, or a prefix of opaque ids — mirroring quota discriminators.
     static func shortIdentity(_ identity: String) -> String {
@@ -288,7 +344,7 @@ public struct OmpUsageProbe: UsageProbe {
         if let meter, !meter.isEmpty {
             parts.append(meter)
         }
-        parts.append(limit.windowToken)
+        parts.append(limit.labelToken)
         if let discriminator, !discriminator.isEmpty {
             parts.append("· \(discriminator)")
         }
@@ -306,7 +362,7 @@ public struct OmpUsageProbe: UsageProbe {
         if let meter, !meter.isEmpty {
             parts.append(meter)
         }
-        parts.append(limit.windowToken)
+        parts.append(limit.labelToken)
         return parts.joined(separator: " ")
     }
 
@@ -416,6 +472,32 @@ public struct OmpUsageProbe: UsageProbe {
         let window: LimitWindow?
         let amount: LimitAmount?
 
+        var isMonetary: Bool {
+            amount?.unit?.caseInsensitiveCompare("usd") == .orderedSame
+        }
+
+        var cappedMonetaryAmounts: (used: Decimal, cap: Decimal)? {
+            guard isMonetary,
+                  let rawLimit = amount?.limit, rawLimit > 0,
+                  let used = amount?.roundedUsed,
+                  let cap = amount?.roundedLimit
+            else { return nil }
+            return (used, cap)
+        }
+
+        var uncappedMonetaryUsed: Decimal? {
+            guard isMonetary, amount?.limit == nil else { return nil }
+            return amount?.roundedUsed
+        }
+
+        /// Monetary rows get a spend-oriented token without changing
+        /// `windowToken`, which remains the grouping key for all meters.
+        var labelToken: String {
+            guard isMonetary else { return windowToken }
+            let token = scope?.windowId ?? window?.id ?? "spend"
+            return token.prefix(1).uppercased() + token.dropFirst()
+        }
+
         /// Percent of this window still remaining, preferring explicit
         /// fractions over derived used/limit math.
         var percentRemaining: Double? {
@@ -457,7 +539,8 @@ public struct OmpUsageProbe: UsageProbe {
         /// Display name of the metered resource when it isn't the default
         /// percent meter (e.g. "Tokens", "Requests").
         var meterName: String? {
-            guard let unit = amount?.unit, !unit.isEmpty,
+            guard !isMonetary,
+                  let unit = amount?.unit, !unit.isEmpty,
                   unit.caseInsensitiveCompare("percent") != .orderedSame
             else { return nil }
             return unit.capitalized
@@ -486,5 +569,21 @@ public struct OmpUsageProbe: UsageProbe {
         let usedFraction: Double?
         let remainingFraction: Double?
         let unit: String?
+
+        var roundedUsed: Decimal? {
+            Self.roundedMoney(used)
+        }
+
+        var roundedLimit: Decimal? {
+            Self.roundedMoney(limit)
+        }
+
+        private static func roundedMoney(_ value: Double?) -> Decimal? {
+            guard let value else { return nil }
+            var decimal = Decimal(value)
+            var rounded = Decimal()
+            NSDecimalRound(&rounded, &decimal, 2, .plain)
+            return rounded
+        }
     }
 }

--- a/Tests/DomainTests/Provider/CostUsageTests.swift
+++ b/Tests/DomainTests/Provider/CostUsageTests.swift
@@ -28,6 +28,29 @@ struct CostUsageTests {
         #expect(cost.providerId == "claude")
     }
 
+    @Test
+    func `defaults kind to API cost`() {
+        let cost = CostUsage(
+            totalCost: 1,
+            apiDuration: 0,
+            providerId: "claude"
+        )
+
+        #expect(cost.kind == .apiCost)
+    }
+
+    @Test
+    func `creates extra usage kind`() {
+        let cost = CostUsage(
+            totalCost: 1,
+            apiDuration: 0,
+            providerId: "claude",
+            kind: .extraUsage
+        )
+
+        #expect(cost.kind == .extraUsage)
+    }
+
     // MARK: - Formatting
 
     @Test
@@ -122,6 +145,41 @@ struct CostUsageTests {
     }
 
     // MARK: - Budget Calculation
+
+    @Test
+    func `calculates budget remaining`() {
+        let cost = CostUsage(
+            totalCost: 5,
+            budget: 20,
+            apiDuration: 0,
+            providerId: "claude"
+        )
+
+        #expect(cost.budgetRemaining == 15)
+    }
+
+    @Test
+    func `floors budget remaining at zero when overspent`() {
+        let cost = CostUsage(
+            totalCost: 25,
+            budget: 20,
+            apiDuration: 0,
+            providerId: "claude"
+        )
+
+        #expect(cost.budgetRemaining == 0)
+    }
+
+    @Test
+    func `budget remaining is nil without a budget`() {
+        let cost = CostUsage(
+            totalCost: 5,
+            apiDuration: 0,
+            providerId: "claude"
+        )
+
+        #expect(cost.budgetRemaining == nil)
+    }
 
     @Test
     func `calculates budget status within budget`() {

--- a/Tests/DomainTests/Provider/UsageQuotaTests.swift
+++ b/Tests/DomainTests/Provider/UsageQuotaTests.swift
@@ -25,6 +25,8 @@ struct UsageQuotaTests {
         #expect(quota.percentRemaining == 65)
         #expect(quota.quotaType == QuotaType.session)
         #expect(quota.providerId == "claude")
+        #expect(quota.dollarUsed == nil)
+        #expect(quota.dollarCap == nil)
     }
 
     @Test
@@ -377,6 +379,21 @@ struct UsageQuotaTests {
 
         // When & Then
         #expect(quota.formattedDollarRemaining == nil)
+    }
+
+    @Test
+    func `quota stores capped dollar spend amounts`() {
+        let quota = UsageQuota(
+            percentRemaining: 75,
+            quotaType: .timeLimit("Claude Extra"),
+            providerId: "omp",
+            dollarUsed: Decimal(string: "123.45"),
+            dollarCap: 500
+        )
+
+        #expect(quota.dollarUsed == Decimal(string: "123.45"))
+        #expect(quota.dollarCap == 500)
+        #expect(quota.dollarRemaining == nil)
     }
 
     // MARK: - Burn Rate

--- a/Tests/DomainTests/Provider/UsageQuotaTests.swift
+++ b/Tests/DomainTests/Provider/UsageQuotaTests.swift
@@ -396,6 +396,20 @@ struct UsageQuotaTests {
         #expect(quota.dollarRemaining == nil)
     }
 
+    @Test
+    func `formats capped zero spend at a glance`() {
+        let quota = UsageQuota(
+            percentRemaining: 100,
+            quotaType: .timeLimit("Claude Extra"),
+            providerId: "omp",
+            dollarUsed: 0,
+            dollarCap: 500
+        )
+
+        #expect(quota.formattedDollarUsed == "$0.00")
+        #expect(quota.formattedDollarCap == "$500")
+    }
+
     // MARK: - Burn Rate
 
     @Test

--- a/Tests/DomainTests/Provider/UsageSnapshotTests.swift
+++ b/Tests/DomainTests/Provider/UsageSnapshotTests.swift
@@ -449,6 +449,28 @@ struct UsageSnapshotTests {
     }
 
     @Test
+    func `group notes accumulate in first appearance order`() {
+        let quotas = [
+            UsageQuota(percentRemaining: 90, quotaType: .timeLimit("Claude 5h"), providerId: "omp", group: "Claude"),
+        ]
+        let metrics = [
+            ExtensionMetric(label: "Claude Extra Usage", value: "Extra usage $1,234.56 spent · no cap", unit: "", group: "Claude"),
+            ExtensionMetric(label: "Claude account", value: "No usage reported", unit: "", group: "Claude"),
+        ]
+        let snapshot = UsageSnapshot(
+            providerId: "omp",
+            quotas: quotas,
+            capturedAt: Date(),
+            extensionMetrics: metrics
+        )
+
+        #expect(snapshot.quotaGroups.first?.note == """
+        Extra usage $1,234.56 spent · no cap
+        No usage reported
+        """)
+    }
+
+    @Test
     func `note placement is header-inline for note-only groups and nil without a note`() {
         let noteOnly = QuotaGroup(title: "Copilot", quotas: [], note: "No usage reported")
         #expect(noteOnly.notePlacement == .headerInline("No usage reported"))

--- a/Tests/InfrastructureTests/Claude/ClaudeAPIUsageProbeTests.swift
+++ b/Tests/InfrastructureTests/Claude/ClaudeAPIUsageProbeTests.swift
@@ -728,6 +728,48 @@ struct ClaudeAPIUsageProbeTests {
     }
 
     @Test
+    func `probe rejects negative spend and falls back to legacy extra usage`() async throws {
+        let snapshot = try await probe(responseJSON: """
+        {
+          "spend": {
+            "enabled": true,
+            "used": { "amount_minor": -125, "currency": "USD", "exponent": 2 },
+            "limit": { "amount_minor": 1000, "currency": "USD", "exponent": 2 }
+          },
+          "extra_usage": {
+            "is_enabled": true,
+            "used_credits": 541,
+            "monthly_limit": 2000,
+            "decimal_places": 2
+          }
+        }
+        """)
+
+        // A negative amount_minor is invalid; the spend row is dropped
+        // instead of silently flipping to +$1.25, and legacy takes over.
+        #expect(snapshot.costUsage?.totalCost == Decimal(string: "5.41"))
+        #expect(snapshot.costUsage?.budget == Decimal(string: "20"))
+        #expect(snapshot.costUsage?.kind == .extraUsage)
+    }
+
+    @Test
+    func `probe drops negative legacy credits instead of flipping sign`() async throws {
+        let snapshot = try await probe(responseJSON: """
+        {
+          "five_hour": { "utilization": 10.0, "resets_at": "2025-01-15T10:00:00Z" },
+          "extra_usage": {
+            "is_enabled": true,
+            "used_credits": -541,
+            "monthly_limit": 2000,
+            "decimal_places": 2
+          }
+        }
+        """)
+
+        #expect(snapshot.costUsage == nil)
+    }
+
+    @Test
     func `probe parses uncapped spend exactly`() async throws {
         let snapshot = try await probe(responseJSON: """
         {

--- a/Tests/InfrastructureTests/Claude/ClaudeAPIUsageProbeTests.swift
+++ b/Tests/InfrastructureTests/Claude/ClaudeAPIUsageProbeTests.swift
@@ -46,6 +46,31 @@ struct ClaudeAPIUsageProbeTests {
         try data.write(to: filePath)
     }
 
+    private func probe(responseJSON: String, subscriptionType: String = "claude_pro") async throws -> UsageSnapshot {
+        let tempDir = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let futureExpiry = Date().addingTimeInterval(3600).timeIntervalSince1970 * 1000
+        try createCredentialsFile(
+            at: tempDir,
+            expiresAt: futureExpiry,
+            subscriptionType: subscriptionType
+        )
+
+        let mockNetwork = MockNetworkClient()
+        let response = HTTPURLResponse(
+            url: URL(string: "https://api.anthropic.com")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        given(mockNetwork).request(.any).willReturn((Data(responseJSON.utf8), response))
+
+        let loader = ClaudeCredentialLoader(homeDirectory: tempDir.path, useKeychain: false)
+        let probe = ClaudeAPIUsageProbe(credentialLoader: loader, networkClient: mockNetwork)
+        return try await probe.probe()
+    }
+
     // MARK: - isAvailable Tests
 
     @Test
@@ -608,6 +633,7 @@ struct ClaudeAPIUsageProbeTests {
         #expect(snapshot.costUsage?.totalCost == Decimal(string: "5.41"))
         // 2000 cents -> $20.00
         #expect(snapshot.costUsage?.budget == Decimal(string: "20"))
+        #expect(snapshot.costUsage?.kind == .extraUsage)
     }
 
     @Test
@@ -653,6 +679,152 @@ struct ClaudeAPIUsageProbeTests {
         #expect(snapshot.costUsage?.budget == Decimal(string: "50"))
         // Verify formatted output shows dollars, not cents
         #expect(snapshot.costUsage?.formattedCost.contains("26.72") == true)
+        #expect(snapshot.costUsage?.kind == .extraUsage)
+    }
+
+    @Test
+    func `probe uses spend when spend and legacy extra usage agree`() async throws {
+        let snapshot = try await probe(responseJSON: """
+        {
+          "spend": {
+            "enabled": true,
+            "used": { "amount_minor": 0, "currency": "USD", "exponent": 2 },
+            "limit": { "amount_minor": 50000, "currency": "USD", "exponent": 2 }
+          },
+          "extra_usage": {
+            "is_enabled": true,
+            "used_credits": 0,
+            "monthly_limit": 50000,
+            "decimal_places": 2
+          }
+        }
+        """)
+
+        #expect(snapshot.costUsage?.totalCost == 0)
+        #expect(snapshot.costUsage?.budget == 500)
+        #expect(snapshot.costUsage?.kind == .extraUsage)
+    }
+
+    @Test
+    func `probe prefers spend when legacy extra usage differs`() async throws {
+        let snapshot = try await probe(responseJSON: """
+        {
+          "spend": {
+            "enabled": true,
+            "used": { "amount_minor": 125, "currency": "USD", "exponent": 2 },
+            "limit": { "amount_minor": 1000, "currency": "USD", "exponent": 2 }
+          },
+          "extra_usage": {
+            "is_enabled": true,
+            "used_credits": 541,
+            "monthly_limit": 2000,
+            "decimal_places": 2
+          }
+        }
+        """)
+
+        #expect(snapshot.costUsage?.totalCost == Decimal(string: "1.25"))
+        #expect(snapshot.costUsage?.budget == 10)
+    }
+
+    @Test
+    func `probe parses uncapped spend exactly`() async throws {
+        let snapshot = try await probe(responseJSON: """
+        {
+          "spend": {
+            "enabled": true,
+            "used": { "amount_minor": 123456, "currency": "USD", "exponent": 2 },
+            "limit": null,
+            "percent": 0
+          },
+          "extra_usage": {
+            "is_enabled": true,
+            "monthly_limit": null,
+            "used_credits": 123456,
+            "decimal_places": 2,
+            "currency": "USD"
+          }
+        }
+        """)
+
+        #expect(snapshot.costUsage?.totalCost == Decimal(string: "1234.56"))
+        #expect(snapshot.costUsage?.budget == nil)
+        #expect(snapshot.costUsage?.kind == .extraUsage)
+    }
+
+    @Test
+    func `probe respects spend money exponents`() async throws {
+        let snapshot = try await probe(responseJSON: """
+        {
+          "spend": {
+            "enabled": true,
+            "used": { "amount_minor": 12345, "exponent": 3 },
+            "limit": { "amount_minor": 2000, "exponent": 1 }
+          }
+        }
+        """)
+
+        #expect(snapshot.costUsage?.totalCost == Decimal(string: "12.345"))
+        #expect(snapshot.costUsage?.budget == 200)
+    }
+
+    @Test
+    func `probe falls back to legacy when spend has no used amount`() async throws {
+        let snapshot = try await probe(responseJSON: """
+        {
+          "spend": {
+            "enabled": true,
+            "used": null,
+            "limit": { "amount_minor": 1000, "exponent": 2 }
+          },
+          "extra_usage": {
+            "is_enabled": true,
+            "used_credits": 541,
+            "monthly_limit": 2000
+          }
+        }
+        """)
+
+        #expect(snapshot.costUsage?.totalCost == Decimal(string: "5.41"))
+        #expect(snapshot.costUsage?.budget == 20)
+        #expect(snapshot.costUsage?.kind == .extraUsage)
+    }
+
+    @Test
+    func `probe respects legacy extra usage decimal places`() async throws {
+        let snapshot = try await probe(responseJSON: """
+        {
+          "extra_usage": {
+            "is_enabled": true,
+            "used_credits": 541,
+            "monthly_limit": 2000,
+            "decimal_places": 3
+          }
+        }
+        """)
+
+        #expect(snapshot.costUsage?.totalCost == Decimal(string: "0.541"))
+        #expect(snapshot.costUsage?.budget == 2)
+        #expect(snapshot.costUsage?.kind == .extraUsage)
+    }
+
+    @Test
+    func `probe omits disabled spend and extra usage`() async throws {
+        let snapshot = try await probe(responseJSON: """
+        {
+          "spend": {
+            "enabled": false,
+            "used": { "amount_minor": 541, "exponent": 2 }
+          },
+          "extra_usage": {
+            "is_enabled": false,
+            "used_credits": 541,
+            "decimal_places": 2
+          }
+        }
+        """)
+
+        #expect(snapshot.costUsage == nil)
     }
 
     @Test
@@ -682,6 +854,7 @@ struct ClaudeAPIUsageProbeTests {
 
         // Should succeed but have no quotas
         #expect(snapshot.quotas.isEmpty)
+        #expect(snapshot.costUsage == nil)
     }
 
     // MARK: - Account Tier Detection Tests

--- a/Tests/InfrastructureTests/Claude/ClaudeAPIUsageProbeTests.swift
+++ b/Tests/InfrastructureTests/Claude/ClaudeAPIUsageProbeTests.swift
@@ -770,6 +770,61 @@ struct ClaudeAPIUsageProbeTests {
     }
 
     @Test
+    func `probe drops spend with invalid cap instead of reporting uncapped`() async throws {
+        let snapshot = try await probe(responseJSON: """
+        {
+          "spend": {
+            "enabled": true,
+            "used":  { "amount_minor": 541, "currency": "USD", "exponent": 2 },
+            "limit": { "amount_minor": -2000, "currency": "USD", "exponent": 2 }
+          }
+        }
+        """)
+
+        // A present-but-invalid cap must not be reclassified as "no monthly
+        // cap"; the whole shape is dropped.
+        #expect(snapshot.costUsage == nil)
+    }
+
+    @Test
+    func `probe falls back to legacy when spend cap is invalid`() async throws {
+        let snapshot = try await probe(responseJSON: """
+        {
+          "spend": {
+            "enabled": true,
+            "used":  { "amount_minor": 125, "currency": "USD", "exponent": 2 },
+            "limit": { "amount_minor": 2000, "currency": "USD", "exponent": -1 }
+          },
+          "extra_usage": {
+            "is_enabled": true,
+            "used_credits": 541,
+            "monthly_limit": 2000,
+            "decimal_places": 2
+          }
+        }
+        """)
+
+        #expect(snapshot.costUsage?.totalCost == Decimal(string: "5.41"))
+        #expect(snapshot.costUsage?.budget == Decimal(string: "20"))
+    }
+
+    @Test
+    func `probe drops legacy shape with invalid monthly limit`() async throws {
+        let snapshot = try await probe(responseJSON: """
+        {
+          "extra_usage": {
+            "is_enabled": true,
+            "used_credits": 541,
+            "monthly_limit": -2000,
+            "decimal_places": 2
+          }
+        }
+        """)
+
+        #expect(snapshot.costUsage == nil)
+    }
+
+    @Test
     func `probe parses uncapped spend exactly`() async throws {
         let snapshot = try await probe(responseJSON: """
         {

--- a/Tests/InfrastructureTests/Claude/ClaudeUsageProbeParsingTests.swift
+++ b/Tests/InfrastructureTests/Claude/ClaudeUsageProbeParsingTests.swift
@@ -613,6 +613,7 @@ struct ClaudeUsageProbeParsingTests {
         #expect(costUsage != nil)
         #expect(costUsage?.totalCost == Decimal(string: "5.41"))
         #expect(costUsage?.budget == Decimal(string: "20.00"))
+        #expect(costUsage?.kind == .extraUsage)
     }
 
     @Test
@@ -862,6 +863,7 @@ struct ClaudeUsageProbeParsingTests {
         #expect(snapshot.costUsage != nil)
         #expect(snapshot.costUsage?.totalCost == Decimal(string: "0.55"))
         #expect(snapshot.costUsage?.budget == nil)
+        #expect(snapshot.costUsage?.kind == .apiCost)
         #expect(snapshot.quotas.isEmpty)
     }
 

--- a/Tests/InfrastructureTests/Claude/ClaudeUsageProbeTests.swift
+++ b/Tests/InfrastructureTests/Claude/ClaudeUsageProbeTests.swift
@@ -287,6 +287,7 @@ struct ClaudeUsageProbeTests {
         #expect(snapshot.costUsage != nil)
         #expect(snapshot.costUsage?.totalCost == Decimal(string: "5.41"))
         #expect(snapshot.costUsage?.budget == Decimal(string: "20.00"))
+        #expect(snapshot.costUsage?.kind == .extraUsage)
         #expect(snapshot.quotas.count >= 1)
     }
 

--- a/Tests/InfrastructureTests/Omp/OmpUsageProbeParsingTests.swift
+++ b/Tests/InfrastructureTests/Omp/OmpUsageProbeParsingTests.swift
@@ -151,6 +151,184 @@ struct OmpUsageProbeParsingTests {
         #expect(zai.resetsAt == nil)
     }
 
+    // MARK: - Monetary Limits
+
+    @Test
+    func `maps capped zero spend to a monetary quota`() throws {
+        let json = """
+        { "reports": [ {
+            "provider": "anthropic",
+            "limits": [ {
+              "id": "anthropic:extra",
+              "label": "Claude Extra Usage",
+              "scope": { "provider": "anthropic", "windowId": "extra" },
+              "amount": {
+                "used": 0,
+                "limit": 500,
+                "remaining": 500,
+                "usedFraction": 0,
+                "remainingFraction": 1,
+                "unit": "usd"
+              }
+            } ]
+        } ] }
+        """
+
+        let snapshot = try OmpUsageProbe.parse(json)
+        let quota = try #require(snapshot.quota(for: .timeLimit("Claude Extra")))
+
+        #expect(quota.percentRemaining == 100)
+        #expect(quota.dollarUsed == 0)
+        #expect(quota.dollarCap == 500)
+        #expect(quota.compactTitle == "Extra")
+        #expect(quota.group == "Claude")
+    }
+
+    @Test
+    func `capped spend honors fractions and preserves rounded dollars`() throws {
+        let json = """
+        { "reports": [ {
+            "provider": "anthropic",
+            "limits": [ {
+              "scope": { "windowId": "extra" },
+              "amount": {
+                "used": 123.45,
+                "limit": 500,
+                "remainingFraction": 0.8,
+                "usedFraction": 0.2,
+                "unit": "USD"
+              }
+            } ]
+        } ] }
+        """
+
+        let snapshot = try OmpUsageProbe.parse(json)
+        let quota = try #require(snapshot.quota(for: .timeLimit("Claude Extra")))
+
+        #expect(quota.percentRemaining == 80)
+        #expect(quota.dollarUsed == Decimal(string: "123.45"))
+        #expect(quota.dollarCap == 500)
+    }
+
+    @Test
+    func `uncapped spend becomes a grouped note instead of a quota`() throws {
+        let json = """
+        { "reports": [ {
+            "provider": "anthropic",
+            "limits": [ {
+              "id": "anthropic:extra",
+              "label": "Claude Extra Usage",
+              "scope": { "provider": "anthropic", "windowId": "extra" },
+              "amount": { "used": 1234.56, "unit": "usd" }
+            } ],
+            "metadata": { "email": "solo@example.com" }
+        } ] }
+        """
+
+        let snapshot = try OmpUsageProbe.parse(json)
+
+        #expect(snapshot.quotas.isEmpty)
+        let metrics = try #require(snapshot.extensionMetrics)
+        #expect(metrics.count == 1)
+        #expect(metrics[0].label == "Claude Extra Usage")
+        #expect(metrics[0].value == "Extra usage $1,234.56 spent · no cap")
+        #expect(metrics[0].icon == "dollarsign.circle")
+        #expect(metrics[0].group == "Claude")
+        #expect(snapshot.quotaGroups.first?.note == "Extra usage $1,234.56 spent · no cap")
+    }
+
+    @Test
+    func `windowless cursor spend labels suppress the usd meter`() throws {
+        let json = """
+        { "reports": [ {
+            "provider": "cursor",
+            "limits": [
+              {
+                "id": "cursor:usd:included",
+                "label": "included spend",
+                "amount": { "used": 1234.56, "limit": 5000, "unit": "UsD" }
+              },
+              {
+                "id": "cursor:usd:bonus",
+                "label": "bonus spend",
+                "amount": { "used": 10, "limit": 100, "unit": "usd" }
+              }
+            ]
+        } ] }
+        """
+
+        let snapshot = try OmpUsageProbe.parse(json)
+        let labels = snapshot.quotas.map(\.quotaType.displayName)
+
+        #expect(labels == ["Cursor Spend", "Cursor Spend (2)"])
+        #expect(labels.allSatisfy { !$0.localizedCaseInsensitiveContains("usd") })
+        #expect(snapshot.quotas.first?.compactTitle == "Spend")
+        #expect(snapshot.quotas.first?.dollarUsed == Decimal(string: "1234.56"))
+        #expect(snapshot.quotas.first?.dollarCap == 5000)
+    }
+
+    @Test
+    func `monetary and window quotas share the account group`() throws {
+        let json = """
+        { "reports": [ {
+            "provider": "anthropic",
+            "limits": [
+              {
+                "scope": { "windowId": "5h" },
+                "window": { "id": "5h", "durationMs": 18000000 },
+                "amount": { "remainingFraction": 0.9, "unit": "percent" }
+              },
+              {
+                "scope": { "windowId": "extra" },
+                "amount": { "used": 125, "limit": 500, "unit": "usd" }
+              }
+            ]
+        } ] }
+        """
+
+        let snapshot = try OmpUsageProbe.parse(json)
+
+        #expect(snapshot.quotas.map(\.quotaType.displayName) == ["Claude 5h", "Claude Extra"])
+        #expect(snapshot.quotas.allSatisfy { $0.group == "Claude" })
+        #expect(snapshot.quotaGroups.count == 1)
+        #expect(snapshot.quotaGroups[0].quotas.count == 2)
+    }
+
+    @Test
+    func `uncapped spend notes discriminate same-provider accounts`() throws {
+        let json = """
+        { "reports": [
+          {
+            "provider": "anthropic",
+            "limits": [ {
+              "scope": { "windowId": "extra" },
+              "amount": { "used": 10, "unit": "usd" }
+            } ],
+            "metadata": { "email": "work@example.com" }
+          },
+          {
+            "provider": "anthropic",
+            "limits": [ {
+              "scope": { "windowId": "extra" },
+              "amount": { "used": 20, "unit": "usd" }
+            } ],
+            "metadata": { "email": "home@example.com" }
+          }
+        ] }
+        """
+
+        let snapshot = try OmpUsageProbe.parse(json)
+        let metrics = try #require(snapshot.extensionMetrics)
+
+        #expect(snapshot.quotas.isEmpty)
+        #expect(metrics.map(\.label) == [
+            "Claude Extra Usage · work",
+            "Claude Extra Usage · home",
+        ])
+        #expect(metrics.map(\.group) == ["Claude · work", "Claude · home"])
+        #expect(Set(metrics.map(\.label)).count == metrics.count)
+    }
+
     // MARK: - Account Email
 
     @Test

--- a/Tests/InfrastructureTests/Omp/OmpUsageProbeParsingTests.swift
+++ b/Tests/InfrastructureTests/Omp/OmpUsageProbeParsingTests.swift
@@ -211,6 +211,24 @@ struct OmpUsageProbeParsingTests {
     }
 
     @Test
+    func `monetary label falls back to window id`() throws {
+        let json = """
+        { "reports": [ {
+            "provider": "opencode-go",
+            "limits": [ {
+              "window": { "id": "monthly" },
+              "amount": { "used": 50, "limit": 500, "unit": "usd" }
+            } ]
+        } ] }
+        """
+
+        let snapshot = try OmpUsageProbe.parse(json)
+        let quota = try #require(snapshot.quota(for: .timeLimit("OpenCode Go Monthly")))
+
+        #expect(quota.compactTitle == "Monthly")
+    }
+
+    @Test
     func `uncapped spend becomes a grouped note instead of a quota`() throws {
         let json = """
         { "reports": [ {

--- a/Tests/InfrastructureTests/Omp/OmpUsageProbeParsingTests.swift
+++ b/Tests/InfrastructureTests/Omp/OmpUsageProbeParsingTests.swift
@@ -211,6 +211,30 @@ struct OmpUsageProbeParsingTests {
     }
 
     @Test
+    func `monetary decode keeps cent-boundary values exact`() throws {
+        // Decimal decodes straight from the JSON number token: 1.005 rounds
+        // to $1.01. A Double round-trip would decode 1.00499… and show $1.00.
+        let json = """
+        { "reports": [ {
+            "provider": "anthropic",
+            "limits": [ {
+              "scope": { "windowId": "extra" },
+              "amount": { "used": 1.005, "limit": 1.25e1, "unit": "usd" }
+            } ]
+        } ] }
+        """
+
+        let snapshot = try OmpUsageProbe.parse(json)
+        let quota = try #require(snapshot.quota(for: .timeLimit("Claude Extra")))
+
+        #expect(quota.dollarUsed == Decimal(string: "1.01"))
+        #expect(quota.dollarCap == Decimal(string: "12.5"))
+        // Derived percent math (no explicit fractions): (12.5-1.005)/12.5.
+        let percent = try #require(quota.percentRemaining)
+        #expect(abs(percent - 91.96) < 0.0001)
+    }
+
+    @Test
     func `monetary label falls back to window id`() throws {
         let json = """
         { "reports": [ {


### PR DESCRIPTION
## Summary

Closes #225.

Adds a monetary rendering path so Claude Extra-usage spend and omp USD limits stop being dropped or mislabeled:

- **Claude Extra usage:** decodes the current OAuth `spend` payload (minor currency units with exponent-aware `Decimal` conversion — no `Double` drift), keeping legacy `extra_usage` as a tolerant fallback scaled by its own `decimal_places` field instead of a hardcoded cents assumption. Renders a distinct "EXTRA USAGE" card showing spend against its own monthly cap, or an explicit "No monthly cap" state.
- **Budget classification:** `CostUsage` now carries a kind (`apiCost` vs `extraUsage`); the user-configured API budget applies only to API-cost cards and no longer leaks in as a misleading cap for uncapped Extra usage.
- **omp USD limits:** capped rows render "$X of $Y" while preserving their percentage-driven status color and progress (`UsageQuota.dollarUsed`/`dollarCap`); uncapped rows become account notes ("$X spent · no cap") instead of being silently dropped by the percent guard or shown as a percent-only meter literally named "Usd".
- **Notes plumbing:** grouped provider notes accumulate in source order rather than overwriting one another, so spend notes and other account notes remain visible together.

## The rules

- A monetary row never fabricates a percentage: capped rows keep their real fraction; uncapped rows carry dollars only and render as notes, not meters.
- Subscription Extra usage and the configured API budget are different meters and are never mixed.
- Rows that are not monetary are untouched; unsupported shapes pass through to existing behavior.

## Testing

- Full suite on this branch merged with current `origin/main` (`23fcfad`, includes #224): `tuist test` → **1687 passed, 0 failed** (173 suites: Acceptance 68, Domain 651, Infrastructure 968).
- Monetary/omp suites on the merged state: `UsageQuotaTests` 44, `UsageSnapshotTests` 32, `OmpUsageProbeParsingTests` 53 (including the #224 org-less dedup cases coexisting with the new monetary mappings), `CostUsageTests` 18, `ClaudeAPIUsageProbe` 35 — all green.
- Manual smoke: stub omp binaries covering the capped and uncapped scenarios, plus a live-account run on omp 16.5.1. Screenshots contain real emails and real spend, so none are attached; synthetic re-captures available on request.

## Merge state

Branch base is `4a6f75d` (v0.4.71). Verified locally that it merges into current `origin/main` with zero conflicts — including `OmpUsageProbe.swift`, where #224's dedup and this branch's monetary mapping touch different regions and both behaviors are covered by the merged test run above.

## Additional notes

- omp-side counterpart: the upstream payload gap (omp itself not parsing Extra-usage spend into a `usd` row) is filed as [can1357/oh-my-pi#5575](https://github.com/can1357/oh-my-pi/issues/5575); this PR only handles what omp already emits today.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Claude “Extra Usage” budget meters driven by OAuth spend, including capped vs uncapped (“No monthly cap”) display.
  - Upgraded Oh My Pi USD limits to show spend-style meters (e.g., “$X of $Y”) for capped quotas and clear “$X spent · no cap” notes for uncapped usage.
  - Improved monetary amount formatting for exponent-based and fractional values.
- **Bug Fixes**
  - Prevented grouped provider notes from overwriting, keeping all spend/account details visible.
  - Ensured API budget caps apply only where appropriate, avoiding caps on uncapped Extra Usage.
- **Documentation**
  - Updated Oh My Pi requirements to match the expanded spend aggregation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->