### PR TITLE
fix: persist refreshed Claude OAuth credentials

### DIFF
--- a/Sources/Infrastructure/Claude/ClaudeCredentialLoader.swift
+++ b/Sources/Infrastructure/Claude/ClaudeCredentialLoader.swift
@@ -58,6 +58,20 @@ public struct ClaudeCredentialLoader: Sendable {
     /// Refresh buffer: 5 minutes before expiration
     private static let refreshBufferMs: Double = 5 * 60 * 1000
 
+    static func keychainSaveArguments(
+        service: String,
+        account: String,
+        password: String
+    ) -> [String] {
+        [
+            "add-generic-password",
+            "-U",
+            "-s", service,
+            "-a", account,
+            "-w", password
+        ]
+    }
+
     public init(
         homeDirectory: String = NSHomeDirectory(),
         keychainService: String = "Claude Code-credentials",
@@ -261,19 +275,13 @@ public struct ClaudeCredentialLoader: Sendable {
             return
         }
 
-        // Delete existing item first (ignore errors if not found)
-        let deleteProcess = Process()
-        deleteProcess.executableURL = URL(fileURLWithPath: "/usr/bin/security")
-        deleteProcess.arguments = ["delete-generic-password", "-s", keychainService]
-        deleteProcess.standardOutput = Pipe()
-        deleteProcess.standardError = Pipe()
-        try? deleteProcess.run()
-        deleteProcess.waitUntilExit()
-
-        // Add new item
         let addProcess = Process()
         addProcess.executableURL = URL(fileURLWithPath: "/usr/bin/security")
-        addProcess.arguments = ["add-generic-password", "-s", keychainService, "-w", jsonString]
+        addProcess.arguments = Self.keychainSaveArguments(
+            service: keychainService,
+            account: NSUserName(),
+            password: jsonString
+        )
         addProcess.standardOutput = Pipe()
         addProcess.standardError = Pipe()
 

--- a/Tests/InfrastructureTests/Claude/ClaudeCredentialLoaderTests.swift
+++ b/Tests/InfrastructureTests/Claude/ClaudeCredentialLoaderTests.swift
@@ -224,6 +224,31 @@ struct ClaudeCredentialLoaderTests {
         #expect(reloaded?.oauth.refreshToken == "new-refresh")
     }
 
+    @Test
+    func `keychain save arguments update existing item for account`() {
+        let password = """
+        {
+          "claudeAiOauth": {
+            "accessToken": "refreshed-token"
+          }
+        }
+        """
+
+        let arguments = ClaudeCredentialLoader.keychainSaveArguments(
+            service: "Claude Code-credentials",
+            account: "test-user",
+            password: password
+        )
+
+        #expect(arguments == [
+            "add-generic-password",
+            "-U",
+            "-s", "Claude Code-credentials",
+            "-a", "test-user",
+            "-w", password
+        ])
+    }
+
     // MARK: - Environment Variable Tests
 
     @Test


### PR DESCRIPTION
## Summary

- persist refreshed Claude OAuth credentials back to Keychain
- update the existing generic-password item in place
- cover the required Keychain command arguments with a regression test

## Root cause

`security add-generic-password` requires an account via `-a`. ClaudeBar omitted
that argument, so the command exited with status 2 after a token refresh. The
refresh itself succeeded in memory, but the stale Keychain credentials were read
again later.

## Validation

- Regression coverage added to `ClaudeCredentialLoaderTests`
- RED: local harness failed against the original source because
  `keychainSaveArguments` did not exist
- GREEN: the same harness passes against the updated source
- Isolated temporary Keychain accepted two consecutive `-U` writes and returned
  the second value
- `swiftc -parse` passes for the changed source and test files
- [Fork Actions test run](https://github.com/jsg333/ClaudeBar/actions/runs/30297383332):
  1,753 tests passed across 177 suites with zero failures
- Upstream Build and Tests workflows are awaiting maintainer approval for this
  first-time fork PR

Fixes #173


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential saving by updating existing Keychain entries directly instead of deleting and recreating them.
  * Reduced the risk of errors when storing Claude authentication credentials.

* **Tests**
  * Added coverage to verify correct Keychain update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->