### PR TITLE
fix(menubar): show reset countdown hours as H:MM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The menu bar reset countdown now shows hours with minutes in "H:MM" form
+  (e.g. "3:58") instead of truncating to whole hours ("3h"), which could
+  understate the remaining time by up to 59 minutes compared with the panel's
+  "3h 58m" detail. Day-level ("2d") and minute-level ("45m") labels are
+  unchanged. (#246)
+
 ---
 
 ## [0.4.77] - 2026-08-12

--- a/Sources/Domain/Provider/UsageQuota.swift
+++ b/Sources/Domain/Provider/UsageQuota.swift
@@ -289,15 +289,16 @@ public struct UsageQuota: Sendable, Equatable, Hashable, Comparable {
         return max(0, resetsAt.timeIntervalSinceNow)
     }
 
-    /// Compact reset duration for the menu bar label (e.g., "1d", "3h 30m", "45m").
-    /// Single largest non-zero unit ("Xd", "Xh", "Xm"); "soon" under a
-    /// minute; nil when reset time is unknown. Smaller-unit precision is
-    /// intentionally dropped to keep the menu bar label short.
+    /// Compact reset duration for the menu bar label (e.g., "1d", "3:58", "45m").
+    /// Hours use "H:MM" so the label stays short without hiding up to 59
+    /// minutes behind a bare "3h"; days keep a single unit since sub-day
+    /// precision matters less at that range. "soon" under a minute; nil when
+    /// reset time is unknown.
     public var compactResetTime: String? {
         guard let timeUntilReset else { return nil }
         let s = Int(timeUntilReset)
         if s >= 86400 { return "\(s / 86400)d" }
-        if s >= 3600  { return "\(s / 3600)h" }
+        if s >= 3600  { return String(format: "%d:%02d", s / 3600, (s % 3600) / 60) }
         if s >= 60    { return "\(s / 60)m" }
         return "soon"
     }

--- a/Tests/DomainTests/Monitor/QuotaMonitorTests.swift
+++ b/Tests/DomainTests/Monitor/QuotaMonitorTests.swift
@@ -197,7 +197,7 @@ struct QuotaMonitorTests {
 
     @Test
     func `menu bar duration display returns compact reset time for selected quota`() async {
-        // Given - claude session quota with reset ~3h away
+        // Given - claude session quota with reset ~3h 58m away
         let settings = makeSettingsRepository()
         let probe = MockUsageProbe()
         given(probe).isAvailable().willReturn(true)
@@ -208,7 +208,7 @@ struct QuotaMonitorTests {
                     percentRemaining: 75,
                     quotaType: .session,
                     providerId: "claude",
-                    resetsAt: Date().addingTimeInterval(3.0 * 3600 + 30)
+                    resetsAt: Date().addingTimeInterval(3.0 * 3600 + 58.0 * 60 + 30)
                 ),
             ],
             capturedAt: Date()
@@ -224,7 +224,7 @@ struct QuotaMonitorTests {
         )
 
         // Then
-        #expect(display?.text == "3h")
+        #expect(display?.text == "3:58")
         #expect(display?.status == .healthy)
     }
 
@@ -462,13 +462,13 @@ struct QuotaMonitorTests {
 
     @Test
     func `menu bar label segments cover the duration-only variant`() async {
-        // Given: session quota with reset ~3h away
+        // Given: session quota with reset ~3h 58m away
         let monitor = await makeRefreshedClaudeMonitor(quotas: [
             UsageQuota(
                 percentRemaining: 75,
                 quotaType: .session,
                 providerId: "claude",
-                resetsAt: Date().addingTimeInterval(3.0 * 3600 + 30)
+                resetsAt: Date().addingTimeInterval(3.0 * 3600 + 58.0 * 60 + 30)
             ),
         ])
 
@@ -483,9 +483,9 @@ struct QuotaMonitorTests {
         )
 
         // Then
-        #expect(label?.text == "3h")
+        #expect(label?.text == "3:58")
         #expect(label?.segments == [
-            MenuBarLabel.Segment(text: "3h", status: .healthy),
+            MenuBarLabel.Segment(text: "3:58", status: .healthy),
         ])
     }
 
@@ -497,7 +497,7 @@ struct QuotaMonitorTests {
                 percentRemaining: 75,
                 quotaType: .session,
                 providerId: "claude",
-                resetsAt: Date().addingTimeInterval(3.0 * 3600 + 30)
+                resetsAt: Date().addingTimeInterval(3.0 * 3600 + 58.0 * 60 + 30)
             ),
             UsageQuota(
                 percentRemaining: 35,
@@ -519,10 +519,10 @@ struct QuotaMonitorTests {
 
         // Then: segments carry the full "percentage · duration" window texts,
         // each with its own per-window status (matching the dual-window test)
-        #expect(label?.text == "5h 75% · 3h | 7d 35% · 6d")
+        #expect(label?.text == "5h 75% · 3:58 | 7d 35% · 6d")
         #expect(label?.status == .warning)
         #expect(label?.segments == [
-            MenuBarLabel.Segment(text: "5h 75% · 3h", status: .healthy),
+            MenuBarLabel.Segment(text: "5h 75% · 3:58", status: .healthy),
             MenuBarLabel.Segment(text: "7d 35% · 6d", status: .warning),
         ])
     }

