### PR TITLE
fix(claude): restrict Share button to Max accounts only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The "Share Claude Code" button no longer appears on Claude Pro, API, or
+  not-yet-identified accounts. Anthropic issues invitation links to Max
+  subscribers only, so on other plans the button could do nothing but fail
+  silently. When a Max account's link fetch does fail, the popover now
+  explains why instead of ignoring the click, and the failure no longer marks
+  Claude's usage data as unavailable. (#243)
+
 ---
 
 ## [0.4.76] - 2026-08-09

--- a/Sources/App/Views/MenuContentView.swift
+++ b/Sources/App/Views/MenuContentView.swift
@@ -113,6 +113,16 @@ struct MenuContentView: View {
                     }
                 }
             }
+
+            // Share Pass Error Overlay
+            if let claudeProvider = selectedProvider as? ClaudeProvider,
+               let passError = claudeProvider.passError {
+                SharePassErrorOverlay(message: passError.localizedDescription) {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        claudeProvider.clearPassError()
+                    }
+                }
+            }
         }
         .frame(width: 400)
         .fixedSize(horizontal: false, vertical: true)
@@ -853,7 +863,8 @@ struct MenuContentView: View {
                 showSharePass = true
             }
         } catch {
-            // Provider stores error in lastError
+            // Provider stores the error in passError, which the popover surfaces
+            // as SharePassErrorOverlay — a failed click is never silent.
         }
     }
 }

--- a/Sources/App/Views/SharePassView.swift
+++ b/Sources/App/Views/SharePassView.swift
@@ -155,6 +155,78 @@ struct SharePassOverlay: View {
     }
 }
 
+// MARK: - Error Overlay
+
+/// Shown when fetching the invitation link fails, so a tapped Share button
+/// never does nothing at all (issue #243).
+struct SharePassErrorOverlay: View {
+    let message: String
+    let onDismiss: () -> Void
+
+    @Environment(\.appTheme) private var theme
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.4)
+                .ignoresSafeArea()
+                .onTapGesture {
+                    onDismiss()
+                }
+
+            VStack(spacing: 12) {
+                HStack {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(theme.statusCritical)
+
+                    Text("Couldn't Get Invitation Link")
+                        .font(.system(size: 14, weight: .bold, design: theme.fontDesign))
+                        .foregroundStyle(theme.textPrimary)
+
+                    Spacer()
+
+                    Button {
+                        onDismiss()
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 18))
+                            .foregroundStyle(theme.textTertiary)
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                Text(message)
+                    .font(.system(size: 11, weight: .medium, design: theme.fontDesign))
+                    .foregroundStyle(theme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Text("Invitation links are only available on Claude Max plans.")
+                    .font(.system(size: 10, weight: .semibold, design: theme.fontDesign))
+                    .foregroundStyle(theme.textTertiary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(16)
+            .background(
+                RoundedRectangle(cornerRadius: 14)
+                    .fill(theme.glassBackground)
+                    .background(
+                        RoundedRectangle(cornerRadius: 14)
+                            .fill(colorScheme == .dark ? Color(white: 0.15) : Color(white: 0.95))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 14)
+                            .stroke(theme.glassBorder, lineWidth: 1)
+                    )
+                    .shadow(color: Color.black.opacity(0.4), radius: 20, y: 10)
+            )
+            .padding(.horizontal, 24)
+        }
+        .transition(.opacity)
+    }
+}
+
 // MARK: - Preview
 
 #Preview("SharePassOverlay") {

--- a/Sources/Domain/Provider/AccountTier.swift
+++ b/Sources/Domain/Provider/AccountTier.swift
@@ -33,6 +33,18 @@ public enum AccountTier: Sendable, Equatable, Hashable {
         case .custom(let badge): return badge
         }
     }
+
+    // MARK: - Entitlements
+
+    /// Whether the tier can issue Claude Code guest passes (invitation links).
+    /// Anthropic only hands these out to Max subscribers, so surfacing the
+    /// feature anywhere else offers an action that can only fail (issue #243).
+    public var supportsGuestPasses: Bool {
+        switch self {
+        case .claudeMax: return true
+        case .claudePro, .claudeApi, .custom: return false
+        }
+    }
 }
 
 // MARK: - Legacy Type Alias

