### PR TITLE
fix(ui): explain the pace tick with a tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The pace tick under quota progress bars now explains itself: hovering the
+  bar shows a mode-aware tooltip ("steady usage would leave ~N% remaining by
+  now"), so the marker no longer reads as a misaligned rendering glitch.
+
 ---
 
 ## [0.4.72] - 2026-07-15

--- a/Sources/App/Views/MenuContentView.swift
+++ b/Sources/App/Views/MenuContentView.swift
@@ -1062,6 +1062,7 @@ struct WrappedStatCard: View {
                     .frame(height: 5)
                 }
             }
+            .help(quota.paceTickHelp(mode: effectiveDisplayMode) ?? "")
 
             // Reset info
             if let resetText = quota.resetTimestampDescription ?? quota.resetText ?? quota.resetDescription {

--- a/Sources/App/Views/QuotaCardView.swift
+++ b/Sources/App/Views/QuotaCardView.swift
@@ -90,6 +90,7 @@ struct QuotaCardView: View {
                     .frame(height: 5)
                 }
             }
+            .help(quota.paceTickHelp(mode: effectiveDisplayMode) ?? "")
         }
         .padding(12)
         .background(Color.primary.opacity(0.05))

--- a/Sources/Domain/Provider/UsageQuota.swift
+++ b/Sources/Domain/Provider/UsageQuota.swift
@@ -197,6 +197,21 @@ public struct UsageQuota: Sendable, Equatable, Hashable, Comparable {
         }
     }
 
+    /// Tooltip copy explaining the pace tick mark under the progress bar.
+    /// Mode-aware: describes where the bar would sit if usage were spread
+    /// evenly across the window. Returns nil when reset time is unknown.
+    public func paceTickHelp(mode: UsageDisplayMode) -> String? {
+        guard let expected = expectedProgressPercent(mode: mode) else { return nil }
+        let base = switch mode {
+        case .used:
+            "Pace marker: steady usage would have used ~\(Int(expected.rounded()))% by now"
+        case .remaining, .pace:
+            "Pace marker: steady usage would leave ~\(Int(expected.rounded()))% remaining by now"
+        }
+        guard let insight = paceInsight else { return base + "." }
+        return base + " — " + insight.prefix(1).lowercased() + insight.dropFirst() + "."
+    }
+
     /// Time until this quota resets (if known)
     public var timeUntilReset: TimeInterval? {
         guard let resetsAt else { return nil }

--- a/Tests/DomainTests/Provider/UsageQuotaTests.swift
+++ b/Tests/DomainTests/Provider/UsageQuotaTests.swift
@@ -467,4 +467,44 @@ struct UsageQuotaTests {
         let elapsed = quota.percentTimeElapsed!
         #expect(elapsed > 49 && elapsed < 51)
     }
+
+    @Test
+    func `paceTickHelp explains expected remaining in remaining mode`() {
+        // 75% of a 5h window elapsed -> steady usage would leave ~25%.
+        let quota = UsageQuota(
+            percentRemaining: 43,
+            quotaType: .timeLimit("Z.ai 5h"),
+            providerId: "zai",
+            resetsAt: Date().addingTimeInterval(1.25 * 3600),
+            windowDuration: 5 * 3600
+        )
+        let help = quota.paceTickHelp(mode: .remaining)!
+        #expect(help.contains("~25% remaining"))
+        // 57 used vs 75 elapsed -> below expected usage, surfaced inline.
+        #expect(help.contains("below expected usage"))
+    }
+
+    @Test
+    func `paceTickHelp uses consumed wording in used mode`() {
+        let quota = UsageQuota(
+            percentRemaining: 43,
+            quotaType: .timeLimit("Z.ai 5h"),
+            providerId: "zai",
+            resetsAt: Date().addingTimeInterval(1.25 * 3600),
+            windowDuration: 5 * 3600
+        )
+        let help = quota.paceTickHelp(mode: .used)!
+        #expect(help.contains("~75%"))
+        #expect(help.contains("used"))
+    }
+
+    @Test
+    func `paceTickHelp is nil without reset time`() {
+        let quota = UsageQuota(
+            percentRemaining: 43,
+            quotaType: .timeLimit("MCP"),
+            providerId: "zai"
+        )
+        #expect(quota.paceTickHelp(mode: .remaining) == nil)
+    }
 }


### PR DESCRIPTION
## Summary

The triangle under quota progress bars (added in 04220bd) marks where the bar would sit if usage were spread evenly across the window — but nothing in the UI says so. When it sits far from the fill it reads as a misaligned rendering glitch, e.g. a 7d card showing 99% remaining with the tick near 18%, or a 5h card at 43% remaining with the tick near 25% (both mathematically correct: `100 − percentTimeElapsed`).

This PR makes the marker self-explanatory without changing its behavior:

- **`UsageQuota.paceTickHelp(mode:)`** — mode-aware tooltip copy ("Pace marker: steady usage would leave ~25% remaining by now — 18% below expected usage."), reusing the existing `paceInsight` wording for the delta.
- Both progress-bar renderers (the menubar popover card in `MenuContentView` and `QuotaCardView`) attach it via `.help(...)` on the bar block — same pattern as the app's existing tooltips. Hover target is the whole bar, not the 6px triangle.

No layout, math, or behavior changes; the tick renders exactly as before.

## Testing

- 3 new domain tests: remaining-mode wording (expected % + inline pace delta), used-mode wording, and nil when reset time is unknown.
- Full suite: `tuist test` → **1668 passed, 0 failed**.
- Not manually smoke-tested in the running app; the tooltip is a standard `.help(...)` attachment (same as the app's existing tooltips), and the copy itself is covered by the domain tests above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added mode-aware hover tooltips to quota progress-bar pace markers, including expected usage percentages.
  - Tooltips now incorporate pace insights when available, and show appropriate wording for the selected display mode.
- **Bug Fixes**
  - Improved the pace marker tooltip behavior under quota progress bars to avoid the perception of a rendering/misalignment issue.
  - When reset timing is unknown, pace markers no longer show misleading tooltip text.
- **Tests**
  - Added unit tests covering pace tooltip content across display modes and missing reset-time scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->