### PR TITLE
fix(zai): recognize CREDIT_LIMIT quota entries for credit-based plan tiers

### DIFF
--- a/Sources/Infrastructure/Zai/ZaiUsageProbe.swift
+++ b/Sources/Infrastructure/Zai/ZaiUsageProbe.swift
@@ -311,18 +311,22 @@ public struct ZaiUsageProbe: UsageProbe {
             switch (limit.type, limit.unit) {
             case ("TIME_LIMIT", _):
                 quotaType = .timeLimit("MCP")
-            case ("TOKENS_LIMIT", 3):
+            case ("TOKENS_LIMIT", 3), ("CREDIT_LIMIT", 3):
                 quotaType = .session
-            case ("TOKENS_LIMIT", 6):
+            case ("TOKENS_LIMIT", 6), ("CREDIT_LIMIT", 6):
                 quotaType = .weekly
-            case ("TOKENS_LIMIT", 7):
+            case ("TOKENS_LIMIT", 7), ("CREDIT_LIMIT", 7):
                 quotaType = .modelSpecific("Monthly")
-            case ("TOKENS_LIMIT", nil):
+            case ("TOKENS_LIMIT", nil), ("CREDIT_LIMIT", nil):
                 // Backward-compat: legacy responses with no `unit` field default to session.
                 quotaType = .session
             case ("TOKENS_LIMIT", let unit?):
                 // Unknown unit — preserve via modelSpecific so it isn't dropped/collapsed.
                 quotaType = .modelSpecific("Tokens (unit \(unit))")
+            case ("CREDIT_LIMIT", let unit?):
+                // Credit-based plan tiers (e.g. GLM Coding Lite) report CREDIT_LIMIT
+                // with the same `unit` semantics as TOKENS_LIMIT.
+                quotaType = .modelSpecific("Credits (unit \(unit))")
             default:
                 // Skip unknown limit types
                 continue

--- a/Tests/InfrastructureTests/Zai/ZaiUsageProbeParsingTests.swift
+++ b/Tests/InfrastructureTests/Zai/ZaiUsageProbeParsingTests.swift
@@ -354,4 +354,91 @@ struct ZaiUsageProbeParsingTests {
         #expect(snapshot.quotas[0].percentRemaining >= 0 && snapshot.quotas[0].percentRemaining <= 100)
         #expect(snapshot.quotas[1].percentRemaining >= 0 && snapshot.quotas[1].percentRemaining <= 100)
     }
+
+    // MARK: - CREDIT_LIMIT Tests
+    //
+    // Credit-based plan tiers (e.g. GLM Coding Lite) report quota entries with
+    // type CREDIT_LIMIT instead of TOKENS_LIMIT, using the same `unit` semantics.
+    // Because the switch only matched TOKENS_LIMIT/TIME_LIMIT tuples, every entry
+    // fell through to `continue` and the probe failed outright with
+    // "No recognized quota types found".
+
+    static let sampleQuotaLimitResponseCreditPlan = """
+    {
+      "data": {
+        "limits": [
+          { "type": "CREDIT_LIMIT", "unit": 3, "number": 5, "usage": 2000,
+            "currentValue": 0, "remaining": 2000, "percentage": 0 },
+          { "type": "CREDIT_LIMIT", "unit": 6, "number": 1, "usage": 10000,
+            "currentValue": 2004, "remaining": 7995, "percentage": 20,
+            "nextResetTime": 1786112351998 }
+        ],
+        "level": "lite"
+      }
+    }
+    """
+
+    @Test
+    func `parses credit-based plan response instead of failing`() throws {
+        let data = Data(Self.sampleQuotaLimitResponseCreditPlan.utf8)
+        let snapshot = try ZaiUsageProbe.parseQuotaLimitResponse(data, providerId: "zai")
+
+        #expect(snapshot.quotas.count == 2)
+        #expect(snapshot.quotas.contains { $0.quotaType == .session })
+        #expect(snapshot.quotas.contains { $0.quotaType == .weekly })
+    }
+
+    @Test
+    func `maps CREDIT_LIMIT unit=3 to session`() throws {
+        let json = """
+        { "data": { "limits": [
+          { "type": "CREDIT_LIMIT", "unit": 3, "percentage": 13 }
+        ] } }
+        """
+        let snapshot = try ZaiUsageProbe.parseQuotaLimitResponse(Data(json.utf8), providerId: "zai")
+        #expect(snapshot.quotas.count == 1)
+        #expect(snapshot.quotas.first?.quotaType == .session)
+        #expect(snapshot.quotas.first?.percentRemaining == 87.0)
+    }
+
+    @Test
+    func `maps CREDIT_LIMIT unit=6 to weekly`() throws {
+        let json = """
+        { "data": { "limits": [
+          { "type": "CREDIT_LIMIT", "unit": 6, "percentage": 20 }
+        ] } }
+        """
+        let snapshot = try ZaiUsageProbe.parseQuotaLimitResponse(Data(json.utf8), providerId: "zai")
+        #expect(snapshot.quotas.count == 1)
+        #expect(snapshot.quotas.first?.quotaType == .weekly)
+        #expect(snapshot.quotas.first?.percentRemaining == 80.0)
+    }
+
+    @Test
+    func `preserves CREDIT_LIMIT with unknown unit rather than dropping it`() throws {
+        let json = """
+        { "data": { "limits": [
+          { "type": "CREDIT_LIMIT", "unit": 99, "percentage": 5 }
+        ] } }
+        """
+        let snapshot = try ZaiUsageProbe.parseQuotaLimitResponse(Data(json.utf8), providerId: "zai")
+        #expect(snapshot.quotas.count == 1)
+        #expect(snapshot.quotas.first?.quotaType == .modelSpecific("Credits (unit 99)"))
+    }
+
+    @Test
+    func `handles mixed TOKENS_LIMIT and CREDIT_LIMIT entries`() throws {
+        let json = """
+        { "data": { "limits": [
+          { "type": "TOKENS_LIMIT", "unit": 3, "percentage": 13 },
+          { "type": "CREDIT_LIMIT", "unit": 6, "percentage": 20 },
+          { "type": "TIME_LIMIT", "unit": 5, "percentage": 1 }
+        ] } }
+        """
+        let snapshot = try ZaiUsageProbe.parseQuotaLimitResponse(Data(json.utf8), providerId: "zai")
+        #expect(snapshot.quotas.count == 3)
+        #expect(snapshot.quotas.contains { $0.quotaType == .session })
+        #expect(snapshot.quotas.contains { $0.quotaType == .weekly })
+        #expect(snapshot.quotas.contains { $0.quotaType == .timeLimit("MCP") })
+    }
 }


### PR DESCRIPTION
## Problem

On credit-based GLM plan tiers (`"level": "lite"`), the Z.ai provider fails
with **`Z.ai Unavailable — Failed to parse output: No recognized quota types found`**,
even though the account is valid and `/api/monitor/usage/quota/limit` returns HTTP 200
with complete quota data.

## Root cause

`ZaiUsageProbe.parseQuotaLimitResponse` switches on `(limit.type, limit.unit)` and
only matches `TIME_LIMIT` and `TOKENS_LIMIT`. Credit-based tiers report the same
information under `CREDIT_LIMIT`, so every entry hits the `default: continue`,
`quotas` ends up empty, and the guard throws.

Actual response from a `lite` account (values redacted for privacy):

```json
{
  "code": 200,
  "data": {
    "limits": [
      { "type": "CREDIT_LIMIT", "unit": 3, "number": 5, "usage": 2000,
        "currentValue": 0, "remaining": 2000, "percentage": 0 },
      { "type": "CREDIT_LIMIT", "unit": 6, "number": 1, "usage": 10000,
        "currentValue": 2004, "remaining": 7995, "percentage": 20,
        "nextResetTime": 1786112351998 }
    ],
    "level": "lite"
  },
  "success": true
}
```

The `unit` semantics are identical to `TOKENS_LIMIT` — `3` is the rolling 5-hour
window and `6` is the rolling multi-day window — so the existing mapping from #181
applies unchanged.

## Fix

Add `CREDIT_LIMIT` to each existing case rather than duplicating the mapping, plus a
catch-all so unrecognised units surface as `Credits (unit N)` instead of being dropped
silently — mirroring the existing `Tokens (unit N)` behaviour.

## Tests

Five new cases in `ZaiUsageProbeParsingTests`: full credit-plan response, `unit=3` →
session, `unit=6` → weekly, unknown-unit preservation, and a mixed
`TOKENS_LIMIT`/`CREDIT_LIMIT`/`TIME_LIMIT` response. `tuist test Infrastructure`
passes (22 tests).

Verified end-to-end against a live `lite` account: probe now logs
`Zai probe success: 2 quotas found` and both windows render in the menu bar.

No behaviour change for token-based plans.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quota reporting for credit-based plans.
  * Session, weekly, and monthly credit limits are now categorized correctly.
  * Unknown credit units are preserved as model-specific quotas.
  * Mixed quota responses are handled more reliably.

* **Tests**
  * Added coverage for credit plans, quota unit mappings, unknown units, and mixed response payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->