--- a/Sources/Domain/Provider/Claude/ClaudeProvider.swift
+++ b/Sources/Domain/Provider/Claude/ClaudeProvider.swift
@@ -45,6 +45,11 @@ public final class ClaudeProvider: AIProvider {
     /// Whether the provider is currently fetching passes
     public private(set) var isFetchingPasses: Bool = false
 
+    /// The last error from a guest pass fetch (nil when the last fetch succeeded).
+    /// Kept separate from `lastError` so a failed invitation-link fetch never
+    /// makes the provider's usage data look unavailable.
+    public private(set) var passError: Error?
+
     // MARK: - Probe Mode
 
     /// The current probe mode (CLI or API)
@@ -307,17 +312,25 @@ public final class ClaudeProvider: AIProvider {
         do {
             let pass = try await passProbe.probe()
             guestPass = pass
-            lastError = nil
+            passError = nil
             return pass
         } catch {
-            lastError = error
+            passError = error
             throw error
         }
     }
 
-    /// Whether guest passes feature is available
+    /// Dismisses the last guest pass error.
+    public func clearPassError() {
+        passError = nil
+    }
+
+    /// Whether the guest passes feature is available.
+    /// Requires both a configured probe and a Max account — Anthropic issues
+    /// invitation links to Max subscribers only, and an unknown tier is not
+    /// evidence of one (issue #243).
     public var supportsGuestPasses: Bool {
-        passProbe != nil
+        passProbe != nil && snapshot?.accountTier?.supportsGuestPasses == true
     }
 
     /// Whether API mode is available (API probe was provided)

--- a/Tests/AcceptanceTests/ActionBarSpec.swift
+++ b/Tests/AcceptanceTests/ActionBarSpec.swift
@@ -80,16 +80,75 @@ struct ActionBarSpec {
     @MainActor
     struct GuestPasses {
 
-        @Test
-        func `Claude supports guest passes when pass probe is provided`() {
+        private static func makeSettings() -> MockProviderSettingsRepository {
             let settings = MockProviderSettingsRepository()
             given(settings).isEnabled(forProvider: .any, defaultValue: .any).willReturn(true)
             given(settings).isEnabled(forProvider: .any).willReturn(true)
             given(settings).setEnabled(.any, forProvider: .any).willReturn()
+            return settings
+        }
 
+        private static func makeUsageProbe(tier: AccountTier?) -> MockUsageProbe {
+            let probe = MockUsageProbe()
+            given(probe).probe().willReturn(
+                UsageSnapshot(providerId: "claude", quotas: [], capturedAt: Date(), accountTier: tier)
+            )
+            given(probe).isAvailable().willReturn(true)
+            return probe
+        }
+
+        @Test
+        func `Claude supports guest passes when pass probe is provided`() {
             // Without pass probe
-            let withoutPass = ClaudeProvider(probe: MockUsageProbe(), settingsRepository: settings)
+            let withoutPass = ClaudeProvider(probe: MockUsageProbe(), settingsRepository: Self.makeSettings())
             #expect(withoutPass.supportsGuestPasses == false)
+        }
+
+        @Test
+        func `Max account sees the Share button`() async throws {
+            let claude = ClaudeProvider(
+                probe: Self.makeUsageProbe(tier: .claudeMax),
+                passProbe: MockClaudePassProbing(),
+                settingsRepository: Self.makeSettings()
+            )
+
+            try await claude.refresh()
+
+            #expect(claude.supportsGuestPasses == true)
+        }
+
+        @Test
+        func `Pro account does not see the Share button`() async throws {
+            // Issue #243: Anthropic issues invitation links to Max plans only.
+            let claude = ClaudeProvider(
+                probe: Self.makeUsageProbe(tier: .claudePro),
+                passProbe: MockClaudePassProbing(),
+                settingsRepository: Self.makeSettings()
+            )
+
+            try await claude.refresh()
+
+            #expect(claude.supportsGuestPasses == false)
+        }
+
+        @Test
+        func `failed pass fetch is reported instead of failing silently`() async {
+            let passProbe = MockClaudePassProbing()
+            given(passProbe).probe().willThrow(ProbeError.parseFailed("Could not find referral URL"))
+            let claude = ClaudeProvider(
+                probe: Self.makeUsageProbe(tier: .claudeMax),
+                passProbe: passProbe,
+                settingsRepository: Self.makeSettings()
+            )
+
+            do {
+                _ = try await claude.fetchPasses()
+            } catch {
+                // Expected to throw
+            }
+
+            #expect(claude.passError != nil)
+            #expect(claude.guestPass == nil)
         }
     }
 }

--- a/Tests/DomainTests/Provider/AccountTierTests.swift
+++ b/Tests/DomainTests/Provider/AccountTierTests.swift
@@ -48,6 +48,30 @@ struct AccountTierTests {
         #expect(AccountTier.custom("ULTRA").badgeText == "ULTRA")
     }
 
+    // MARK: - Guest Pass Eligibility Tests
+
+    @Test
+    func `claudeMax is eligible for guest passes`() {
+        #expect(AccountTier.claudeMax.supportsGuestPasses == true)
+    }
+
+    @Test
+    func `claudePro is not eligible for guest passes`() {
+        // Anthropic only issues Claude Code invitation links to Max subscribers.
+        #expect(AccountTier.claudePro.supportsGuestPasses == false)
+    }
+
+    @Test
+    func `claudeApi is not eligible for guest passes`() {
+        #expect(AccountTier.claudeApi.supportsGuestPasses == false)
+    }
+
+    @Test
+    func `custom tier is not eligible for guest passes`() {
+        #expect(AccountTier.custom("MAX").supportsGuestPasses == false)
+        #expect(AccountTier.custom("ULTRA").supportsGuestPasses == false)
+    }
+
     // MARK: - Equality Tests
 
     @Test

--- a/Tests/DomainTests/Provider/Claude/ClaudeProviderPassTests.swift
+++ b/Tests/DomainTests/Provider/Claude/ClaudeProviderPassTests.swift
@@ -16,21 +16,100 @@ struct ClaudeProviderPassTests {
         return mock
     }
 
+    /// Creates a usage probe that yields a snapshot on the given account tier.
+    private func makeUsageProbe(tier: AccountTier?) -> MockUsageProbe {
+        let mock = MockUsageProbe()
+        given(mock).probe().willReturn(
+            UsageSnapshot(providerId: "claude", quotas: [], capturedAt: Date(), accountTier: tier)
+        )
+        given(mock).isAvailable().willReturn(true)
+        return mock
+    }
+
     @Test
-    func `supportsGuestPasses returns true when passProbe is configured`() {
+    func `supportsGuestPasses returns true for a Max account`() async throws {
         let settings = makeSettingsRepository()
-        let mockProbe = MockUsageProbe()
         let mockPassProbe = MockClaudePassProbing()
-        let claude = ClaudeProvider(probe: mockProbe, passProbe: mockPassProbe, settingsRepository: settings)
+        let claude = ClaudeProvider(
+            probe: makeUsageProbe(tier: .claudeMax),
+            passProbe: mockPassProbe,
+            settingsRepository: settings
+        )
+
+        try await claude.refresh()
 
         #expect(claude.supportsGuestPasses == true)
     }
 
     @Test
-    func `supportsGuestPasses returns false when passProbe is nil`() {
+    func `supportsGuestPasses returns false for a Pro account`() async throws {
+        // Issue #243: invitation links are Max-only, so Pro accounts must not
+        // see the Share button — clicking it could only ever fail.
         let settings = makeSettingsRepository()
-        let mockProbe = MockUsageProbe()
-        let claude = ClaudeProvider(probe: mockProbe, settingsRepository: settings)
+        let mockPassProbe = MockClaudePassProbing()
+        let claude = ClaudeProvider(
+            probe: makeUsageProbe(tier: .claudePro),
+            passProbe: mockPassProbe,
+            settingsRepository: settings
+        )
+
+        try await claude.refresh()
+
+        #expect(claude.supportsGuestPasses == false)
+    }
+
+    @Test
+    func `supportsGuestPasses returns false for an API account`() async throws {
+        let settings = makeSettingsRepository()
+        let mockPassProbe = MockClaudePassProbing()
+        let claude = ClaudeProvider(
+            probe: makeUsageProbe(tier: .claudeApi),
+            passProbe: mockPassProbe,
+            settingsRepository: settings
+        )
+
+        try await claude.refresh()
+
+        #expect(claude.supportsGuestPasses == false)
+    }
+
+    @Test
+    func `supportsGuestPasses returns false when the account tier is unknown`() async throws {
+        let settings = makeSettingsRepository()
+        let mockPassProbe = MockClaudePassProbing()
+        let claude = ClaudeProvider(
+            probe: makeUsageProbe(tier: nil),
+            passProbe: mockPassProbe,
+            settingsRepository: settings
+        )
+
+        try await claude.refresh()
+
+        #expect(claude.supportsGuestPasses == false)
+    }
+
+    @Test
+    func `supportsGuestPasses returns false before the first refresh`() {
+        let settings = makeSettingsRepository()
+        let mockPassProbe = MockClaudePassProbing()
+        let claude = ClaudeProvider(
+            probe: makeUsageProbe(tier: .claudeMax),
+            passProbe: mockPassProbe,
+            settingsRepository: settings
+        )
+
+        #expect(claude.supportsGuestPasses == false)
+    }
+
+    @Test
+    func `supportsGuestPasses returns false when passProbe is nil`() async throws {
+        let settings = makeSettingsRepository()
+        let claude = ClaudeProvider(
+            probe: makeUsageProbe(tier: .claudeMax),
+            settingsRepository: settings
+        )
+
+        try await claude.refresh()
 
         #expect(claude.supportsGuestPasses == false)
     }
@@ -122,14 +201,14 @@ struct ClaudeProviderPassTests {
     }
 
     @Test
-    func `fetchPasses stores error on failure`() async {
+    func `fetchPasses stores passError on failure`() async {
         let settings = makeSettingsRepository()
         let mockProbe = MockUsageProbe()
         let mockPassProbe = MockClaudePassProbing()
         given(mockPassProbe).probe().willThrow(ProbeError.executionFailed("CLI error"))
         let claude = ClaudeProvider(probe: mockProbe, passProbe: mockPassProbe, settingsRepository: settings)
 
-        #expect(claude.lastError == nil)
+        #expect(claude.passError == nil)
 
         do {
             _ = try await claude.fetchPasses()
@@ -137,6 +216,87 @@ struct ClaudeProviderPassTests {
             // Expected to throw
         }
 
-        #expect(claude.lastError != nil)
+        #expect(claude.passError != nil)
+    }
+
+    @Test
+    func `fetchPasses failure leaves the usage error untouched`() async {
+        // A failed invitation-link fetch says nothing about usage data, so it
+        // must not make the provider look unavailable in the popover.
+        let settings = makeSettingsRepository()
+        let mockProbe = MockUsageProbe()
+        let mockPassProbe = MockClaudePassProbing()
+        given(mockPassProbe).probe().willThrow(ProbeError.executionFailed("CLI error"))
+        let claude = ClaudeProvider(probe: mockProbe, passProbe: mockPassProbe, settingsRepository: settings)
+
+        do {
+            _ = try await claude.fetchPasses()
+        } catch {
+            // Expected to throw
+        }
+
+        #expect(claude.lastError == nil)
+    }
+
+    /// Pass probe that fails once, then succeeds — lets a single provider walk
+    /// the error-then-recovery path that a fixed stub can't express.
+    private final class FailThenSucceedPassProbe: ClaudePassProbing, @unchecked Sendable {
+        private var callCount = 0
+        let pass = ClaudePass(
+            passesRemaining: 1,
+            referralURL: URL(string: "https://claude.ai/referral/TEST")!
+        )
+
+        func isAvailable() async -> Bool { true }
+
+        func probe() async throws -> ClaudePass {
+            callCount += 1
+            if callCount == 1 {
+                throw ProbeError.executionFailed("CLI error")
+            }
+            return pass
+        }
+    }
+
+    @Test
+    func `fetchPasses clears a previous passError on success`() async throws {
+        let settings = makeSettingsRepository()
+        let mockProbe = MockUsageProbe()
+        let claude = ClaudeProvider(
+            probe: mockProbe,
+            passProbe: FailThenSucceedPassProbe(),
+            settingsRepository: settings
+        )
+
+        do {
+            _ = try await claude.fetchPasses()
+        } catch {
+            // Expected to throw
+        }
+        #expect(claude.passError != nil)
+
+        _ = try await claude.fetchPasses()
+
+        #expect(claude.passError == nil)
+    }
+
+    @Test
+    func `clearPassError removes the stored pass error`() async {
+        let settings = makeSettingsRepository()
+        let mockProbe = MockUsageProbe()
+        let mockPassProbe = MockClaudePassProbing()
+        given(mockPassProbe).probe().willThrow(ProbeError.executionFailed("CLI error"))
+        let claude = ClaudeProvider(probe: mockProbe, passProbe: mockPassProbe, settingsRepository: settings)
+
+        do {
+            _ = try await claude.fetchPasses()
+        } catch {
+            // Expected to throw
+        }
+        #expect(claude.passError != nil)
+
+        claude.clearPassError()
+
+        #expect(claude.passError == nil)
     }
 }

--- a/docs/architecture/USER_BEHAVIORS.md
+++ b/docs/architecture/USER_BEHAVIORS.md
@@ -302,7 +302,7 @@ Scenario: Disabled provider does not affect overall status
 | # | Behavior |
 |---|----------|
 | 24 | User clicks Dashboard → opens provider's web dashboard in browser |
-| 25 | User clicks Share (Claude only) → shows referral link overlay with pass count |
+| 25 | User clicks Share (Claude Max only) → shows referral link overlay with pass count |
 | 26 | Settings button shows red badge when app update available |
 | 27 | User clicks Quit → app terminates |
 
@@ -324,16 +324,36 @@ Scenario: Provider with no dashboard
 **#25 — Share Claude Code guest passes**
 ```
 Scenario: Share referral link
-  Given Claude is selected
+  Given Claude is selected on a Max account
     And `claude /passes` returns a referral URL with 3 passes left
   When the user clicks Share
   Then the overlay shows the referral link
     And shows "3 passes left"
+
+Scenario: Pro account has no Share button
+  Given Claude is selected on a Pro account
+  When the user views the action bar
+  Then the Share button is hidden
+    # Anthropic issues invitation links to Max plans only
+
+Scenario: Unknown account tier has no Share button
+  Given Claude is selected
+    And the account tier has not been determined yet
+  When the user views the action bar
+  Then the Share button is hidden
+
+Scenario: Fetching the referral link fails
+  Given Claude is selected on a Max account
+    And `claude /passes` fails
+  When the user clicks Share
+  Then an error overlay explains why the link could not be fetched
+    And the provider's usage data is still shown as available
 ```
 
 ### Inner TDD Tests (existing)
 - `ClaudePassProbeTests.*`
-- `ClaudeProviderTests.fetchPasses stores guest pass data`
+- `ClaudeProviderPassTests.*`
+- `AccountTierTests.claude* is (not) eligible for guest passes`
 
 ---
 


### PR DESCRIPTION
- Show "Share Claude Code" button only for Claude Max tier users
- Add passError state to report invitation link fetch failures explicitly
- Display error overlay on failed share attempts instead of failing silently
- Prevent pass fetch failures from marking usage data as unavailable
- Add tests covering guest pass availability and error handling
- fix #243 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Share is now available only to Claude Max accounts.
  - Added an error overlay explaining invitation-link fetch failures, with backdrop and close-button dismissal.
- **Bug Fixes**
  - Invitation-link failures no longer incorrectly make usage data unavailable.
  - Errors clear automatically after a successful retry or when dismissed.
- **Documentation**
  - Updated behavior documentation to reflect Max-only sharing and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->