--- a/Tests/DomainTests/Provider/MenuBarDurationDisplayTests.swift
+++ b/Tests/DomainTests/Provider/MenuBarDurationDisplayTests.swift
@@ -20,10 +20,10 @@ struct MenuBarDurationDisplayTests {
     // MARK: - Text formatting
 
     @Test
-    func `text shows compact hours when reset is hours away`() {
-        let q = quota(resetsAt: Date().addingTimeInterval(3.0 * 3600 + 30))
+    func `text shows hours with minutes when reset is hours away`() {
+        let q = quota(resetsAt: Date().addingTimeInterval(3.0 * 3600 + 58.0 * 60 + 30))
         let display = MenuBarDurationDisplay(quota: q)
-        #expect(display.text == "3h")
+        #expect(display.text == "3:58")
     }
 
     @Test

--- a/Tests/DomainTests/Provider/UsageQuotaTests.swift
+++ b/Tests/DomainTests/Provider/UsageQuotaTests.swift
@@ -120,10 +120,24 @@ struct UsageQuotaTests {
     }
 
     @Test
-    func `compactResetTime shows hours when under a day`() {
-        let resetDate = Date().addingTimeInterval(3.0 * 3600 + 15.0 * 60 + 30)
+    func `compactResetTime shows hours and minutes when under a day`() {
+        let resetDate = Date().addingTimeInterval(3.0 * 3600 + 58.0 * 60 + 30)
         let quota = UsageQuota(percentRemaining: 35, quotaType: .weekly, providerId: "claude", resetsAt: resetDate)
-        #expect(quota.compactResetTime == "3h")
+        #expect(quota.compactResetTime == "3:58")
+    }
+
+    @Test
+    func `compactResetTime pads minutes to two digits`() {
+        let resetDate = Date().addingTimeInterval(5.0 * 3600 + 5.0 * 60 + 30)
+        let quota = UsageQuota(percentRemaining: 35, quotaType: .weekly, providerId: "claude", resetsAt: resetDate)
+        #expect(quota.compactResetTime == "5:05")
+    }
+
+    @Test
+    func `compactResetTime shows whole hours with zero minutes`() {
+        let resetDate = Date().addingTimeInterval(3.0 * 3600 + 30)
+        let quota = UsageQuota(percentRemaining: 35, quotaType: .weekly, providerId: "claude", resetsAt: resetDate)
+        #expect(quota.compactResetTime == "3:00")
     }
 
     @Test


### PR DESCRIPTION
## Summary

The menu bar reset countdown truncated to the largest unit, so a quota resetting in 3h 58m displayed as "3h" — up to 59 minutes off from the panel's "3h 58m" detail. As #246 puts it, that doesn't align with "being able to see the quota status at a glance."

This adopts the compact notation suggested in the issue: hours now render as **"H:MM"** (e.g. "3:58"), keeping the label nearly as narrow as before while matching the panel to the minute.

| Time until reset | Before | After |
|---|---|---|
| 3h 58m | `3h` | `3:58` |
| 5h 5m | `5h` | `5:05` |
| 2d 5h | `2d` | `2d` (unchanged) |
| 45m | `45m` | `45m` (unchanged) |

Day-level truncation is left as-is: the proportional error at a multi-day horizon is small, and the colon notation doesn't extend naturally to days. Happy to change that too if preferred.

## Changes

- `UsageQuota.compactResetTime`: hours branch formats as `H:MM` with zero-padded minutes; days/minutes/"soon" branches untouched.
- Updated the format expectations in `UsageQuotaTests`, `MenuBarDurationDisplayTests`, and `QuotaMonitorTests` (TDD red first), and added cases for minute padding ("5:05") and whole hours ("3:00").
- CHANGELOG entry under [Unreleased].

## Testing

- Domain suite: 683 tests pass; Infrastructure suite: 1086 tests pass.
- Verified in a local Debug build: menu bar shows `5h 93% · 3:18` where it previously showed `5h 93% · 3h`, matching the panel's "Resets in 3h 18m".

Fixes #246

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Menu bar quota reset countdowns now display hours and minutes (`H:MM`) for resets within a day, providing more precise timing.

- **Bug Fixes**
  - Preserved existing day-, minute-, soon-, and unknown-reset display behavior while improving hour-level accuracy.

- **Documentation**
  - Updated release notes and feature documentation to reflect the new countdown format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->