### PR TITLE
feat(omp): condense long account discriminators in the menu bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cells materialized. Cards now lay out eagerly — the popover shows a few
   dozen at most, so laziness bought nothing — and the scroll view knows exact
   content heights up front.
+- Long account discriminators no longer flood the menu bar. Oh My Pi quota
+  labels embed an account token to keep multi-account quota keys unique
+  (e.g. "Claude 7d · jkjk987654321012"), and the dual-window menu bar label
+  rendered the whole thing. Aggregated quotas now carry a condensed menu-bar
+  title that truncates tokens longer than 8 characters to a 7-character
+  prefix plus an ellipsis ("Claude 7d · jkjk987…"); the menu bar and the
+  quota picker chips in Settings prefer it, while the full label — and
+  therefore every persisted quota key — stays unchanged. Condensed titles
+  that collide across accounts sharing a prefix get a numeric suffix
+  ("jkjk987… (2)") so the chips stay distinguishable.
 
 ---
 

--- a/Sources/App/Views/SettingsView.swift
+++ b/Sources/App/Views/SettingsView.swift
@@ -460,7 +460,7 @@ struct SettingsContentView: View {
                         HStack(spacing: 8) {
                             ForEach(menuBarQuotaOptions, id: \.quotaType.quotaKey) { quota in
                                 MenuBarQuotaChoiceButton(
-                                    title: quota.quotaType.displayName,
+                                    title: quota.menuBarTitle ?? quota.quotaType.displayName,
                                     isSelected: settings.menuBarPercentageQuotaKey == quota.quotaType.quotaKey
                                 ) {
                                     settings.menuBarPercentageQuotaKey = quota.quotaType.quotaKey
@@ -491,7 +491,7 @@ struct SettingsContentView: View {
 
                             ForEach(secondaryMenuBarQuotaOptions, id: \.quotaType.quotaKey) { quota in
                                 MenuBarQuotaChoiceButton(
-                                    title: quota.quotaType.displayName,
+                                    title: quota.menuBarTitle ?? quota.quotaType.displayName,
                                     isSelected: settings.menuBarSecondaryQuotaKey == quota.quotaType.quotaKey
                                 ) {
                                     settings.menuBarSecondaryQuotaKey = quota.quotaType.quotaKey

--- a/Sources/Domain/Monitor/QuotaMonitor.swift
+++ b/Sources/Domain/Monitor/QuotaMonitor.swift
@@ -235,8 +235,10 @@ public final class QuotaMonitor {
     /// The primary window renders exactly as the single-window label always has
     /// (percentage and/or duration joined by " · "). When `secondaryQuotaKey` is
     /// non-empty and differs from the primary, a second window is appended: each
-    /// window is prefixed with its `QuotaType.shortLabel` and the two are joined
-    /// by " | ", e.g. "5h 12% | 7d 34%". The status is the most severe of the
+    /// window is prefixed with the quota's `menuBarTitle` when the probe set one
+    /// (a condensed form of labels too wide for the menu bar), otherwise its
+    /// `QuotaType.shortLabel`, and the two are joined by " | ", e.g.
+    /// "5h 12% | 7d 34%". The status is the most severe of the
     /// shown windows, and each window is also exposed individually via
     /// `MenuBarLabel.segments` for renderers that draw them on separate lines.
     ///
@@ -290,8 +292,17 @@ public final class QuotaMonitor {
 
         switch (primary, secondary) {
         case let (.some(primary), .some(secondary)):
-            let primaryLabel = QuotaType(quotaKey: primaryQuotaKey)?.shortLabel ?? primaryQuotaKey
-            let secondaryLabel = QuotaType(quotaKey: secondaryQuotaKey)?.shortLabel ?? secondaryQuotaKey
+            // Window prefix: the quota's own condensed menu-bar title wins
+            // (probes set it when the full label is too wide, e.g. a long
+            // account discriminator), then the type's short label.
+            func windowPrefix(forQuotaKey quotaKey: String) -> String {
+                if let title = quota(providerId: providerId, quotaKey: quotaKey)?.menuBarTitle {
+                    return title
+                }
+                return QuotaType(quotaKey: quotaKey)?.shortLabel ?? quotaKey
+            }
+            let primaryLabel = windowPrefix(forQuotaKey: primaryQuotaKey)
+            let secondaryLabel = windowPrefix(forQuotaKey: secondaryQuotaKey)
             // Each window becomes its own segment (prefixed text + that
             // window's status) so stacked rendering can draw and tint them
             // independently; the joined text stays the canonical single-line

--- a/Sources/Domain/Provider/UsageQuota.swift
+++ b/Sources/Domain/Provider/UsageQuota.swift
@@ -46,6 +46,14 @@ public struct UsageQuota: Sendable, Equatable, Hashable, Comparable {
     /// `quotaType` so persisted quota keys and the menu bar are unaffected.
     public let compactTitle: String?
 
+    /// Menu-bar window title used when this quota renders as one of two
+    /// joined/stacked windows (e.g. "Claude 7d · jkjk987…"). Probes set it
+    /// when the full label is too wide for the menu bar — typically a long
+    /// account discriminator. The menu bar falls back to
+    /// `quotaType.shortLabel` when nil. The full label stays in `quotaType`
+    /// so persisted quota keys are unaffected.
+    public let menuBarTitle: String?
+
     // MARK: - Initialization
 
     public init(
@@ -59,7 +67,8 @@ public struct UsageQuota: Sendable, Equatable, Hashable, Comparable {
         dollarUsed: Decimal? = nil,
         dollarCap: Decimal? = nil,
         group: String? = nil,
-        compactTitle: String? = nil
+        compactTitle: String? = nil,
+        menuBarTitle: String? = nil
     ) {
         self.percentRemaining = min(100, percentRemaining)  // Allow negative, cap at 100
         self.quotaType = quotaType
@@ -72,6 +81,7 @@ public struct UsageQuota: Sendable, Equatable, Hashable, Comparable {
         self.dollarCap = dollarCap
         self.group = group
         self.compactTitle = compactTitle
+        self.menuBarTitle = menuBarTitle
     }
 
     // MARK: - Domain Behavior

--- a/Sources/Infrastructure/Omp/OmpUsageProbe.swift
+++ b/Sources/Infrastructure/Omp/OmpUsageProbe.swift
@@ -131,6 +131,7 @@ public struct OmpUsageProbe: UsageProbe {
         var accountRows: [ExtensionMetric] = []
         var seenRowLabels: Set<String> = []
         var seenGroupTitles: Set<String> = []
+        var seenMenuBarTitles: Set<String> = []
 
         for (index, report) in payload.reports.enumerated() {
             let needsDiscriminator = providerReportCounts[report.provider, default: 0] > 1
@@ -195,7 +196,9 @@ public struct OmpUsageProbe: UsageProbe {
                         dollarUsed: monetaryAmounts?.used,
                         dollarCap: monetaryAmounts?.cap,
                         group: group,
-                        compactTitle: Self.compactTitle(limit: limit, meter: meter, providerName: providerName)
+                        compactTitle: Self.compactTitle(limit: limit, meter: meter, providerName: providerName),
+                        menuBarTitle: Self.menuBarTitle(label: label, discriminator: discriminator)
+                            .map { Self.uniqueLabel($0, seen: &seenMenuBarTitles) }
                     )
                 )
             }
@@ -444,6 +447,34 @@ public struct OmpUsageProbe: UsageProbe {
         }
         parts.append(display.token)
         return parts.joined(separator: " ")
+    }
+
+    /// Menu-bar variant of a quota label: identical text with a long account
+    /// discriminator truncated to a short prefix plus an ellipsis
+    /// ("Claude 7d · jkjk987654321012" → "Claude 7d · jkjk987…"). The menu
+    /// bar renders the whole label as a window prefix, and a 16-character
+    /// token wastes most of its width. Returns nil when the label carries no
+    /// discriminator or it is already short enough — the menu bar then falls
+    /// back to the full label. Distinct discriminators can share a condensed
+    /// prefix without tripping the full-label "(2)" guard, so callers must
+    /// uniquify the result (`uniqueLabel`) before display. Purely
+    /// presentational: quota labels and persisted quota keys keep the full
+    /// discriminator.
+    static func menuBarTitle(label: String, discriminator: String?) -> String? {
+        guard let discriminator, !discriminator.isEmpty else { return nil }
+        let condensed = condensedDiscriminator(discriminator)
+        guard condensed != discriminator else { return nil }
+        return label.replacingOccurrences(of: "· \(discriminator)", with: "· \(condensed)")
+    }
+
+    /// Truncates a quota-label discriminator for menu bar display: tokens
+    /// longer than 8 characters keep their first 7 plus an ellipsis. The
+    /// 8-character budget already covers every opaque-id discriminator
+    /// (`accountDiscriminator` caps those at 8), so only long email local
+    /// parts get shortened.
+    static func condensedDiscriminator(_ discriminator: String) -> String {
+        guard discriminator.count > 8 else { return discriminator }
+        return "\(discriminator.prefix(7))…"
     }
 
     /// Maps Oh My Pi upstream provider ids to short display names.

--- a/Tests/DomainTests/Monitor/QuotaMonitorTests.swift
+++ b/Tests/DomainTests/Monitor/QuotaMonitorTests.swift
@@ -427,6 +427,40 @@ struct QuotaMonitorTests {
     }
 
     @Test
+    func `menu bar label prefers the quota's menuBarTitle for window prefixes`() async {
+        // Given: an aggregated quota whose full label carries a long account
+        // discriminator, condensed by the probe into `menuBarTitle`; the
+        // weekly window carries no override
+        let monitor = await makeRefreshedClaudeMonitor(quotas: [
+            UsageQuota(
+                percentRemaining: 69,
+                quotaType: .timeLimit("Claude 7d · jkjk987654321012"),
+                providerId: "claude",
+                menuBarTitle: "Claude 7d · jkjk987…"
+            ),
+            UsageQuota(percentRemaining: 35, quotaType: .weekly, providerId: "claude"),
+        ])
+
+        // When
+        let label = monitor.menuBarLabel(
+            providerId: "claude",
+            primaryQuotaKey: "time:Claude 7d · jkjk987654321012",
+            secondaryQuotaKey: "weekly",
+            showPercentage: true,
+            showDuration: false,
+            mode: .remaining
+        )
+
+        // Then: the condensed title replaces the full label in the joined
+        // text and the segment; windows without an override keep shortLabel
+        #expect(label?.text == "Claude 7d · jkjk987… 69% | 7d 35%")
+        #expect(label?.segments == [
+            MenuBarLabel.Segment(text: "Claude 7d · jkjk987… 69%", status: .healthy),
+            MenuBarLabel.Segment(text: "7d 35%", status: .warning),
+        ])
+    }
+
+    @Test
     func `menu bar label segments cover the duration-only variant`() async {
         // Given: session quota with reset ~3h away
         let monitor = await makeRefreshedClaudeMonitor(quotas: [

--- a/Tests/InfrastructureTests/Omp/OmpUsageProbeParsingTests.swift
+++ b/Tests/InfrastructureTests/Omp/OmpUsageProbeParsingTests.swift
@@ -436,6 +436,111 @@ struct OmpUsageProbeParsingTests {
     }
 
     @Test
+    func `condenses long discriminators into the menu bar title`() throws {
+        // A 16-character email local part is a legitimate quota-key
+        // discriminator but wastes most of the menu bar's width — the quota
+        // carries a truncated variant for display while the persisted key
+        // keeps the full token.
+        let json = """
+        { "reports": [
+          {
+            "provider": "anthropic",
+            "limits": [ {
+              "scope": { "windowId": "7d" },
+              "window": { "id": "7d", "durationMs": 604800000 },
+              "amount": { "remainingFraction": 0.69 }
+            } ],
+            "metadata": { "email": "jkjk987654321012@example.com" }
+          },
+          {
+            "provider": "anthropic",
+            "limits": [ {
+              "scope": { "windowId": "7d" },
+              "window": { "id": "7d", "durationMs": 604800000 },
+              "amount": { "remainingFraction": 0.4 }
+            } ],
+            "metadata": { "email": "work@example.com" }
+          }
+        ] }
+        """
+        let snapshot = try OmpUsageProbe.parse(json)
+
+        let long = try #require(snapshot.quotas.first {
+            $0.quotaType.displayName == "Claude 7d · jkjk987654321012"
+        })
+        #expect(long.menuBarTitle == "Claude 7d · jkjk987…")
+
+        // Short discriminators need no condensing — nil falls back to the
+        // full label in the menu bar.
+        let short = try #require(snapshot.quotas.first {
+            $0.quotaType.displayName == "Claude 7d · work"
+        })
+        #expect(short.menuBarTitle == nil)
+    }
+
+    @Test
+    func `suffixes menu bar titles when condensed discriminators collide`() throws {
+        // Two distinct discriminators can share the 7-character condensed
+        // prefix; the full labels differ, so the label-level "(2)" guard
+        // never fires. The condensed titles must still stay unique, or the
+        // menu bar and the Settings quota picker chips become
+        // indistinguishable.
+        let json = """
+        { "reports": [
+          {
+            "provider": "anthropic",
+            "limits": [ {
+              "scope": { "windowId": "7d" },
+              "window": { "id": "7d", "durationMs": 604800000 },
+              "amount": { "remainingFraction": 0.69 }
+            } ],
+            "metadata": { "email": "jkjk987654321012@example.com" }
+          },
+          {
+            "provider": "anthropic",
+            "limits": [ {
+              "scope": { "windowId": "7d" },
+              "window": { "id": "7d", "durationMs": 604800000 },
+              "amount": { "remainingFraction": 0.4 }
+            } ],
+            "metadata": { "email": "jkjk987999999999@example.com" }
+          }
+        ] }
+        """
+        let snapshot = try OmpUsageProbe.parse(json)
+
+        let titles = snapshot.quotas.compactMap(\.menuBarTitle)
+        #expect(titles == [
+            "Claude 7d · jkjk987…",
+            "Claude 7d · jkjk987… (2)",
+        ])
+        // Full labels — and therefore persisted quota keys — keep the
+        // untruncated discriminators and never collided in the first place.
+        #expect(Set(snapshot.quotas.map(\.quotaType.quotaKey)).count == 2)
+    }
+
+    @Test
+    func `keeps single-account quotas free of menu bar title overrides`() throws {
+        // One account per provider gets no discriminator, so there is
+        // nothing to condense.
+        let json = """
+        { "reports": [ {
+            "provider": "anthropic",
+            "limits": [ {
+              "scope": { "windowId": "5h" },
+              "window": { "id": "5h", "durationMs": 18000000 },
+              "amount": { "remainingFraction": 0.5 }
+            } ],
+            "metadata": { "email": "jkjk987654321012@example.com" }
+        } ] }
+        """
+        let snapshot = try OmpUsageProbe.parse(json)
+
+        #expect(snapshot.quotas.count == 1)
+        #expect(snapshot.quotas[0].menuBarTitle == nil)
+    }
+
+    @Test
     func `qualifies multiple meters sharing one window`() throws {
         // Z.ai can meter tokens and requests over the same window; both
         // must stay distinguishable without degrading to bare ordinals.


### PR DESCRIPTION
## Problem

When the Oh My Pi harness holds multiple accounts on the same upstream provider, quota labels embed an account discriminator to keep persisted quota keys unique — up to 16 characters for email local parts, e.g. `Claude 7d · jkjk987654321012`.

The dual-window menu bar label renders the whole label as the window prefix, so a single long discriminator eats most of the menu bar:

```
Codex 7d 65% · 5d
Claude 7d · jkjk987654321012 69% · 4d
```

The same full label also fills the QUOTA / SECONDARY QUOTA picker chips in Settings, pushing sibling chips off-screen.

## Fix

- `UsageQuota` gains an optional `menuBarTitle` — same pattern as the existing `compactTitle`: purely presentational, the full label (and therefore every persisted quota key) stays untouched.
- `OmpUsageProbe` sets it when a discriminator is longer than 8 characters, truncating to a 7-character prefix plus an ellipsis: `Claude 7d · jkjk987…`. Opaque-id discriminators are already capped at 8 characters (`accountDiscriminator`) and stay as-is; short email local parts and `#N` ordinals are untouched (`menuBarTitle == nil`).
- Distinct discriminators can share a condensed prefix without ever tripping the label-level `(2)` guard (the full labels differ), so condensed titles run through their own uniqueness pass: `jkjk987… (2)`.
- `QuotaMonitor.menuBarLabel` prefers the quota's `menuBarTitle` for dual-window prefixes, falling back to `QuotaType.shortLabel` as before.
- The Settings quota picker chips prefer `menuBarTitle ?? quotaType.displayName`, so the chips match what the menu bar shows.

After: `Claude 7d · jkjk987… 69% · 4d`.

Single-window labels never render the label text, so their behavior is unchanged.

## Tests

- `QuotaMonitorTests`: dual-window label uses the quota's `menuBarTitle` for the prefix (joined text and segments); windows without an override keep `shortLabel`.
- `OmpUsageProbeParsingTests`:
  - 16-char email local part → condensed `menuBarTitle`, short discriminator → `nil`.
  - single-account report → `nil` (no discriminator, nothing to condense).
  - prefix-colliding discriminators (`jkjk987654321012` vs `jkjk987999999999`) → `jkjk987…` / `jkjk987… (2)` while quota keys never collided in the first place.

`tuist test Domain` and `tuist test Infrastructure` pass; the app target builds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu-bar quota labels for accounts with long discriminators.
  * Long account tokens are condensed for easier reading.
  * Added numeric suffixes when condensed labels would otherwise collide.
  * Preserved full quota labels and persisted quota keys.
  * Updated quota windows and selectors to use the condensed titles consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->