### PR TITLE
feat: add DeepSeek provider

### DIFF
--- a/Sources/App/ClaudeBarApp.swift
+++ b/Sources/App/ClaudeBarApp.swift
@@ -100,6 +100,10 @@ struct ClaudeBarApp: App {
                 probe: MiniMaxUsageProbe(settingsRepository: settingsRepository),
                 settingsRepository: settingsRepository
             ),
+            DeepSeekProvider(
+                probe: DeepSeekUsageProbe(settingsRepository: settingsRepository),
+                settingsRepository: settingsRepository
+            ),
             AlibabaProvider(
                 probe: AlibabaUsageProbe(settingsRepository: settingsRepository, cookieProvider: AlibabaBrowserCookieProvider()),
                 settingsRepository: settingsRepository

--- a/Sources/App/Settings/AppSettings.swift
+++ b/Sources/App/Settings/AppSettings.swift
@@ -294,6 +294,7 @@ public final class AppSettings {
     public var zai: ZaiSettingsRepository { repository }
     public var bedrock: BedrockSettingsRepository { repository }
     public var minimax: MiniMaxSettingsRepository { repository }
+    public var deepseek: DeepSeekSettingsRepository { repository }
     public var alibaba: AlibabaSettingsRepository { repository }
     public var hook: HookSettingsRepository { repository }
 

--- a/Sources/App/Views/ProviderIcons.swift
+++ b/Sources/App/Views/ProviderIcons.swift
@@ -95,6 +95,7 @@ struct ProviderIconView: View {
         case "zai": return "z.square.fill"
         case "copilot": return "chevron.left.forwardslash.chevron.right"
         case "minimax": return "waveform"
+        case "deepseek": return "d.square.fill"
         case "opencode-go": return "square.stack.3d.up.fill"
         case "omp": return "terminal.fill"
         case "grok": return "line.diagonal"

--- a/Sources/App/Views/ProviderVisualIdentity.swift
+++ b/Sources/App/Views/ProviderVisualIdentity.swift
@@ -356,6 +356,34 @@ extension MiniMaxProvider: ProviderVisualIdentity {
     }
 }
 
+// MARK: - DeepSeekProvider Visual Identity
+
+extension DeepSeekProvider: ProviderVisualIdentity {
+    public var symbolIcon: String { "d.square.fill" }
+
+    public var iconAssetName: String { "DeepSeekIcon" }
+
+    public func themeColor(for scheme: ColorScheme) -> Color {
+        // DeepSeek brand blue
+        scheme == .dark
+            ? Color(red: 0.42, green: 0.52, blue: 1.0)
+            : Color(red: 0.23, green: 0.35, blue: 0.92)
+    }
+
+    public func themeGradient(for scheme: ColorScheme) -> LinearGradient {
+        LinearGradient(
+            colors: [
+                themeColor(for: scheme),
+                scheme == .dark
+                    ? Color(red: 0.22, green: 0.28, blue: 0.85)
+                    : Color(red: 0.15, green: 0.20, blue: 0.75)
+            ],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+}
+
 // MARK: - MistralProvider Visual Identity
 
 extension MistralProvider: ProviderVisualIdentity {
@@ -528,6 +556,10 @@ enum ProviderVisualIdentityLookup {
             return scheme == .dark
                 ? Color(red: 0.91, green: 0.27, blue: 0.42)
                 : Color(red: 0.82, green: 0.20, blue: 0.35)
+        case "deepseek":
+            return scheme == .dark
+                ? Color(red: 0.42, green: 0.52, blue: 1.0)
+                : Color(red: 0.23, green: 0.35, blue: 0.92)
         case "cursor":
             return scheme == .dark
                 ? Color(red: 0.20, green: 0.78, blue: 0.82)
@@ -603,6 +635,10 @@ enum ProviderVisualIdentityLookup {
             secondaryColor = scheme == .dark
                 ? Color(red: 0.96, green: 0.53, blue: 0.24)
                 : Color(red: 0.86, green: 0.43, blue: 0.14)
+        case "deepseek":
+            secondaryColor = scheme == .dark
+                ? Color(red: 0.22, green: 0.28, blue: 0.85)
+                : Color(red: 0.15, green: 0.20, blue: 0.75)
         case "cursor":
             secondaryColor = scheme == .dark
                 ? Color(red: 0.15, green: 0.55, blue: 0.75)
@@ -652,6 +688,7 @@ enum ProviderVisualIdentityLookup {
         case "kimi": return "KimiIcon"
         case "kiro": return "KiroIcon"
         case "minimax": return "MiniMaxIcon"
+        case "deepseek": return "DeepSeekIcon"
         case "cursor": return "CursorIcon"
         case "mistral": return "MistralIcon"
         case "opencode-go": return "OpenCodeIcon"
@@ -675,6 +712,7 @@ enum ProviderVisualIdentityLookup {
         case "kimi": return "Kimi"
         case "kiro": return "Kiro"
         case "minimax": return "MiniMax"
+        case "deepseek": return "DeepSeek"
         case "cursor": return "Cursor"
         case "mistral": return "Mistral"
         case "opencode-go": return "OpenCode Go"
@@ -698,6 +736,7 @@ enum ProviderVisualIdentityLookup {
         case "kimi": return "k.square.fill"
         case "kiro": return "wand.and.stars.inverse"
         case "minimax": return "waveform"
+        case "deepseek": return "d.square.fill"
         case "cursor": return "cursorarrow.rays"
         case "mistral": return "cat.fill"
         case "opencode-go": return "square.stack.3d.up.fill"

--- a/Sources/App/Views/Settings/DeepSeekConfigCard.swift
+++ b/Sources/App/Views/Settings/DeepSeekConfigCard.swift
@@ -1,0 +1,291 @@
+import SwiftUI
+import Domain
+import Infrastructure
+
+/// DeepSeek provider configuration card for SettingsView.
+/// Mirrors MiniMaxConfigCard (minus the region picker) — DeepSeek has a single global endpoint.
+struct DeepSeekConfigCard: View {
+    let monitor: QuotaMonitor
+
+    @State private var settings = AppSettings.shared
+    @Environment(\.appTheme) private var theme
+
+    @State private var deepSeekConfigExpanded: Bool = false
+    @State private var deepSeekApiKeyInput: String = ""
+    @State private var deepSeekAuthEnvVarInput: String = ""
+    @State private var showDeepSeekApiKey: Bool = false
+    @State private var isTestingDeepSeek = false
+    @State private var deepSeekTestResult: String?
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $deepSeekConfigExpanded) {
+            Divider()
+                .background(theme.glassBorder)
+                .padding(.vertical, 12)
+
+            deepSeekConfigForm
+        } label: {
+            deepSeekConfigHeader
+                .contentShape(.rect)
+                .onTapGesture {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        deepSeekConfigExpanded.toggle()
+                    }
+                }
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 14)
+                .fill(theme.cardGradient)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14)
+                        .stroke(
+                            LinearGradient(
+                                colors: [
+                                    theme.glassBorder, theme.glassBorder.opacity(0.5)
+                                ],
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            ),
+                            lineWidth: 1
+                        )
+                )
+        )
+        .onAppear {
+            deepSeekAuthEnvVarInput = settings.deepseek.deepseekAuthEnvVar()
+        }
+    }
+
+    private var deepSeekConfigHeader: some View {
+        HStack(spacing: 10) {
+            ZStack {
+                Circle()
+                    .fill(
+                        LinearGradient(
+                            colors: [
+                                Color(red: 0.42, green: 0.52, blue: 1.0),
+                                Color(red: 0.22, green: 0.28, blue: 0.85)
+                            ],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                    .frame(width: 32, height: 32)
+
+                Image(systemName: "d.square.fill")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundStyle(.white)
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("DeepSeek Configuration")
+                    .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
+                    .foregroundStyle(theme.textPrimary)
+
+                Text("Balance tracking")
+                    .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
+                    .foregroundStyle(theme.textTertiary)
+            }
+
+            Spacer()
+        }
+    }
+
+    private var deepSeekConfigForm: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            // API Key input
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Text("API KEY")
+                        .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
+                        .foregroundStyle(theme.textSecondary)
+                        .tracking(0.5)
+
+                    Spacer()
+
+                    if settings.deepseek.hasDeepSeekApiKey() {
+                        HStack(spacing: 3) {
+                            Image(systemName: "checkmark.circle.fill")
+                                .font(.system(size: 9))
+                            Text("Configured")
+                                .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
+                        }
+                        .foregroundStyle(theme.statusHealthy)
+                    }
+                }
+
+                HStack(spacing: 6) {
+                    Group {
+                        if showDeepSeekApiKey {
+                            TextField("", text: $deepSeekApiKeyInput, prompt: Text("sk-...").foregroundStyle(theme.textTertiary))
+                        } else {
+                            SecureField("", text: $deepSeekApiKeyInput, prompt: Text("sk-...").foregroundStyle(theme.textTertiary))
+                        }
+                    }
+                    .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
+                    .foregroundStyle(theme.textPrimary)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 8)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(theme.glassBackground)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .stroke(theme.glassBorder, lineWidth: 1)
+                            )
+                    )
+
+                    Button {
+                        showDeepSeekApiKey.toggle()
+                    } label: {
+                        Image(systemName: showDeepSeekApiKey ? "eye.slash.fill" : "eye.fill")
+                            .font(.system(size: 11))
+                            .foregroundStyle(theme.textSecondary)
+                            .frame(width: 28, height: 28)
+                            .background(
+                                Circle()
+                                    .fill(theme.glassBackground)
+                            )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+            // Environment Variable
+            VStack(alignment: .leading, spacing: 6) {
+                Text("API KEY ENV VAR (ALTERNATIVE)")
+                    .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
+                    .foregroundStyle(theme.textSecondary)
+                    .tracking(0.5)
+
+                TextField("", text: $deepSeekAuthEnvVarInput, prompt: Text("DEEPSEEK_API_KEY").foregroundStyle(theme.textTertiary))
+                    .font(.system(size: 12, weight: .medium, design: theme.fontDesign))
+                    .foregroundStyle(theme.textPrimary)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 8)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(theme.glassBackground)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .stroke(theme.glassBorder, lineWidth: 1)
+                            )
+                    )
+                    .onChange(of: deepSeekAuthEnvVarInput) { _, newValue in
+                        settings.deepseek.setDeepSeekAuthEnvVar(newValue)
+                    }
+            }
+
+            // Token lookup order
+            VStack(alignment: .leading, spacing: 4) {
+                Text("API KEY LOOKUP ORDER")
+                    .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
+                    .foregroundStyle(theme.textSecondary)
+                    .tracking(0.5)
+
+                Text("1. First checks environment variable (default: DEEPSEEK_API_KEY)")
+                    .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
+                    .foregroundStyle(theme.textTertiary)
+                Text("2. Falls back to API key entered above")
+                    .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
+                    .foregroundStyle(theme.textTertiary)
+            }
+
+            // Save & Test button
+            if isTestingDeepSeek {
+                HStack {
+                    ProgressView()
+                        .scaleEffect(0.7)
+                    Text("Testing connection...")
+                        .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
+                        .foregroundStyle(theme.textSecondary)
+                }
+            } else {
+                Button {
+                    Task {
+                        await testDeepSeekConnection()
+                    }
+                } label: {
+                    Text("Save & Test Connection")
+                        .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6)
+                                .fill(theme.accentPrimary)
+                        )
+                }
+                .buttonStyle(.plain)
+            }
+
+            if let result = deepSeekTestResult {
+                Text(result)
+                    .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
+                    .foregroundStyle(result.contains("Success") ? theme.statusHealthy : theme.statusCritical)
+            }
+
+            // Help link
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Get your API key from the DeepSeek platform")
+                    .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
+                    .foregroundStyle(theme.textTertiary)
+
+                Link(destination: URL(string: "https://platform.deepseek.com/api_keys")!) {
+                    HStack(spacing: 3) {
+                        Text("Open DeepSeek API Keys")
+                            .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
+                        Image(systemName: "arrow.up.right")
+                            .font(.system(size: 7, weight: .bold))
+                    }
+                    .foregroundStyle(theme.accentPrimary)
+                }
+            }
+
+            // Delete API key
+            if settings.deepseek.hasDeepSeekApiKey() {
+                Button {
+                    settings.deepseek.deleteDeepSeekApiKey()
+                    deepSeekApiKeyInput = ""
+                    deepSeekTestResult = nil
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "trash.fill")
+                            .font(.system(size: 9))
+                        Text("Remove API Key")
+                            .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
+                    }
+                    .foregroundStyle(theme.statusCritical)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    private func testDeepSeekConnection() async {
+        isTestingDeepSeek = true
+        deepSeekTestResult = nil
+
+        settings.deepseek.setDeepSeekAuthEnvVar(deepSeekAuthEnvVarInput)
+        if !deepSeekApiKeyInput.isEmpty {
+            AppLog.credentials.info("Saving DeepSeek API key for connection test")
+            settings.deepseek.saveDeepSeekApiKey(deepSeekApiKeyInput)
+            deepSeekApiKeyInput = ""
+        }
+
+        AppLog.credentials.info("Testing DeepSeek connection via provider refresh")
+        await monitor.refresh(providerId: "deepseek")
+
+        if let error = monitor.provider(for: "deepseek")?.lastError {
+            AppLog.credentials.error("DeepSeek connection test failed: \(error.localizedDescription)")
+            deepSeekTestResult = "Failed: \(error.localizedDescription)"
+        } else {
+            AppLog.credentials.info("DeepSeek connection test succeeded")
+            deepSeekTestResult = "Success: Connection verified"
+        }
+
+        isTestingDeepSeek = false
+    }
+}

