### PR TITLE
fix(omp): humanize machine window ids on quota cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one another, so spend notes and other account notes remain visible together.
 - Claude's configured API budget now applies only to API-cost cards; it no
   longer supplies a misleading cap for uncapped Extra Usage.
+- Oh My Pi quota cards no longer show raw machine window ids. For Kimi,
+  the 5-hour rate-limit card now reads "5h" (derived from the reported
+  window duration) instead of "300TIME_UNIT_MINUTE", and the total-quota
+  card shows Kimi's own "Total quota" label instead of "DEFAULT".
+  Label-derived card titles also drop a duplicated provider prefix
+  (Gemini) and redundant shared-window meter words (Copilot). Card
+  titles only: full quota labels and persisted quota keys are unchanged,
+  so existing menu-bar selections keep working.
 
 ---
 

--- a/Sources/Infrastructure/Omp/OmpUsageProbe.swift
+++ b/Sources/Infrastructure/Omp/OmpUsageProbe.swift
@@ -647,7 +647,9 @@ public struct OmpUsageProbe: UsageProbe {
         /// derived from the window duration, the limit's own label, the
         /// window label, the raw id. Label-derived tokens drop a leading
         /// provider name (Gemini labels embed it) since the section header
-        /// already carries that context.
+        /// already carries that context. Only the LIMIT's label is
+        /// self-describing — a window label ("Monthly") names timing, not
+        /// the metered resource, so it keeps the shared-window meter prefix.
         func displayWindowToken(providerName: String) -> DisplayWindowToken {
             let raw = scope?.windowId ?? window?.id
             if let raw, Self.isCompactWindowToken(raw) {
@@ -666,7 +668,7 @@ public struct OmpUsageProbe: UsageProbe {
             if let windowLabel = window?.label, !windowLabel.isEmpty {
                 return DisplayWindowToken(
                     token: Self.strippingProviderPrefix(windowLabel, providerName: providerName),
-                    selfDescribing: true
+                    selfDescribing: false
                 )
             }
             return DisplayWindowToken(token: raw ?? "limit", selfDescribing: false)

--- a/Sources/Infrastructure/Omp/OmpUsageProbe.swift
+++ b/Sources/Infrastructure/Omp/OmpUsageProbe.swift
@@ -195,7 +195,7 @@ public struct OmpUsageProbe: UsageProbe {
                         dollarUsed: monetaryAmounts?.used,
                         dollarCap: monetaryAmounts?.cap,
                         group: group,
-                        compactTitle: Self.compactTitle(limit: limit, meter: meter)
+                        compactTitle: Self.compactTitle(limit: limit, meter: meter, providerName: providerName)
                     )
                 )
             }
@@ -419,15 +419,30 @@ public struct OmpUsageProbe: UsageProbe {
     /// Builds the short in-section card title (e.g. "5h", "Spark 7d",
     /// "Tokens 5h") — the provider/account context lives in the section
     /// header (`UsageQuota.group`), so it is not repeated per card.
-    static func compactTitle(limit: UsageLimit, meter: String?) -> String {
+    /// Purely presentational: quota labels and persisted quota keys keep
+    /// the raw window token (see `UsageQuota.compactTitle`).
+    static func compactTitle(limit: UsageLimit, meter: String?, providerName: String) -> String {
         var parts: [String] = []
         if let tier = limit.scope?.tier, !tier.isEmpty {
             parts.append(tier.capitalized)
         }
-        if let meter, !meter.isEmpty {
+        // Monetary rows keep their spend-oriented `labelToken` contract
+        // ("Extra", "Monthly", "Spend") — window humanization only applies
+        // to window/rate meters.
+        if limit.isMonetary {
+            if let meter, !meter.isEmpty {
+                parts.append(meter)
+            }
+            parts.append(limit.labelToken)
+            return parts.joined(separator: " ")
+        }
+        let display = limit.displayWindowToken(providerName: providerName)
+        // A label-derived token already names the metered resource
+        // ("Premium Requests"); prefixing the meter would duplicate it.
+        if let meter, !meter.isEmpty, !display.selfDescribing {
             parts.append(meter)
         }
-        parts.append(limit.labelToken)
+        parts.append(display.token)
         return parts.joined(separator: " ")
     }
 
@@ -607,8 +622,87 @@ public struct OmpUsageProbe: UsageProbe {
         }
 
         /// Compact window token like "5h", "7d", "1w", "1mo".
+        ///
+        /// This raw chain is identity: it feeds quota labels (persisted
+        /// quota keys) and meter-qualification grouping, so it is never
+        /// humanized — display cleanup lives in `displayWindowToken`.
         var windowToken: String {
             scope?.windowId ?? window?.id ?? window?.label ?? "limit"
+        }
+
+        /// Card-title token plus whether it already describes the metered
+        /// resource on its own (label-derived tokens do; machine tokens
+        /// need the meter prefix when several meters share one window).
+        struct DisplayWindowToken {
+            let token: String
+            let selfDescribing: Bool
+        }
+
+        /// Humanized token for the in-section card title.
+        ///
+        /// Some reporters emit machine window ids next to human labels
+        /// (Kimi's 5-hour rate limit arrives as `300time_unit_minute` with
+        /// label "5h limit"; its summary row is `default` with label
+        /// "Total quota"). Prefer, in order: an already-compact id, a token
+        /// derived from the window duration, the limit's own label, the
+        /// window label, the raw id. Label-derived tokens drop a leading
+        /// provider name (Gemini labels embed it) since the section header
+        /// already carries that context.
+        func displayWindowToken(providerName: String) -> DisplayWindowToken {
+            let raw = scope?.windowId ?? window?.id
+            if let raw, Self.isCompactWindowToken(raw) {
+                return DisplayWindowToken(token: raw, selfDescribing: false)
+            }
+            if let seconds = windowDurationSeconds,
+               let derived = Self.compactDurationToken(seconds) {
+                return DisplayWindowToken(token: derived, selfDescribing: false)
+            }
+            if let label, !label.isEmpty {
+                return DisplayWindowToken(
+                    token: Self.strippingProviderPrefix(label, providerName: providerName),
+                    selfDescribing: true
+                )
+            }
+            if let windowLabel = window?.label, !windowLabel.isEmpty {
+                return DisplayWindowToken(
+                    token: Self.strippingProviderPrefix(windowLabel, providerName: providerName),
+                    selfDescribing: true
+                )
+            }
+            return DisplayWindowToken(token: raw ?? "limit", selfDescribing: false)
+        }
+
+        /// True for tokens that already read as a compact window ("5h",
+        /// "7d", "1mo") and can go on a card verbatim.
+        static func isCompactWindowToken(_ token: String) -> Bool {
+            token.range(
+                of: "^\\d{1,4}(s|m|h|d|w|mo|y)$",
+                options: [.regularExpression, .caseInsensitive]
+            ) != nil
+        }
+
+        /// Formats a window length as its largest whole unit ("5h", "7d",
+        /// "90m"); nil for non-positive lengths and for payload garbage
+        /// (non-finite or Int-overflowing durations must degrade to the
+        /// label fallback, never trap).
+        static func compactDurationToken(_ seconds: TimeInterval) -> String? {
+            guard let total = Int(exactly: seconds.rounded()), total > 0 else { return nil }
+            if total % 86_400 == 0 { return "\(total / 86_400)d" }
+            if total % 3_600 == 0 { return "\(total / 3_600)h" }
+            if total % 60 == 0 { return "\(total / 60)m" }
+            return "\(total)s"
+        }
+
+        /// Drops a leading "<providerName> " from a label-derived token —
+        /// the section header already names the provider, and some
+        /// reporters (Gemini) embed it in every limit label.
+        static func strippingProviderPrefix(_ label: String, providerName: String) -> String {
+            let trimmed = label.trimmingCharacters(in: .whitespaces)
+            guard trimmed.count > providerName.count + 1,
+                  trimmed.lowercased().hasPrefix(providerName.lowercased() + " ")
+            else { return trimmed }
+            return String(trimmed.dropFirst(providerName.count + 1))
+                .trimmingCharacters(in: .whitespaces)
         }
 
         /// Groups limits that share a (tier, window) on one account, so

--- a/Tests/InfrastructureTests/Omp/OmpUsageProbeParsingTests.swift
+++ b/Tests/InfrastructureTests/Omp/OmpUsageProbeParsingTests.swift
@@ -573,6 +573,34 @@ struct OmpUsageProbeParsingTests {
     }
 
     @Test
+    func `keeps the meter prefix for window-label card titles`() throws {
+        // A window label ("Monthly") names timing, not the metered
+        // resource: two meters falling back to the same window label must
+        // stay distinguishable on their cards.
+        let json = """
+        { "reports": [ {
+            "provider": "zai",
+            "limits": [
+              {
+                "scope": { "windowId": "billing-cycle" },
+                "window": { "id": "billing-cycle", "label": "Monthly" },
+                "amount": { "usedFraction": 0.1, "remainingFraction": 0.9, "unit": "tokens" }
+              },
+              {
+                "scope": { "windowId": "billing-cycle" },
+                "window": { "id": "billing-cycle", "label": "Monthly" },
+                "amount": { "usedFraction": 0.2, "remainingFraction": 0.8, "unit": "requests" }
+              }
+            ]
+        } ] }
+        """
+        let snapshot = try OmpUsageProbe.parse(json)
+        let titles = snapshot.quotas.compactMap(\.compactTitle)
+
+        #expect(titles == ["Tokens Monthly", "Requests Monthly"])
+    }
+
+    @Test
     func `degrades oversized window durations to the label instead of trapping`() throws {
         // durationMs is attacker-adjacent external JSON; a finite value past
         // Int.max must fall through to the label fallback, not crash the

--- a/Tests/InfrastructureTests/Omp/OmpUsageProbeParsingTests.swift
+++ b/Tests/InfrastructureTests/Omp/OmpUsageProbeParsingTests.swift
@@ -466,6 +466,134 @@ struct OmpUsageProbeParsingTests {
         #expect(!labels.contains { $0.hasSuffix("(2)") })
     }
 
+    // MARK: - Card Title Humanization
+
+    /// Modeled on live `omp usage --json` output for `kimi-code` (omp
+    /// v17.0.2): the reporter emits machine window ids alongside human
+    /// labels. All values are synthetic.
+    static let kimiResponse = """
+    { "reports": [ {
+        "provider": "kimi-code",
+        "limits": [
+          {
+            "id": "kimi-code:0",
+            "label": "Total quota",
+            "scope": { "provider": "kimi-code", "windowId": "default", "shared": true },
+            "window": { "id": "default", "label": "Usage window", "resetsAt": 1784828755000 },
+            "amount": { "unit": "unknown", "limit": 100, "used": 16, "remaining": 84, "usedFraction": 0.16, "remainingFraction": 0.84 }
+          },
+          {
+            "id": "kimi-code:1",
+            "label": "5h limit",
+            "scope": { "provider": "kimi-code", "windowId": "300time_unit_minute", "shared": true },
+            "window": { "id": "300time_unit_minute", "label": "5h limit", "durationMs": 18000000 },
+            "amount": { "unit": "unknown", "limit": 100, "used": 81, "remaining": 19, "usedFraction": 0.81, "remainingFraction": 0.19 }
+          }
+        ],
+        "metadata": { "endpoint": "https://api.kimi.com/coding/v1/usages" }
+    } ] }
+    """
+
+    @Test
+    func `derives a compact card title from the window duration for machine ids`() throws {
+        // "300time_unit_minute" is omp's machine id for Kimi's 5-hour rate
+        // limit; the card must read "5h", not the raw id. The quota label —
+        // and therefore the persisted quota key — keeps the raw token.
+        let snapshot = try OmpUsageProbe.parse(Self.kimiResponse)
+        let rate = try #require(snapshot.quota(for: .timeLimit("Kimi 300time_unit_minute")))
+
+        #expect(rate.compactTitle == "5h")
+        #expect(rate.percentRemaining == 19.0)
+        #expect(rate.windowDuration == 18_000)
+    }
+
+    @Test
+    func `falls back to the limit label for card titles when a window has no duration`() throws {
+        // Kimi's summary row has windowId "default" and no duration; the
+        // card shows Kimi's own "Total quota" label while the quota key
+        // stays on the raw token.
+        let snapshot = try OmpUsageProbe.parse(Self.kimiResponse)
+        let total = try #require(snapshot.quota(for: .timeLimit("Kimi default")))
+
+        #expect(total.compactTitle == "Total quota")
+        #expect(total.resetsAt == Date(timeIntervalSince1970: 1_784_828_755))
+        #expect(snapshot.quotas.allSatisfy { $0.group == "Kimi" })
+    }
+
+    @Test
+    func `strips the provider prefix from label-derived card titles`() throws {
+        // Gemini limit labels embed the provider name ("Gemini <model>")
+        // and its window ids ("reset-<epoch>") carry no duration; the card
+        // sits inside the "Gemini" section already, so the prefix goes.
+        let json = """
+        { "reports": [ {
+            "provider": "google-gemini-cli",
+            "limits": [ {
+              "label": "Gemini gemini-2.5-pro",
+              "scope": { "provider": "google-gemini-cli", "windowId": "reset-1784310000000" },
+              "window": { "id": "reset-1784310000000", "label": "Quota window", "resetsAt": 1784310000000 },
+              "amount": { "usedFraction": 0.3, "remainingFraction": 0.7 }
+            } ]
+        } ] }
+        """
+        let snapshot = try OmpUsageProbe.parse(json)
+        let quota = try #require(snapshot.quota(for: .timeLimit("Gemini reset-1784310000000")))
+
+        #expect(quota.compactTitle == "gemini-2.5-pro")
+    }
+
+    @Test
+    func `keeps meter words off self-describing card titles`() throws {
+        // Copilot meters three request pools over one "monthly" window;
+        // each label already names its resource, so the shared-window meter
+        // prefix must not double it ("Requests Premium Requests").
+        let json = """
+        { "reports": [ {
+            "provider": "github-copilot",
+            "limits": [
+              {
+                "label": "Premium Requests",
+                "scope": { "windowId": "monthly" },
+                "window": { "id": "monthly", "label": "Monthly" },
+                "amount": { "usedFraction": 0.1, "remainingFraction": 0.9, "unit": "requests" }
+              },
+              {
+                "label": "Chat Requests",
+                "scope": { "windowId": "monthly" },
+                "window": { "id": "monthly", "label": "Monthly" },
+                "amount": { "usedFraction": 0.2, "remainingFraction": 0.8, "unit": "requests" }
+              }
+            ]
+        } ] }
+        """
+        let snapshot = try OmpUsageProbe.parse(json)
+        let titles = snapshot.quotas.compactMap(\.compactTitle)
+
+        #expect(titles == ["Premium Requests", "Chat Requests"])
+    }
+
+    @Test
+    func `degrades oversized window durations to the label instead of trapping`() throws {
+        // durationMs is attacker-adjacent external JSON; a finite value past
+        // Int.max must fall through to the label fallback, not crash the
+        // Int conversion.
+        let json = """
+        { "reports": [ {
+            "provider": "kimi-code",
+            "limits": [ {
+              "label": "Broken window",
+              "scope": { "windowId": "broken_machine_id" },
+              "window": { "id": "broken_machine_id", "durationMs": 1.0e308 },
+              "amount": { "usedFraction": 0.5, "remainingFraction": 0.5 }
+            } ]
+        } ] }
+        """
+        let snapshot = try OmpUsageProbe.parse(json)
+        let quota = try #require(snapshot.quota(for: .timeLimit("Kimi broken_machine_id")))
+
+        #expect(quota.compactTitle == "Broken window")
+    }
+
     // MARK: - Accounts Without Usage
 
     @Test


### PR DESCRIPTION
## Problem

With the Oh My Pi provider, Kimi's quota cards render raw machine window ids:

- the 5-hour rate limit shows as **`300TIME_UNIT_MINUTE`**
- the total quota shows as **`DEFAULT`**

omp's `kimi-code` reporter emits machine window ids next to human labels — captured from live `omp usage --json` (omp v17.0.2, values as observed):

```json
{ "id": "kimi-code:0", "label": "Total quota",
  "scope": { "windowId": "default" },
  "window": { "id": "default", "label": "Usage window", "resetsAt": 1784828755083 } }

{ "id": "kimi-code:1", "label": "5h limit",
  "scope": { "windowId": "300time_unit_minute" },
  "window": { "id": "300time_unit_minute", "label": "5h limit", "durationMs": 18000000 } }
```

`compactTitle` was built from the raw `windowToken` (`scope.windowId ?? window.id`), and `MenuContentView` uppercases the card title.

## Change

Humanize the **card title only**. Quota labels — and therefore persisted quota keys and menu-bar selections — keep the raw window token, per the `UsageQuota.compactTitle` design note ("The full label stays in `quotaType` so persisted quota keys and the menu bar are unaffected"). `windowToken`, `windowGroupKey`, `quotaLabel`, and meter qualification are byte-identical to `main`.

New `displayWindowToken(providerName:)` feeds `compactTitle` and prefers, in order:

1. an already-compact id (`5h`, `7d`, `1mo` — existing Claude/Codex/Z.ai titles unchanged);
2. a token derived from `window.durationMs` (`300time_unit_minute` + 18000000 ms → **`5h`**);
3. the limit's own label (`default` → **`Total quota`**), then the window label — both with a leading provider name stripped, since the card already sits inside that provider's section (Gemini embeds `"Gemini <model>"` in every limit label, per `oh-my-pi/packages/ai/src/usage/gemini.ts`);
4. the raw id.

Titles derived from the limit's own label are self-describing, so the shared-window meter prefix is suppressed for them (window-label fallbacks keep it — a window label names timing, not the metered resource) — Copilot meters three request pools over one `monthly` window with labels like `"Premium Requests"` (`usage/github-copilot.ts`), which would otherwise render as "Requests Premium Requests".

`compactDurationToken` converts via `Int(exactly:)`, so a malformed/oversized `durationMs` from external JSON degrades to the label fallback instead of trapping.

Kimi cards after this change: **`5h`** and **`Total quota`**.

## Not in this PR

The 5h card also shows no reset countdown. That is not displayable from ClaudeBar's side: the Kimi API does return `limits[].detail.resetTime`, but omp v17.0.2 loses it for windowed limits (`packages/ai/src/usage/kimi.ts` — when a limit already carries a `window`, `toUsageLimit` uses that window as-is; the `row.resetsAt` parsed from `detail` is only consulted in the no-window fallback branch), so `omp usage --json` carries no `resetsAt` for that limit. Filed upstream as can1357/oh-my-pi#5899; once omp emits it, the existing `resetsAt` path renders the countdown with no further ClaudeBar change.

## Tests

An earlier iteration of this branch humanized the full quota label; its display tests were run RED against the unchanged probe first (cards titled `"default"` / `"300time_unit_minute"`). Review flagged that label changes orphan persisted quota keys, so the fix was narrowed to `compactTitle`-only and the tests reworked to pin both halves of that contract:

- `derives a compact card title from the window duration for machine ids` — card `5h`, key stays `time:Kimi 300time_unit_minute`
- `falls back to the limit label for card titles when a window has no duration` — card `Total quota`, key stays `time:Kimi default`
- `strips the provider prefix from label-derived card titles` (gemini-shaped payload)
- `keeps meter words off self-describing card titles` (copilot-shaped payload)
- `keeps the meter prefix for window-label card titles` (window labels name timing, not the metered resource — review follow-up in df27702)
- `degrades oversized window durations to the label instead of trapping` (hardening, added after the RED run)

Full `InfrastructureTests` target: **961 tests / 75 suites passed**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quota cards with clearer, human-readable window labels such as “5h” instead of machine-generated identifiers.
  * Updated Kimi quota cards to display “Total quota” and accurate rate-limit labels.
  * Removed duplicated provider and meter wording from card titles.
  * Preserved existing quota selections while improving displayed labels.
  * Improved fallback labels when duration information is unavailable or unusually large.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->