--- a/Sources/App/Views/SettingsView.swift
+++ b/Sources/App/Views/SettingsView.swift
@@ -34,6 +34,7 @@ struct SettingsContentView: View {
         static let bedrock = "bedrock"
         static let kimi = "kimi"
         static let minimax = "minimax"
+        static let deepseek = "deepseek"
         static let alibaba = "alibaba"
     }
 
@@ -59,6 +60,10 @@ struct SettingsContentView: View {
 
     private var isMiniMaxEnabled: Bool {
         monitor.provider(for: ProviderID.minimax)?.isEnabled ?? false
+    }
+
+    private var isDeepSeekEnabled: Bool {
+        monitor.provider(for: ProviderID.deepseek)?.isEnabled ?? false
     }
 
     private var isBedrockEnabled: Bool {
@@ -114,6 +119,10 @@ struct SettingsContentView: View {
                     }
                     if isMiniMaxEnabled {
                         MiniMaxConfigCard(monitor: monitor)
+                            .transition(.opacity.combined(with: .move(edge: .top)))
+                    }
+                    if isDeepSeekEnabled {
+                        DeepSeekConfigCard(monitor: monitor)
                             .transition(.opacity.combined(with: .move(edge: .top)))
                     }
                     if isAlibabaEnabled {

--- a/Sources/App/Views/Theme.swift
+++ b/Sources/App/Views/Theme.swift
@@ -634,6 +634,11 @@ extension AppTheme {
             return scheme == .dark
                 ? Color(red: 0.91, green: 0.27, blue: 0.42)
                 : Color(red: 0.82, green: 0.20, blue: 0.35)
+        case "deepseek":
+            // DeepSeek brand blue
+            return scheme == .dark
+                ? Color(red: 0.42, green: 0.52, blue: 1.0)
+                : Color(red: 0.23, green: 0.35, blue: 0.92)
         case "alibaba":
             // Alibaba Cloud orange
             return scheme == .dark
@@ -694,6 +699,11 @@ extension AppTheme {
             secondaryColor = scheme == .dark
                 ? Color(red: 0.96, green: 0.53, blue: 0.24)
                 : Color(red: 0.86, green: 0.43, blue: 0.14)
+        case "deepseek":
+            // DeepSeek blue gradient
+            secondaryColor = scheme == .dark
+                ? Color(red: 0.22, green: 0.28, blue: 0.85)
+                : Color(red: 0.15, green: 0.20, blue: 0.75)
         case "alibaba":
             // Alibaba orange-to-red gradient
             secondaryColor = scheme == .dark
@@ -733,6 +743,7 @@ extension AppTheme {
         case "zai": return "ZaiIcon"
         case "bedrock": return "BedrockIcon"
         case "minimax": return "MiniMaxIcon"
+        case "deepseek": return "DeepSeekIcon"
         case "alibaba": return "AlibabaIcon"
         case "opencode-go": return "OpenCodeIcon"
         case "omp": return "OmpIcon"
@@ -752,6 +763,7 @@ extension AppTheme {
         case "zai": return "Z.ai"
         case "bedrock": return "AWS Bedrock"
         case "minimax": return "MiniMax"
+        case "deepseek": return "DeepSeek"
         case "alibaba": return "Alibaba"
         case "opencode-go": return "OpenCode Go"
         case "omp": return "Oh My Pi"
@@ -771,6 +783,7 @@ extension AppTheme {
         case "zai": return "z.square.fill"
         case "bedrock": return "cloud.fill" // AWS cloud icon
         case "minimax": return "waveform"
+        case "deepseek": return "d.square.fill"
         case "alibaba": return "cloud.fill"
         case "opencode-go": return "square.stack.3d.up.fill"
         case "omp": return "terminal.fill"

--- a/Sources/Domain/Provider/DeepSeek/DeepSeekProvider.swift
+++ b/Sources/Domain/Provider/DeepSeek/DeepSeekProvider.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Observation
+
+/// DeepSeek AI provider - a rich domain model.
+/// Observable class with its own state (isSyncing, snapshot, error).
+/// Owns its probe and manages its own data lifecycle.
+@MainActor
+@Observable
+public final class DeepSeekProvider: AIProvider {
+    // MARK: - Identity (Protocol Requirement)
+
+    public let id: String = "deepseek"
+    public let name: String = "DeepSeek"
+    public let cliCommand: String = "" // API-only provider, no CLI
+
+    public var dashboardURL: URL? {
+        URL(string: "https://platform.deepseek.com/usage")
+    }
+
+    public var statusPageURL: URL? {
+        nil
+    }
+
+    /// Whether the provider is enabled (persisted via settingsRepository)
+    public var isEnabled: Bool {
+        didSet {
+            settingsRepository.setEnabled(isEnabled, forProvider: id)
+        }
+    }
+
+    // MARK: - State (Observable)
+
+    /// Whether the provider is currently syncing data
+    public private(set) var isSyncing: Bool = false
+
+    /// The current usage snapshot (nil if never refreshed or unavailable)
+    public private(set) var snapshot: UsageSnapshot?
+
+    /// The last error that occurred during refresh
+    public private(set) var lastError: Error?
+
+    // MARK: - Internal
+
+    /// The probe used to fetch usage data
+    private let probe: any UsageProbe
+    private let settingsRepository: any DeepSeekSettingsRepository
+
+    // MARK: - Initialization
+
+    /// Creates a DeepSeek provider with the specified probe
+    /// - Parameter probe: The probe to use for fetching usage data
+    /// - Parameter settingsRepository: The repository for persisting settings
+    public init(probe: any UsageProbe, settingsRepository: any DeepSeekSettingsRepository) {
+        self.probe = probe
+        self.settingsRepository = settingsRepository
+        // Default to disabled - requires API key configuration
+        self.isEnabled = settingsRepository.isEnabled(forProvider: "deepseek", defaultValue: false)
+    }
+
+    // MARK: - AIProvider Protocol
+
+    public func isAvailable() async -> Bool {
+        await probe.isAvailable()
+    }
+
+    /// Refreshes the usage data and updates the snapshot.
+    /// Sets isSyncing during refresh and captures any errors.
+    @discardableResult
+    public func refresh() async throws -> UsageSnapshot {
+        isSyncing = true
+        defer { isSyncing = false }
+
+        do {
+            let newSnapshot = try await probe.probe()
+            snapshot = newSnapshot
+            lastError = nil
+            return newSnapshot
+        } catch {
+            lastError = error
+            throw error
+        }
+    }
+}

--- a/Sources/Domain/Provider/ProviderSettingsRepository.swift
+++ b/Sources/Domain/Provider/ProviderSettingsRepository.swift
@@ -234,6 +234,28 @@ public protocol MiniMaxSettingsRepository: ProviderSettingsRepository {
     func hasMinimaxApiKey() -> Bool
 }
 
+/// DeepSeek-specific settings repository, extending base ProviderSettingsRepository.
+/// Stores the API key and env-var name for DeepSeek balance monitoring.
+public protocol DeepSeekSettingsRepository: ProviderSettingsRepository {
+    /// Gets the environment variable name for DeepSeek API key (empty = use default DEEPSEEK_API_KEY)
+    func deepseekAuthEnvVar() -> String
+
+    /// Sets the environment variable name for DeepSeek API key
+    func setDeepSeekAuthEnvVar(_ envVar: String)
+
+    /// Saves the DeepSeek API key (for Settings UI input)
+    func saveDeepSeekApiKey(_ key: String)
+
+    /// Retrieves the DeepSeek API key
+    func getDeepSeekApiKey() -> String?
+
+    /// Deletes the DeepSeek API key
+    func deleteDeepSeekApiKey()
+
+    /// Checks if a DeepSeek API key is saved
+    func hasDeepSeekApiKey() -> Bool
+}
+
 /// Alibaba Coding Plan-specific settings repository, extending base ProviderSettingsRepository.
 /// Stores region, cookie source, manual cookie, and API key for Alibaba Coding Plan quota monitoring.
 public protocol AlibabaSettingsRepository: ProviderSettingsRepository {

--- a/Sources/Domain/Provider/UsageQuota.swift
+++ b/Sources/Domain/Provider/UsageQuota.swift
@@ -54,6 +54,11 @@ public struct UsageQuota: Sendable, Equatable, Hashable, Comparable {
     /// so persisted quota keys are unaffected.
     public let menuBarTitle: String?
 
+    /// ISO 4217 currency code for dollar-based quotas (e.g. "USD", "CNY").
+    /// nil means USD (the default). Used by `formattedDollarRemaining` to pick
+    /// the display symbol; ignored for percentage-based quotas.
+    public let currency: String?
+
     // MARK: - Initialization
 
     public init(
@@ -68,7 +73,8 @@ public struct UsageQuota: Sendable, Equatable, Hashable, Comparable {
         dollarCap: Decimal? = nil,
         group: String? = nil,
         compactTitle: String? = nil,
-        menuBarTitle: String? = nil
+        menuBarTitle: String? = nil,
+        currency: String? = nil
     ) {
         self.percentRemaining = min(100, percentRemaining)  // Allow negative, cap at 100
         self.quotaType = quotaType
@@ -82,6 +88,7 @@ public struct UsageQuota: Sendable, Equatable, Hashable, Comparable {
         self.group = group
         self.compactTitle = compactTitle
         self.menuBarTitle = menuBarTitle
+        self.currency = currency
     }
 
     // MARK: - Domain Behavior
@@ -107,11 +114,13 @@ public struct UsageQuota: Sendable, Equatable, Hashable, Comparable {
         dollarRemaining != nil
     }
 
-    /// Formatted dollar remaining string (e.g., "$50.00"), nil for percentage-based quotas
+    /// Formatted balance remaining string (e.g., "$50.00", "¥110.00"), nil for percentage-based quotas.
+    /// The symbol follows `currency` (default "$" when nil or USD).
     public var formattedDollarRemaining: String? {
         guard let dollarRemaining else { return nil }
         let amount = NSDecimalNumber(decimal: dollarRemaining).doubleValue
-        return String(format: "$%.2f", amount)
+        let symbol = currency.map(Self.currencySymbol(for:)) ?? "$"
+        return String(format: "%@%.2f", symbol, amount)
     }
 
     /// Formatted spend amount for capped monetary quotas (e.g. "$1,234.56").
@@ -136,6 +145,22 @@ public struct UsageQuota: Sendable, Equatable, Hashable, Comparable {
         formatter.maximumFractionDigits = 2
         let value = formatter.string(from: amount as NSDecimalNumber) ?? "\(amount)"
         return "$\(value)"
+    }
+
+    /// Maps an ISO 4217 currency code to its display symbol (e.g., "USD" → "$", "CNY" → "¥").
+    /// Unknown codes fall back to the uppercased code with a trailing space.
+    public static func currencySymbol(for code: String) -> String {
+        switch code.uppercased() {
+        case "USD", "US", "US$": return "$"
+        case "CNY", "CNH", "RMB", "CN", "¥": return "¥"
+        case "EUR": return "€"
+        case "GBP": return "£"
+        case "JPY": return "¥"
+        case "HKD": return "HK$"
+        case "KRW": return "₩"
+        case "SGD": return "S$"
+        default: return code.uppercased() + " "
+        }
     }
 
     /// Whether this quota needs attention (warning, critical, or depleted)

--- a/Sources/Infrastructure/DeepSeek/DeepSeekUsageProbe.swift
+++ b/Sources/Infrastructure/DeepSeek/DeepSeekUsageProbe.swift
@@ -9,6 +9,9 @@ public struct DeepSeekUsageProbe: UsageProbe {
     private let networkClient: any NetworkClient
     private let settingsRepository: any DeepSeekSettingsRepository
     private let timeout: TimeInterval
+    /// Reads an environment variable by name. Injected so tests are
+    /// deterministic regardless of the host environment.
+    private let environmentValue: @Sendable (String) -> String?
 
     /// The DeepSeek balance endpoint
     static let balanceURL = URL(string: "https://api.deepseek.com/user/balance")!
@@ -16,11 +19,13 @@ public struct DeepSeekUsageProbe: UsageProbe {
     public init(
         networkClient: any NetworkClient = URLSession.shared,
         settingsRepository: any DeepSeekSettingsRepository,
-        timeout: TimeInterval = 30
+        timeout: TimeInterval = 30,
+        environmentValue: @escaping @Sendable (String) -> String? = { ProcessInfo.processInfo.environment[$0] }
     ) {
         self.networkClient = networkClient
         self.settingsRepository = settingsRepository
         self.timeout = timeout
+        self.environmentValue = environmentValue
     }
 
     // MARK: - Token Resolution
@@ -29,7 +34,7 @@ public struct DeepSeekUsageProbe: UsageProbe {
         // First, check environment variable if configured
         let envVarName = settingsRepository.deepseekAuthEnvVar()
         let effectiveEnvVar = envVarName.isEmpty ? "DEEPSEEK_API_KEY" : envVarName
-        if let envValue = ProcessInfo.processInfo.environment[effectiveEnvVar], !envValue.isEmpty {
+        if let envValue = environmentValue(effectiveEnvVar), !envValue.isEmpty {
             AppLog.probes.debug("DeepSeek: Using API key from env var '\(effectiveEnvVar)'")
             return envValue
         }
@@ -135,8 +140,12 @@ public struct DeepSeekUsageProbe: UsageProbe {
         let granted = selected.grantedBalance.flatMap { Decimal(string: $0, locale: posixLocale) }
         let toppedUp = selected.toppedUpBalance.flatMap { Decimal(string: $0, locale: posixLocale) }
 
+        // Balance has no cap → percent is 100 when available. When DeepSeek
+        // reports is_available == false, the balance can't be used for API
+        // calls, so surface the quota as depleted.
+        let percentRemaining: Double = response.isAvailable == false ? 0 : 100
         let quota = UsageQuota(
-            percentRemaining: 100, // no cap → percent is always 100
+            percentRemaining: percentRemaining,
             quotaType: .modelSpecific("Balance"),
             providerId: providerId,
             resetText: breakdownText(granted: granted, toppedUp: toppedUp, currency: selected.currency),

--- a/Sources/Infrastructure/DeepSeek/DeepSeekUsageProbe.swift
+++ b/Sources/Infrastructure/DeepSeek/DeepSeekUsageProbe.swift
@@ -1,0 +1,190 @@
+import Foundation
+import Domain
+
+/// Probes the DeepSeek API for balance information.
+/// DeepSeek is pay-per-use and exposes no percentage/window quota — only a
+/// monetary balance via `GET https://api.deepseek.com/user/balance`.
+/// Authentication: Bearer token from env var or stored API key.
+public struct DeepSeekUsageProbe: UsageProbe {
+    private let networkClient: any NetworkClient
+    private let settingsRepository: any DeepSeekSettingsRepository
+    private let timeout: TimeInterval
+
+    /// The DeepSeek balance endpoint
+    static let balanceURL = URL(string: "https://api.deepseek.com/user/balance")!
+
+    public init(
+        networkClient: any NetworkClient = URLSession.shared,
+        settingsRepository: any DeepSeekSettingsRepository,
+        timeout: TimeInterval = 30
+    ) {
+        self.networkClient = networkClient
+        self.settingsRepository = settingsRepository
+        self.timeout = timeout
+    }
+
+    // MARK: - Token Resolution
+
+    func getApiKey() -> String? {
+        // First, check environment variable if configured
+        let envVarName = settingsRepository.deepseekAuthEnvVar()
+        let effectiveEnvVar = envVarName.isEmpty ? "DEEPSEEK_API_KEY" : envVarName
+        if let envValue = ProcessInfo.processInfo.environment[effectiveEnvVar], !envValue.isEmpty {
+            AppLog.probes.debug("DeepSeek: Using API key from env var '\(effectiveEnvVar)'")
+            return envValue
+        }
+
+        // Fall back to stored API key
+        if let storedKey = settingsRepository.getDeepSeekApiKey(), !storedKey.isEmpty {
+            AppLog.probes.debug("DeepSeek: Using stored API key")
+            return storedKey
+        }
+
+        return nil
+    }
+
+    // MARK: - UsageProbe
+
+    public func isAvailable() async -> Bool {
+        let hasKey = getApiKey() != nil
+        if !hasKey {
+            AppLog.probes.debug("DeepSeek: Not available - no API key configured")
+        }
+        return hasKey
+    }
+
+    public func probe() async throws -> UsageSnapshot {
+        guard let apiKey = getApiKey(), !apiKey.isEmpty else {
+            AppLog.probes.error("DeepSeek: No API key configured (check env var or settings)")
+            throw ProbeError.authenticationRequired
+        }
+
+        AppLog.probes.info("Starting DeepSeek probe...")
+
+        var request = URLRequest(url: Self.balanceURL)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = timeout
+
+        let (data, response) = try await networkClient.request(request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ProbeError.executionFailed("Invalid response")
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            AppLog.probes.error("DeepSeek API returned HTTP \(httpResponse.statusCode)")
+            if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
+                throw ProbeError.authenticationRequired
+            }
+            throw ProbeError.executionFailed("DeepSeek API returned HTTP \(httpResponse.statusCode)")
+        }
+
+        // Log raw response at debug level
+        if let responseText = String(data: data, encoding: .utf8) {
+            AppLog.probes.debug("DeepSeek API response: \(responseText.prefix(500))")
+        }
+
+        let snapshot = try Self.parseResponse(data, providerId: "deepseek")
+
+        AppLog.probes.info("DeepSeek probe success: \(snapshot.quotas.count) quotas found")
+        for quota in snapshot.quotas {
+            AppLog.probes.info("  - \(quota.quotaType.displayName): \(quota.formattedDollarRemaining ?? "n/a") remaining")
+        }
+
+        return snapshot
+    }
+
+    // MARK: - Response Parsing (Static for testability)
+
+    /// Parses the DeepSeek user balance response into a UsageSnapshot.
+    /// DeepSeek reports a monetary balance with no percentage cap, so the quota
+    /// uses `dollarRemaining` with `percentRemaining` pinned to 100 (AmpCode pattern).
+    static func parseResponse(_ data: Data, providerId: String) throws -> UsageSnapshot {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+        let response: DeepSeekBalanceResponse
+        do {
+            response = try decoder.decode(DeepSeekBalanceResponse.self, from: data)
+        } catch {
+            AppLog.probes.error("DeepSeek parse failed: Invalid JSON - \(error.localizedDescription)")
+            if let rawString = String(data: data, encoding: .utf8) {
+                AppLog.probes.debug("DeepSeek raw response: \(rawString.prefix(500))")
+            }
+            throw ProbeError.parseFailed("Invalid JSON: \(error.localizedDescription)")
+        }
+
+        let balanceInfos = response.balanceInfos ?? []
+
+        guard !balanceInfos.isEmpty else {
+            AppLog.probes.error("DeepSeek: Empty balance_infos in response")
+            throw ProbeError.noData
+        }
+
+        // Use the account's primary balance entry. DeepSeek returns the billing
+        // currency first (e.g. CNY for Chinese accounts); preferring USD would
+        // mislabel those balances as USD.
+        let selected = balanceInfos[0]
+
+        let posixLocale = Locale(identifier: "en_US_POSIX")
+        guard let total = Decimal(string: selected.totalBalance, locale: posixLocale) else {
+            throw ProbeError.parseFailed("Invalid total_balance: \(selected.totalBalance)")
+        }
+        let granted = selected.grantedBalance.flatMap { Decimal(string: $0, locale: posixLocale) }
+        let toppedUp = selected.toppedUpBalance.flatMap { Decimal(string: $0, locale: posixLocale) }
+
+        let quota = UsageQuota(
+            percentRemaining: 100, // no cap → percent is always 100
+            quotaType: .modelSpecific("Balance"),
+            providerId: providerId,
+            resetText: breakdownText(granted: granted, toppedUp: toppedUp, currency: selected.currency),
+            dollarRemaining: total,
+            currency: selected.currency
+        )
+
+        return UsageSnapshot(
+            providerId: providerId,
+            quotas: [quota],
+            capturedAt: Date()
+        )
+    }
+
+    // MARK: - Formatting
+
+    /// Builds the "Paid: $30.00 · Granted: $10.00" breakdown subtitle,
+    /// using the balance's currency symbol (e.g. ¥ for CNY).
+    static func breakdownText(granted: Decimal?, toppedUp: Decimal?, currency: String) -> String? {
+        var parts: [String] = []
+        if let toppedUp {
+            parts.append("Paid: \(formatAmount(toppedUp, currency: currency))")
+        }
+        if let granted {
+            parts.append("Granted: \(formatAmount(granted, currency: currency))")
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    static func formatAmount(_ amount: Decimal, currency: String) -> String {
+        String(
+            format: "%@%.2f",
+            UsageQuota.currencySymbol(for: currency),
+            NSDecimalNumber(decimal: amount).doubleValue
+        )
+    }
+}
+
+// MARK: - Response Models (Internal)
+
+struct DeepSeekBalanceResponse: Decodable {
+    let isAvailable: Bool?
+    let balanceInfos: [DeepSeekBalanceInfo]?
+}
+
+struct DeepSeekBalanceInfo: Decodable {
+    let currency: String
+    let totalBalance: String
+    let grantedBalance: String?
+    let toppedUpBalance: String?
+}

--- a/Sources/Infrastructure/Storage/JSONSettingsRepository.swift
+++ b/Sources/Infrastructure/Storage/JSONSettingsRepository.swift
@@ -519,3 +519,33 @@ public final class JSONSettingsRepository:
         getMinimaxApiKey() != nil
     }
 }
+
+// MARK: - DeepSeekSettingsRepository
+
+extension JSONSettingsRepository: DeepSeekSettingsRepository {
+    public func deepseekAuthEnvVar() -> String {
+        store.read(key: "deepseek.authEnvVar") ?? ""
+    }
+
+    public func setDeepSeekAuthEnvVar(_ envVar: String) {
+        store.write(value: envVar, key: "deepseek.authEnvVar")
+    }
+
+    // DeepSeek Credentials (UserDefaults for now)
+
+    public func saveDeepSeekApiKey(_ key: String) {
+        credentials.set(key, forKey: "com.claudebar.credentials.deepseek-api-key")
+    }
+
+    public func getDeepSeekApiKey() -> String? {
+        credentials.string(forKey: "com.claudebar.credentials.deepseek-api-key")
+    }
+
+    public func deleteDeepSeekApiKey() {
+        credentials.removeObject(forKey: "com.claudebar.credentials.deepseek-api-key")
+    }
+
+    public func hasDeepSeekApiKey() -> Bool {
+        getDeepSeekApiKey() != nil
+    }
+}

--- a/Sources/Infrastructure/Storage/UserDefaultsProviderSettingsRepository.swift
+++ b/Sources/Infrastructure/Storage/UserDefaultsProviderSettingsRepository.swift
@@ -3,7 +3,7 @@ import Domain
 
 /// UserDefaults-based implementation of ProviderSettingsRepository and its sub-protocols.
 /// Persists provider settings like isEnabled state and provider-specific configuration.
-public final class UserDefaultsProviderSettingsRepository: ZaiSettingsRepository, CopilotSettingsRepository, BedrockSettingsRepository, ClaudeSettingsRepository, CodexSettingsRepository, KimiSettingsRepository, MiniMaxSettingsRepository, AlibabaSettingsRepository, HookSettingsRepository, @unchecked Sendable {
+public final class UserDefaultsProviderSettingsRepository: ZaiSettingsRepository, CopilotSettingsRepository, BedrockSettingsRepository, ClaudeSettingsRepository, CodexSettingsRepository, KimiSettingsRepository, MiniMaxSettingsRepository, DeepSeekSettingsRepository, AlibabaSettingsRepository, HookSettingsRepository, @unchecked Sendable {
     /// Shared singleton instance
     public static let shared = UserDefaultsProviderSettingsRepository()
 
@@ -308,6 +308,32 @@ public final class UserDefaultsProviderSettingsRepository: ZaiSettingsRepository
         userDefaults.object(forKey: Keys.minimaxiApiKey) != nil
     }
 
+    // MARK: - DeepSeekSettingsRepository
+
+    public func deepseekAuthEnvVar() -> String {
+        userDefaults.string(forKey: Keys.deepseekAuthEnvVar) ?? ""
+    }
+
+    public func setDeepSeekAuthEnvVar(_ envVar: String) {
+        userDefaults.set(envVar, forKey: Keys.deepseekAuthEnvVar)
+    }
+
+    public func saveDeepSeekApiKey(_ key: String) {
+        userDefaults.set(key, forKey: Keys.deepseekApiKey)
+    }
+
+    public func getDeepSeekApiKey() -> String? {
+        userDefaults.string(forKey: Keys.deepseekApiKey)
+    }
+
+    public func deleteDeepSeekApiKey() {
+        userDefaults.removeObject(forKey: Keys.deepseekApiKey)
+    }
+
+    public func hasDeepSeekApiKey() -> Bool {
+        userDefaults.object(forKey: Keys.deepseekApiKey) != nil
+    }
+
     // MARK: - AlibabaSettingsRepository
 
     public func alibabaRegion() -> AlibabaRegion {
@@ -410,6 +436,9 @@ public final class UserDefaultsProviderSettingsRepository: ZaiSettingsRepository
         static let minimaxRegion = "providerConfig.minimaxRegion"
         static let minimaxiAuthEnvVar = "providerConfig.minimaxiAuthEnvVar"
         static let minimaxiApiKey = "com.claudebar.credentials.minimaxi-api-key"
+        // DeepSeek settings
+        static let deepseekAuthEnvVar = "providerConfig.deepseekAuthEnvVar"
+        static let deepseekApiKey = "com.claudebar.credentials.deepseek-api-key"
         // Alibaba settings
         static let alibabaRegion = "providerConfig.alibabaRegion"
         static let alibabaCookieSource = "providerConfig.alibabaCookieSource"

--- a/Tests/DomainTests/Provider/UsageQuotaTests.swift
+++ b/Tests/DomainTests/Provider/UsageQuotaTests.swift
@@ -382,6 +382,36 @@ struct UsageQuotaTests {
     }
 
     @Test
+    func `formattedDollarRemaining uses CNY symbol when currency is CNY`() {
+        // Given
+        let quota = UsageQuota(percentRemaining: 100, quotaType: .modelSpecific("Balance"), providerId: "deepseek", dollarRemaining: Decimal(110), currency: "CNY")
+
+        // When & Then
+        #expect(quota.formattedDollarRemaining == "¥110.00")
+    }
+
+    @Test
+    func `formattedDollarRemaining defaults to dollar symbol when currency is nil or USD`() {
+        // Given
+        let nilCurrency = UsageQuota(percentRemaining: 100, quotaType: .modelSpecific("Balance"), providerId: "deepseek", dollarRemaining: Decimal(40))
+        let usdCurrency = UsageQuota(percentRemaining: 100, quotaType: .modelSpecific("Balance"), providerId: "deepseek", dollarRemaining: Decimal(40), currency: "USD")
+
+        // When & Then
+        #expect(nilCurrency.formattedDollarRemaining == "$40.00")
+        #expect(usdCurrency.formattedDollarRemaining == "$40.00")
+    }
+
+    @Test
+    func `currencySymbol maps common codes and falls back to code`() {
+        // When & Then
+        #expect(UsageQuota.currencySymbol(for: "USD") == "$")
+        #expect(UsageQuota.currencySymbol(for: "CNY") == "¥")
+        #expect(UsageQuota.currencySymbol(for: "cny") == "¥") // case-insensitive
+        #expect(UsageQuota.currencySymbol(for: "EUR") == "€")
+        #expect(UsageQuota.currencySymbol(for: "XYZ") == "XYZ ")
+    }
+
+    @Test
     func `quota stores capped dollar spend amounts`() {
         let quota = UsageQuota(
             percentRemaining: 75,

--- a/Tests/InfrastructureTests/DeepSeek/DeepSeekUsageProbeParsingTests.swift
+++ b/Tests/InfrastructureTests/DeepSeek/DeepSeekUsageProbeParsingTests.swift
@@ -1,0 +1,198 @@
+import Testing
+import Foundation
+@testable import Infrastructure
+@testable import Domain
+
+@Suite
+struct DeepSeekUsageProbeParsingTests {
+
+    // MARK: - Sample Data
+
+    static let sampleSuccessResponse = """
+    {
+      "is_available": true,
+      "balance_infos": [
+        {
+          "currency": "USD",
+          "total_balance": "40.00",
+          "granted_balance": "10.00",
+          "topped_up_balance": "30.00"
+        }
+      ]
+    }
+    """
+
+    static let sampleCNYResponse = """
+    {
+      "is_available": true,
+      "balance_infos": [
+        {
+          "currency": "CNY",
+          "total_balance": "110.00",
+          "granted_balance": "10.00",
+          "topped_up_balance": "100.00"
+        }
+      ]
+    }
+    """
+
+    static let sampleMultiCurrencyResponse = """
+    {
+      "is_available": true,
+      "balance_infos": [
+        {
+          "currency": "CNY",
+          "total_balance": "110.00",
+          "granted_balance": "10.00",
+          "topped_up_balance": "100.00"
+        },
+        {
+          "currency": "USD",
+          "total_balance": "40.00",
+          "granted_balance": "10.00",
+          "topped_up_balance": "30.00"
+        }
+      ]
+    }
+    """
+
+    static let sampleMissingFieldsResponse = """
+    {
+      "is_available": true,
+      "balance_infos": [
+        {
+          "currency": "USD",
+          "total_balance": "40.00",
+          "topped_up_balance": "30.00"
+        }
+      ]
+    }
+    """
+
+    static let sampleEmptyBalanceInfosResponse = """
+    {
+      "is_available": true,
+      "balance_infos": []
+    }
+    """
+
+    // MARK: - Parsing Tests
+
+    @Test
+    func `parses balance_infos into a single balance quota`() throws {
+        // Given
+        let data = Data(Self.sampleSuccessResponse.utf8)
+
+        // When
+        let snapshot = try DeepSeekUsageProbe.parseResponse(data, providerId: "deepseek")
+
+        // Then
+        #expect(snapshot.quotas.count == 1)
+        #expect(snapshot.quotas[0].quotaType == .modelSpecific("Balance"))
+        #expect(snapshot.providerId == "deepseek")
+    }
+
+    @Test
+    func `maps total_balance string to dollarRemaining`() throws {
+        // Given
+        let data = Data(Self.sampleSuccessResponse.utf8)
+
+        // When
+        let snapshot = try DeepSeekUsageProbe.parseResponse(data, providerId: "deepseek")
+
+        // Then: balance is unbounded, so percent is always 100
+        #expect(snapshot.quotas[0].dollarRemaining == Decimal(40))
+        #expect(snapshot.quotas[0].percentRemaining == 100)
+        #expect(snapshot.quotas[0].isDollarBased)
+        // Currency is detected from the response, not hardcoded to USD
+        #expect(snapshot.quotas[0].currency == "USD")
+        #expect(snapshot.quotas[0].formattedDollarRemaining == "$40.00")
+    }
+
+    @Test
+    func `uses first entry as primary currency when multiple present`() throws {
+        // Given: CNY is the account's primary balance, listed first
+        let data = Data(Self.sampleMultiCurrencyResponse.utf8)
+
+        // When
+        let snapshot = try DeepSeekUsageProbe.parseResponse(data, providerId: "deepseek")
+
+        // Then: the primary (first) currency is used, not a later USD entry
+        #expect(snapshot.quotas[0].dollarRemaining == Decimal(110))
+        #expect(snapshot.quotas[0].currency == "CNY")
+        #expect(snapshot.quotas[0].formattedDollarRemaining == "¥110.00")
+    }
+
+    @Test
+    func `falls back to first entry when no USD present`() throws {
+        // Given
+        let data = Data(Self.sampleCNYResponse.utf8)
+
+        // When
+        let snapshot = try DeepSeekUsageProbe.parseResponse(data, providerId: "deepseek")
+
+        // Then: CNY balance is detected and displayed with the ¥ symbol
+        #expect(snapshot.quotas[0].dollarRemaining == Decimal(110))
+        #expect(snapshot.quotas[0].currency == "CNY")
+        #expect(snapshot.quotas[0].formattedDollarRemaining == "¥110.00")
+    }
+
+    @Test
+    func `builds breakdown resetText`() throws {
+        // Given
+        let data = Data(Self.sampleSuccessResponse.utf8)
+
+        // When
+        let snapshot = try DeepSeekUsageProbe.parseResponse(data, providerId: "deepseek")
+
+        // Then
+        #expect(snapshot.quotas[0].resetText == "Paid: $30.00 · Granted: $10.00")
+    }
+
+    @Test
+    func `builds CNY breakdown resetText`() throws {
+        // Given
+        let data = Data(Self.sampleCNYResponse.utf8)
+
+        // When
+        let snapshot = try DeepSeekUsageProbe.parseResponse(data, providerId: "deepseek")
+
+        // Then
+        #expect(snapshot.quotas[0].resetText == "Paid: ¥100.00 · Granted: ¥10.00")
+    }
+
+    @Test
+    func `handles missing optional balance fields`() throws {
+        // Given: granted_balance omitted
+        let data = Data(Self.sampleMissingFieldsResponse.utf8)
+
+        // When
+        let snapshot = try DeepSeekUsageProbe.parseResponse(data, providerId: "deepseek")
+
+        // Then: only the present part appears in the breakdown
+        #expect(snapshot.quotas.count == 1)
+        #expect(snapshot.quotas[0].resetText == "Paid: $30.00")
+    }
+
+    @Test
+    func `throws noData on empty balance_infos`() throws {
+        // Given
+        let data = Data(Self.sampleEmptyBalanceInfosResponse.utf8)
+
+        // When & Then
+        #expect(throws: ProbeError.noData) {
+            try DeepSeekUsageProbe.parseResponse(data, providerId: "deepseek")
+        }
+    }
+
+    @Test
+    func `throws parseFailed on invalid JSON`() throws {
+        // Given
+        let data = Data("not json".utf8)
+
+        // When & Then
+        #expect(throws: ProbeError.self) {
+            try DeepSeekUsageProbe.parseResponse(data, providerId: "deepseek")
+        }
+    }
+}

--- a/Tests/InfrastructureTests/DeepSeek/DeepSeekUsageProbeParsingTests.swift
+++ b/Tests/InfrastructureTests/DeepSeek/DeepSeekUsageProbeParsingTests.swift
@@ -76,6 +76,20 @@ struct DeepSeekUsageProbeParsingTests {
     }
     """
 
+    static let sampleUnavailableResponse = """
+    {
+      "is_available": false,
+      "balance_infos": [
+        {
+          "currency": "USD",
+          "total_balance": "5.00",
+          "granted_balance": "0.00",
+          "topped_up_balance": "5.00"
+        }
+      ]
+    }
+    """
+
     // MARK: - Parsing Tests
 
     @Test
@@ -175,6 +189,20 @@ struct DeepSeekUsageProbeParsingTests {
     }
 
     @Test
+    func `maps unavailable balance to depleted status`() throws {
+        // Given: is_available false means the balance can't be used for API calls
+        let data = Data(Self.sampleUnavailableResponse.utf8)
+
+        // When
+        let snapshot = try DeepSeekUsageProbe.parseResponse(data, providerId: "deepseek")
+
+        // Then: quota is depleted but the balance amount is still surfaced
+        #expect(snapshot.quotas[0].percentRemaining == 0)
+        #expect(snapshot.quotas[0].status == .depleted)
+        #expect(snapshot.quotas[0].dollarRemaining == Decimal(5))
+    }
+
+    @Test
     func `throws noData on empty balance_infos`() throws {
         // Given
         let data = Data(Self.sampleEmptyBalanceInfosResponse.utf8)
@@ -190,9 +218,15 @@ struct DeepSeekUsageProbeParsingTests {
         // Given
         let data = Data("not json".utf8)
 
-        // When & Then
-        #expect(throws: ProbeError.self) {
-            try DeepSeekUsageProbe.parseResponse(data, providerId: "deepseek")
+        // When & Then: must be parseFailed specifically, not any ProbeError
+        do {
+            _ = try DeepSeekUsageProbe.parseResponse(data, providerId: "deepseek")
+            Issue.record("Expected ProbeError.parseFailed")
+        } catch {
+            guard case ProbeError.parseFailed = error else {
+                Issue.record("Expected ProbeError.parseFailed, got \(error)")
+                return
+            }
         }
     }
 }

--- a/Tests/InfrastructureTests/DeepSeek/DeepSeekUsageProbeTests.swift
+++ b/Tests/InfrastructureTests/DeepSeek/DeepSeekUsageProbeTests.swift
@@ -1,0 +1,186 @@
+import Testing
+import Foundation
+import Mockable
+@testable import Infrastructure
+@testable import Domain
+
+@Suite
+struct DeepSeekUsageProbeTests {
+
+    // MARK: - Sample Data
+
+    static let sampleApiResponse = """
+    {
+      "is_available": true,
+      "balance_infos": [
+        {
+          "currency": "USD",
+          "total_balance": "40.00",
+          "granted_balance": "10.00",
+          "topped_up_balance": "30.00"
+        }
+      ]
+    }
+    """
+
+    // MARK: - Helper
+
+    /// Creates a probe with test UserDefaults and mock network client
+    private func makeProbe(
+        apiKey: String? = nil,
+        envVar: String = "",
+        networkClient: any NetworkClient = MockNetworkClient()
+    ) -> DeepSeekUsageProbe {
+        let defaults = UserDefaults(suiteName: "DeepSeekProbeTests.\(UUID().uuidString)")!
+        let settingsRepository = UserDefaultsProviderSettingsRepository(userDefaults: defaults)
+        settingsRepository.setDeepSeekAuthEnvVar(envVar)
+        if let apiKey {
+            settingsRepository.saveDeepSeekApiKey(apiKey)
+        }
+        return DeepSeekUsageProbe(
+            networkClient: networkClient,
+            settingsRepository: settingsRepository
+        )
+    }
+
+    private func makeHTTPResponse(statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://api.deepseek.com/user/balance")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+
+    // MARK: - isAvailable Tests
+
+    @Test
+    func `isAvailable returns false when no API key`() async {
+        // Given: no API key configured, no env var
+        let probe = makeProbe()
+
+        // When & Then
+        #expect(await probe.isAvailable() == false)
+    }
+
+    @Test
+    func `isAvailable returns true when API key exists`() async {
+        // Given
+        let probe = makeProbe(apiKey: "test-key-123")
+
+        // When & Then
+        #expect(await probe.isAvailable() == true)
+    }
+
+    // MARK: - probe Tests
+
+    @Test
+    func `probe returns UsageSnapshot on success`() async throws {
+        // Given
+        let mockNetwork = MockNetworkClient()
+        let responseData = Data(Self.sampleApiResponse.utf8)
+        let httpResponse = makeHTTPResponse(statusCode: 200)
+        given(mockNetwork)
+            .request(.any)
+            .willReturn((responseData, httpResponse))
+
+        let probe = makeProbe(apiKey: "test-key", networkClient: mockNetwork)
+
+        // When
+        let snapshot = try await probe.probe()
+
+        // Then
+        #expect(snapshot.quotas.count == 1)
+        #expect(snapshot.quotas[0].quotaType == .modelSpecific("Balance"))
+        #expect(snapshot.quotas[0].dollarRemaining == Decimal(40))
+        #expect(snapshot.providerId == "deepseek")
+    }
+
+    @Test
+    func `probe sends Bearer and Accept headers to the balance endpoint`() async throws {
+        // Given
+        let mockNetwork = MockNetworkClient()
+        let responseData = Data(Self.sampleApiResponse.utf8)
+        let httpResponse = makeHTTPResponse(statusCode: 200)
+        var capturedRequest: URLRequest?
+        given(mockNetwork)
+            .request(.any)
+            .willProduce { request in
+                capturedRequest = request
+                return (responseData, httpResponse)
+            }
+
+        let probe = makeProbe(apiKey: "test-key", networkClient: mockNetwork)
+
+        // When
+        _ = try await probe.probe()
+
+        // Then
+        #expect(capturedRequest?.httpMethod == "GET")
+        #expect(capturedRequest?.url?.absoluteString == "https://api.deepseek.com/user/balance")
+        #expect(capturedRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer test-key")
+        #expect(capturedRequest?.value(forHTTPHeaderField: "Accept") == "application/json")
+    }
+
+    @Test
+    func `probe throws authenticationRequired when no API key`() async {
+        // Given
+        let probe = makeProbe()
+
+        // When & Then
+        await #expect(throws: ProbeError.authenticationRequired) {
+            try await probe.probe()
+        }
+    }
+
+    @Test
+    func `probe throws authenticationRequired on HTTP 401`() async {
+        // Given
+        let mockNetwork = MockNetworkClient()
+        let httpResponse = makeHTTPResponse(statusCode: 401)
+        given(mockNetwork)
+            .request(.any)
+            .willReturn((Data(), httpResponse))
+
+        let probe = makeProbe(apiKey: "bad-key", networkClient: mockNetwork)
+
+        // When & Then
+        await #expect(throws: ProbeError.authenticationRequired) {
+            try await probe.probe()
+        }
+    }
+
+    @Test
+    func `probe throws authenticationRequired on HTTP 403`() async {
+        // Given
+        let mockNetwork = MockNetworkClient()
+        let httpResponse = makeHTTPResponse(statusCode: 403)
+        given(mockNetwork)
+            .request(.any)
+            .willReturn((Data(), httpResponse))
+
+        let probe = makeProbe(apiKey: "bad-key", networkClient: mockNetwork)
+
+        // When & Then
+        await #expect(throws: ProbeError.authenticationRequired) {
+            try await probe.probe()
+        }
+    }
+
+    @Test
+    func `probe throws executionFailed on HTTP 500`() async {
+        // Given
+        let mockNetwork = MockNetworkClient()
+        let httpResponse = makeHTTPResponse(statusCode: 500)
+        given(mockNetwork)
+            .request(.any)
+            .willReturn((Data(), httpResponse))
+
+        let probe = makeProbe(apiKey: "test-key", networkClient: mockNetwork)
+
+        // When & Then
+        await #expect(throws: ProbeError.self) {
+            try await probe.probe()
+        }
+    }
+}

--- a/Tests/InfrastructureTests/DeepSeek/DeepSeekUsageProbeTests.swift
+++ b/Tests/InfrastructureTests/DeepSeek/DeepSeekUsageProbeTests.swift
@@ -39,7 +39,9 @@ struct DeepSeekUsageProbeTests {
         }
         return DeepSeekUsageProbe(
             networkClient: networkClient,
-            settingsRepository: settingsRepository
+            settingsRepository: settingsRepository,
+            // Deterministic: no env var in tests, regardless of the host environment
+            environmentValue: { _ in nil }
         )
     }
 
@@ -178,9 +180,15 @@ struct DeepSeekUsageProbeTests {
 
         let probe = makeProbe(apiKey: "test-key", networkClient: mockNetwork)
 
-        // When & Then
-        await #expect(throws: ProbeError.self) {
-            try await probe.probe()
+        // When & Then: must be executionFailed specifically, not any ProbeError
+        do {
+            _ = try await probe.probe()
+            Issue.record("Expected ProbeError.executionFailed")
+        } catch {
+            guard case ProbeError.executionFailed = error else {
+                Issue.record("Expected ProbeError.executionFailed, got \(error)")
+                return
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds **DeepSeek** balance monitoring to ClaudeBar. DeepSeek is pay-per-use and exposes no percentage/window quota — only monetary balance — so the provider fetches `GET https://api.deepseek.com/user/balance` and displays it as a balance card (AmpCode's `dollarRemaining` pattern).

## What's included

- **`DeepSeekUsageProbe`** — API-based probe (Bearer API key, `DEEPSEEK_API_KEY` env-var fallback), parses `balance_infos`, uses the account's primary (first) currency entry
- **`DeepSeekProvider`** — `@MainActor @Observable` provider, **disabled by default** (requires API key, like MiniMax)
- **`DeepSeekSettingsRepository`** — ISP sub-protocol with API-key CRUD in both repositories (credential key identical in both, avoiding MiniMax's key mismatch)
- **Currency-aware display** — `UsageQuota` gained a `currency` field; `formattedDollarRemaining` renders `¥` for CNY, `$` for USD
- **Settings UI** — `DeepSeekConfigCard` (API key SecureField, env-var field, Save & Test Connection, remove-key)
- **Visual identity** — DeepSeek-blue theme, `d.square.fill` symbol, all `ProviderVisualIdentityLookup` tables + legacy `Theme.swift`
- **16 tests** — parsing (USD/CNY/multi-currency, breakdown, error paths) + probe behavior (mock `NetworkClient`)

## Verification

- Full suite: **168 suites, 1,683 tests, 0 failures**
- App builds cleanly in Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DeepSeek as a supported AI provider with usage and balance monitoring.
  * Added settings for API keys, environment variables, credential removal, and connection testing.
  * Added DeepSeek branding, icons, colors, gradients, links, and configuration guidance.
  * Added currency-aware balance display, including support for CNY and other common currencies.

* **Bug Fixes**
  * Improved error handling and status feedback during provider connection and balance refreshes.

* **Tests**
  * Added coverage for credentials, API responses, currencies, quota formatting, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->