### PR TITLE
feat(menubar): drive the countdown on its own clock with a pulsing colon

### DIFF
--- a/Sources/App/StatusItemLabelDriver.swift
+++ b/Sources/App/StatusItemLabelDriver.swift
@@ -30,8 +30,14 @@ final class StatusItemLabelDriver {
     private var statusItem: NSStatusItem?
     private var labelSync: ObservationRenderSync<LabelContent>?
     private var loopSync: ObservationRenderSync<RefreshLoopKey>?
+    private var blinkSync: ObservationRenderSync<Bool>?
     private var streamConsumer: Task<Void, Never>?
     private var wakeObserver: NSObjectProtocol?
+
+    /// Drives the countdown: every tick re-reads the label (picking up the
+    /// current wall clock) and flips `blinkPhase`. See `startBlinkTimer`.
+    private var blinkTimer: Timer?
+    private var blinkPhase = true
 
     /// The image currently owned by this driver, and the content it encodes.
     /// Used both to skip redundant redraws (repainting an intact image can
@@ -66,6 +72,11 @@ final class StatusItemLabelDriver {
         /// content (not read at draw time) so changing the size in Settings
         /// invalidates the observation sync and repaints the label.
         var stackedSize: MenuBarStackedSize = .default
+        /// Blink phase for an H:MM countdown's separator colon. Only alternates
+        /// while the label actually holds a countdown colon, so a "2d" or "45m"
+        /// label keeps comparing equal across ticks and never repaints for the
+        /// blink alone (see `render`'s early-out).
+        var colonVisible: Bool = true
     }
 
     /// Attaches to the `NSStatusItem` exposed by MenuBarExtraAccess and starts
@@ -84,6 +95,7 @@ final class StatusItemLabelDriver {
         )
         labelSync = sync
         sync.start()
+        startBlinkLifecycle()
 
         // SwiftUI wipes `button.image` whenever the scene re-evaluates (every
         // dropdown open/close flips the `isPresented` binding). Restore it
@@ -130,13 +142,17 @@ final class StatusItemLabelDriver {
             burnRateThreshold: settings.burnRateThreshold
         )
 
+        let label = freshLabel ?? lastKnownLabel(whenFreshIsMissing: freshLabel)
+        let hasCountdownColon = label.map { !CountdownColon.ranges(in: $0.text).isEmpty } ?? false
+
         return LabelContent(
-            label: freshLabel ?? lastKnownLabel(whenFreshIsMissing: freshLabel),
+            label: label,
             fallbackStatus: effectiveSelectedProviderStatus,
             sessionPhase: sessionMonitor.activeSession?.phase,
             themeModeId: settings.themeMode,
             stacked: settings.menuBarStackedEnabled,
-            stackedSize: settings.menuBarStackedSize
+            stackedSize: settings.menuBarStackedSize,
+            colonVisible: hasCountdownColon ? blinkPhase : true
         )
     }
 
@@ -211,12 +227,14 @@ final class StatusItemLabelDriver {
                 parts.append(StatusBarStackedImageRenderer.image(
                     top: (label.segments[0].text, theme.statusColor(for: label.segments[0].status)),
                     bottom: (label.segments[1].text, theme.statusColor(for: label.segments[1].status)),
-                    size: content.stackedSize
+                    size: content.stackedSize,
+                    colonVisible: content.colonVisible
                 ))
             } else {
                 parts.append(StatusBarPercentageImageRenderer.image(
                     text: label.text,
-                    color: theme.statusColor(for: label.status)
+                    color: theme.statusColor(for: label.status),
+                    colonVisible: content.colonVisible
                 ))
             }
         } else {
@@ -274,6 +292,60 @@ final class StatusItemLabelDriver {
         }
         composed.isTemplate = false
         return composed
+    }
+
+    // MARK: - Countdown Tick
+
+    /// Half a second on, half a second off — the cadence a digital clock blinks
+    /// its separator at. Also the rate the label re-reads the wall clock, so a
+    /// countdown advances within half a second of the true minute boundary.
+    private static let blinkInterval: TimeInterval = 0.5
+
+    /// Starts watching whether a duration is shown at all, running the
+    /// countdown tick only while one is. Sibling of `startMonitoringLifecycle`.
+    ///
+    /// Before this existed the label had no clock: the countdown text is
+    /// computed fresh on every draw, but nothing *caused* a draw on a time
+    /// basis. It advanced only as a side effect of something else changing — a
+    /// probe result, a Claude Code hook event, opening the dropdown — so on an
+    /// idle machine with background refresh off it could sit visibly stale.
+    private func startBlinkLifecycle() {
+        guard blinkSync == nil else { return }
+        let sync = ObservationRenderSync<Bool>(
+            read: { [self] in settings.menuBarDurationEnabled },
+            render: { [self] showsDuration in
+                showsDuration ? startBlinkTimer() : stopBlinkTimer()
+            }
+        )
+        blinkSync = sync
+        sync.start()
+    }
+
+    private func startBlinkTimer() {
+        guard blinkTimer == nil else { return }
+        let timer = Timer(timeInterval: Self.blinkInterval, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.blinkPhase.toggle()
+                // refreshNow, not renderNow: the tick must not arm a new
+                // observation registration twice a second, and must keep the
+                // equality check so a colon-less label ("2d") never repaints.
+                self.labelSync?.refreshNow()
+            }
+        }
+        // .common, not the default mode: a runloop in tracking mode (any menu
+        // open) would otherwise stall the tick and freeze the colon mid-pulse.
+        RunLoop.main.add(timer, forMode: .common)
+        blinkTimer = timer
+    }
+
+    private func stopBlinkTimer() {
+        guard blinkTimer != nil else { return }
+        blinkTimer?.invalidate()
+        blinkTimer = nil
+        // Never leave the colon parked in its dimmed phase.
+        blinkPhase = true
+        labelSync?.refreshNow()
     }
 
     // MARK: - Background Refresh Lifecycle
@@ -345,17 +417,48 @@ final class StatusItemLabelDriver {
     }
 }
 
+/// Pulses the separator colon of an H:MM countdown by fading it, shared by both
+/// status-bar renderers.
+///
+/// Fading rather than hiding is deliberate. The label is drawn in
+/// `monospacedDigitSystemFont`, where only the *digits* are fixed-width —
+/// punctuation stays proportional. Substituting a space for the colon would
+/// therefore change the label's width twice a second and shove every menu bar
+/// item to its left. The glyph always draws at full size; only its alpha
+/// changes, so the metrics are identical in both phases.
+enum CountdownColonStyle {
+    /// Alpha of the colon in its dimmed phase. Low enough to read as a pulse,
+    /// high enough that the time never looks like it lost a character.
+    private static let dimmedAlpha: CGFloat = 0.25
+
+    /// Dims the countdown colons in `attributed` when the blink phase is off.
+    /// A no-op in the visible phase, and for any text with no countdown colon.
+    @MainActor
+    static func apply(colonVisible: Bool, to attributed: NSMutableAttributedString, baseColor: Color) {
+        guard !colonVisible else { return }
+        let text = attributed.string
+        let ranges = CountdownColon.ranges(in: text)
+        guard !ranges.isEmpty else { return }
+
+        let dimmed = NSColor(baseColor).withAlphaComponent(dimmedAlpha)
+        for range in ranges {
+            attributed.addAttribute(.foregroundColor, value: dimmed, range: NSRange(range, in: text))
+        }
+    }
+}
+
 /// Renders status text as an original-color image because macOS can ignore
 /// `Text.foregroundStyle` inside a menu bar item.
 enum StatusBarPercentageImageRenderer {
     @MainActor
-    static func image(text: String, color: Color) -> NSImage {
+    static func image(text: String, color: Color, colonVisible: Bool = true) -> NSImage {
         let font = NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .semibold)
         let attributes: [NSAttributedString.Key: Any] = [
             .font: font,
             .foregroundColor: NSColor(color),
         ]
-        let attributedText = NSAttributedString(string: text, attributes: attributes)
+        let attributedText = NSMutableAttributedString(string: text, attributes: attributes)
+        CountdownColonStyle.apply(colonVisible: colonVisible, to: attributedText, baseColor: color)
         let textSize = attributedText.size()
         let imageSize = NSSize(width: ceil(textSize.width), height: ceil(textSize.height))
         let image = NSImage(size: imageSize, flipped: false) { _ in
@@ -402,14 +505,20 @@ enum StatusBarStackedImageRenderer {
     static func image(
         top: (text: String, color: Color),
         bottom: (text: String, color: Color),
-        size: MenuBarStackedSize = .default
+        size: MenuBarStackedSize = .default,
+        colonVisible: Bool = true
     ) -> NSImage {
         let font = NSFont.monospacedDigitSystemFont(ofSize: size.stackedLinePointSize, weight: .semibold)
+        // Each line carries its own countdown (or none), so each is styled
+        // independently — but both share the phase, so the two colons pulse
+        // together instead of drifting against each other.
         func attributedLine(_ line: (text: String, color: Color)) -> NSAttributedString {
-            NSAttributedString(string: line.text, attributes: [
+            let attributed = NSMutableAttributedString(string: line.text, attributes: [
                 .font: font,
                 .foregroundColor: NSColor(line.color),
             ])
+            CountdownColonStyle.apply(colonVisible: colonVisible, to: attributed, baseColor: line.color)
+            return attributed
         }
         let topLine = attributedLine(top)
         let bottomLine = attributedLine(bottom)

--- a/Sources/Domain/Monitor/ObservationRenderSync.swift
+++ b/Sources/Domain/Monitor/ObservationRenderSync.swift
@@ -52,6 +52,28 @@ public final class ObservationRenderSync<Content: Equatable> {
         sync()
     }
 
+    /// Re-reads and renders *only if the value changed*, without arming a new
+    /// observation registration.
+    ///
+    /// For callers that drive their own tick (the menu bar's countdown ticks
+    /// twice a second) and must not go through `renderNow`. Each `sync` arms a
+    /// fresh `withObservationTracking` registration, and a registration is only
+    /// torn down when it fires — so a ticking caller would accumulate one per
+    /// tick, all of them armed on the same properties, until some observed
+    /// value finally changed and fired the whole backlog at once.
+    ///
+    /// Skipping the re-arm is safe: the registration from the last real `sync`
+    /// is still armed and still catches genuine state changes. Reading the
+    /// values untracked here does not consume it.
+    public func refreshNow() {
+        guard isStarted else { return }
+        let content = read()
+        if content != lastRendered {
+            lastRendered = content
+            render(content)
+        }
+    }
+
     private func sync() {
         guard isStarted else { return }
         let content = withObservationTracking {

--- a/Sources/Domain/Provider/CountdownColon.swift
+++ b/Sources/Domain/Provider/CountdownColon.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Locates the separator colon inside an hours-and-minutes countdown so a
+/// renderer can animate it.
+///
+/// The menu bar label carries no clock of its own: the countdown text advances
+/// only when the label is redrawn, which makes a correct-but-static "4:40"
+/// indistinguishable from a stale one. Pulsing the colon is the signal that the
+/// value is live, the same way a digital clock blinks its separator.
+///
+/// Only a `digit:digit-digit` run counts. A probe can set a `menuBarTitle`
+/// containing a colon (e.g. an account discriminator), and that punctuation
+/// must not pulse — it isn't counting down.
+///
+/// Lives in Domain because "which characters are the countdown separator" is a
+/// rule worth testing; how the pulse is drawn stays in the App layer.
+public enum CountdownColon {
+    /// A colon preceded by a digit and followed by exactly two digits — the
+    /// shape `UsageQuota.compactResetTime` emits for the 1h–24h range ("4:40").
+    /// The capture group isolates the colon itself, so each returned range
+    /// addresses one character.
+    private static let pattern = #"\d(:)\d\d"#
+
+    private static let regex = try? NSRegularExpression(pattern: pattern)
+
+    /// Ranges of the countdown colons in `text`, in order.
+    ///
+    /// Empty when there is nothing to animate — a `"45m"` or `"2d"` label, a
+    /// label with no duration shown, or a colon that belongs to something other
+    /// than a countdown. A dual-window label yields one range per window that
+    /// is currently in hours range.
+    public static func ranges(in text: String) -> [Range<String.Index>] {
+        guard let regex, !text.isEmpty else { return [] }
+
+        let full = NSRange(text.startIndex..<text.endIndex, in: text)
+        return regex.matches(in: text, range: full).compactMap { match in
+            guard match.numberOfRanges >= 2 else { return nil }
+            return Range(match.range(at: 1), in: text)
+        }
+    }
+}

--- a/Tests/DomainTests/Monitor/ObservationRenderSyncTests.swift
+++ b/Tests/DomainTests/Monitor/ObservationRenderSyncTests.swift
@@ -150,6 +150,108 @@ struct ObservationRenderSyncTests {
         #expect(recorder.rendered == ["initial", "initial"])
     }
 
+    // MARK: - refreshNow (self-driven ticks)
+
+    @Test
+    func `refreshNow renders when the value changed`() {
+        // Given — the menu bar's countdown tick re-reads the wall clock
+        let source = Source()
+        let recorder = RenderRecorder()
+        let sync = ObservationRenderSync(
+            read: { source.value },
+            render: { recorder.record($0) }
+        )
+        sync.start()
+
+        // When
+        source.value = "ticked"
+        sync.refreshNow()
+
+        // Then
+        #expect(recorder.rendered == ["initial", "ticked"])
+    }
+
+    @Test
+    func `refreshNow does not render when the value is unchanged`() {
+        // Given — a colon-less menu bar label ("2d") must not repaint on every
+        // tick just because the clock advanced.
+        let source = Source()
+        let recorder = RenderRecorder()
+        let sync = ObservationRenderSync(
+            read: { source.value },
+            render: { recorder.record($0) }
+        )
+        sync.start()
+
+        // When — many ticks with nothing changing
+        sync.refreshNow()
+        sync.refreshNow()
+        sync.refreshNow()
+
+        // Then — unlike renderNow, no forced repaints
+        #expect(recorder.rendered == ["initial"])
+    }
+
+    @Test
+    func `refreshNow leaves observation armed so later state changes still render`() async {
+        // Given — refreshNow deliberately skips re-arming observation, so a
+        // ticking caller cannot accumulate one registration per tick. The
+        // registration from the last real sync must survive that.
+        let source = Source()
+        let recorder = RenderRecorder()
+        let sync = ObservationRenderSync(
+            read: { source.value },
+            render: { recorder.record($0) }
+        )
+        sync.start()
+
+        // When — ticks happen, then genuine observed state changes
+        sync.refreshNow()
+        sync.refreshNow()
+        source.value = "observed change"
+        await waitUntil { recorder.rendered.count >= 2 }
+
+        // Then — the change still reached the sink
+        #expect(recorder.rendered == ["initial", "observed change"])
+    }
+
+    @Test
+    func `refreshNow does nothing before start`() {
+        // Given
+        let source = Source()
+        let recorder = RenderRecorder()
+        let sync = ObservationRenderSync(
+            read: { source.value },
+            render: { recorder.record($0) }
+        )
+
+        // When
+        sync.refreshNow()
+
+        // Then
+        #expect(recorder.rendered.isEmpty)
+    }
+
+    @Test
+    func `refreshNow does nothing after stop`() {
+        // Given — the tick timer can outlive a stop by one fire
+        let source = Source()
+        let recorder = RenderRecorder()
+        let sync = ObservationRenderSync(
+            read: { source.value },
+            render: { recorder.record($0) }
+        )
+        sync.start()
+        sync.stop()
+
+        // When
+        source.value = "after stop"
+        sync.refreshNow()
+
+        // Then
+        #expect(recorder.rendered == ["initial"])
+    }
+
     @Test
     func `menu bar label content stays in sync with provider refreshes`() async {
         // Given — the real domain chain: provider snapshot → monitor → label

--- a/Tests/DomainTests/Provider/CountdownColonTests.swift
+++ b/Tests/DomainTests/Provider/CountdownColonTests.swift
@@ -1,0 +1,112 @@
+import Testing
+import Foundation
+@testable import Domain
+
+@Suite
+struct CountdownColonTests {
+
+    private func colons(in text: String) -> [String] {
+        CountdownColon.ranges(in: text).map { String(text[$0]) }
+    }
+
+    // MARK: - Finding the countdown colon
+
+    @Test
+    func `finds the colon in an hours-and-minutes countdown`() {
+        let text = "4:40"
+        let ranges = CountdownColon.ranges(in: text)
+
+        #expect(ranges.count == 1)
+        #expect(colons(in: text) == [":"])
+        #expect(text[ranges[0]] == ":")
+    }
+
+    @Test
+    func `finds the colon inside a composed single-window label`() {
+        let text = "98% · 4:40"
+        let ranges = CountdownColon.ranges(in: text)
+
+        #expect(ranges.count == 1)
+        #expect(text[ranges[0]] == ":")
+    }
+
+    @Test
+    func `finds a colon in each window of a dual-window label`() {
+        let ranges = CountdownColon.ranges(in: "5h 12% · 4:40 | 7d 34% · 3:20")
+
+        #expect(ranges.count == 2)
+    }
+
+    @Test
+    func `finds only the window that is in hours range`() {
+        let text = "0h 98% · 4:40 | Fable 22% · 2d"
+        let ranges = CountdownColon.ranges(in: text)
+
+        #expect(ranges.count == 1)
+        #expect(text[ranges[0]] == ":")
+    }
+
+    // MARK: - Labels with nothing to blink
+
+    @Test
+    func `returns no ranges for a minutes-only countdown`() {
+        #expect(CountdownColon.ranges(in: "98% · 45m").isEmpty)
+    }
+
+    @Test
+    func `returns no ranges for a days countdown`() {
+        #expect(CountdownColon.ranges(in: "22% · 2d").isEmpty)
+    }
+
+    @Test
+    func `returns no ranges for a label with no duration at all`() {
+        #expect(CountdownColon.ranges(in: "98%").isEmpty)
+    }
+
+    @Test
+    func `returns no ranges for an empty label`() {
+        #expect(CountdownColon.ranges(in: "").isEmpty)
+    }
+
+    // MARK: - Colons that are not countdowns
+
+    @Test
+    func `ignores a colon that is not preceded by a digit`() {
+        // A probe-supplied menuBarTitle can carry a colon (e.g. an account
+        // discriminator). Only a digit:digit-digit run is a countdown.
+        #expect(CountdownColon.ranges(in: "acct:main 12% · 45m").isEmpty)
+    }
+
+    @Test
+    func `ignores a colon that is not followed by two digits`() {
+        #expect(CountdownColon.ranges(in: "4:4m").isEmpty)
+        #expect(CountdownColon.ranges(in: "4: 40").isEmpty)
+    }
+
+    // MARK: - Range validity
+
+    @Test
+    func `ranges address exactly one character each`() {
+        let text = "0h 98% · 4:40 | 7d 34% · 3:20"
+
+        for range in CountdownColon.ranges(in: text) {
+            #expect(text.distance(from: range.lowerBound, to: range.upperBound) == 1)
+        }
+    }
+
+    @Test
+    func `ranges survive conversion to NSRange for attributed-string use`() {
+        // The menu bar renderer dims these ranges inside an NSAttributedString,
+        // so the returned ranges must convert cleanly against the same string.
+        let text = "0h 98% · 4:40"
+        let ranges = CountdownColon.ranges(in: text)
+        let nsText = text as NSString
+
+        #expect(ranges.count == 1)
+        for range in ranges {
+            let nsRange = NSRange(range, in: text)
+            #expect(nsRange.length == 1)
+            #expect(nsText.substring(with: nsRange) == ":")
+        }
+    }
+}

--- a/docs/features/countdown-colon.md
+++ b/docs/features/countdown-colon.md
@@ -1,0 +1,114 @@
+# Countdown Colon
+
+The menu bar duration readout (`0h 98% · 4:40`) now advances on its own clock, and pulses the `:` separator to show that it is live.
+
+---
+
+## The problem
+
+The countdown *value* was always correct when drawn. `MenuBarDurationDisplay.text` is a computed property, resolving through `UsageQuota.compactResetTime` → `resetsAt.timeIntervalSinceNow`, specifically so it reflects the current wall clock on every draw rather than freezing at construction time.
+
+What was missing was anything to *cause* a draw on a time basis. `StatusItemLabelDriver` paints through `ObservationRenderSync`, which re-runs only when an `@Observable` property it read changes — and wall-clock time is not observable. So the label repainted only as a side effect of something else:
+
+| Trigger | Source |
+|---|---|
+| Probe snapshot / settings / session-phase change | `currentLabelContent()` |
+| Background refresh tick | `restartMonitoring`'s stream consumer |
+| Claude Code hook event → `sessionMonitor.activeSession` mutation | `ClaudeBarApp.startHookServer` |
+| System wake | `NSWorkspace.didWakeNotification` |
+| Dropdown open/close | `reassertPresentation()` |
+
+The hook path is why the countdown *looked* like it worked: while Claude Code is running, `PreToolUse`/`PostToolUse`/`Stop` events fire constantly, mutating `activeSession` and re-rendering the label many times a minute. Take that away — Claude Code idle or quit, and `app.backgroundSyncEnabled` defaulting to `false` — and the label could sit visibly stale until the user opened the dropdown.
+
+A stale-but-plausible countdown is worse than an obviously missing one: nothing distinguishes a correct `4:40` from one frozen twenty minutes ago.
+
+## Behavior
+
+- A **0.5s tick** runs whenever a duration is shown (`menuBarDurationEnabled`). Every tick re-reads the label, so the countdown advances within half a second of the true minute boundary regardless of probe activity, hook traffic, or background-refresh setting.
+- When the countdown is in **H:MM** range, the `:` fades to **25% alpha** on alternate ticks and back — the cadence a digital clock blinks its separator at.
+- Both menu bar layouts pulse: the single-line label and each line of the stacked dual-window label (both share one phase, so the two colons pulse together rather than drifting).
+- No new setting. The pulse rides on the existing "Show duration" toggle.
+
+```
+0.0s   0h 98% · 4:40 | Fable 22% · 2d
+0.5s   0h 98% · 4 40 | Fable 22% · 2d     ← colon at 25% alpha (still drawn)
+1.0s   0h 98% · 4:40 | Fable 22% · 2d
+```
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│                      Domain (tested)                                      │
+│                                                                           │
+│   UsageQuota.compactResetTime ──▶ "4:40"        (unchanged)               │
+│                                                                           │
+│   CountdownColon.ranges(in:) ──▶ [Range<String.Index>]                    │
+│     matches \d(:)\d\d only — a probe's menuBarTitle colon never pulses    │
+│                                                                           │
+│   ObservationRenderSync.refreshNow()  ★ new entry point                   │
+└──────────────────────────────────────────────────────────────────────────┘
+                                    │
+┌──────────────────────────────────────────────────────────────────────────┐
+│                      App — StatusItemLabelDriver                          │
+│                                                                           │
+│   blinkSync : ObservationRenderSync<Bool>                                 │
+│     watches menuBarDurationEnabled ──▶ start/stop blinkTimer              │
+│                       │                                                   │
+│                       ▼                                                   │
+│   blinkTimer (0.5s, RunLoop .common mode)                                 │
+│     every tick: blinkPhase.toggle() ──▶ labelSync.refreshNow()            │
+│                       │                                                   │
+│                       ▼                                                   │
+│   LabelContent { …, colonVisible: Bool }                                  │
+│     colonVisible alternates ONLY when the label holds a countdown colon   │
+│                       │                                                   │
+│         ┌─────────────┴──────────────┐                                    │
+│         ▼                            ▼                                    │
+│   StatusBarPercentage-        StatusBarStacked-                           │
+│   ImageRenderer               ImageRenderer                               │
+│         └─────────────┬──────────────┘                                    │
+│                       ▼                                                   │
+│   CountdownColonStyle.apply(colonVisible:to:baseColor:)                   │
+│     dims the colon ranges inside the NSAttributedString                   │
+│                       ▼                                                   │
+│              statusItem.button.image                                      │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+## Design decisions
+
+### Fade the colon, never hide it
+
+The label draws in `monospacedDigitSystemFont`, where only the **digits** are fixed-width — punctuation stays proportional. Substituting a space for the colon would change the label's width twice a second and shove every menu bar item to its left. So the glyph always draws at full size and only its alpha changes: identical metrics in both phases, one attributed-string draw, no layout jitter.
+
+25% rather than 0% also keeps the time reading as a complete value; a fully vanishing colon reads as a dropped character.
+
+### `refreshNow()`, not `renderNow()`
+
+Each `ObservationRenderSync.sync()` arms a **new** `withObservationTracking` registration, and a registration is only torn down when it fires. A caller ticking at 2 Hz through `renderNow()` would accumulate one armed registration per tick — roughly 1,200 over ten idle minutes — all watching the same properties, then fire the entire backlog in a single burst on the next probe result, each spawning a Task that re-arms.
+
+`refreshNow()` re-reads and renders **without** arming a new registration. This is safe because the registration from the last real `sync()` is still armed and still catches genuine state changes; reading the values untracked does not consume it. It also keeps the equality check that `renderNow()` deliberately bypasses.
+
+### `colonVisible` only alternates when there is a colon
+
+For a `2d` or `45m` label the flag stays constant, so `LabelContent` compares equal across ticks and `render()` early-outs before touching the image. Those labels get the freshness fix (they still recompute, so `45m` → `44m` lands on time) at the cost of one struct comparison per tick, with no repaint until the text genuinely changes.
+
+## Scope
+
+The colon only exists in the **1h–24h** range — that is the shape `compactResetTime` emits. Below an hour (`45m`), above a day (`2d`), and the sub-minute `soon` have no separator to pulse. Those labels get the self-driven tick but no animation. Widening the animation would mean changing the compact time format itself, which is a separate decision.
+
+## Files
+
+| File | Change |
+|---|---|
+| `Sources/Domain/Provider/CountdownColon.swift` | New — locates countdown colons |
+| `Sources/Domain/Monitor/ObservationRenderSync.swift` | New `refreshNow()` |
+| `Sources/App/StatusItemLabelDriver.swift` | Blink timer + lifecycle, `LabelContent.colonVisible`, `CountdownColonStyle`, both renderers |
+
+## Tests
+
+Logic lives in Domain because the project has no App test target (`DomainTests`, `InfrastructureTests`, `AcceptanceTests` only); the App layer keeps only the drawing.
+
+- `Tests/DomainTests/Provider/CountdownColonTests.swift` — 12 tests: H:MM detection, dual-window labels, `45m`/`2d`/empty labels, colons that are not countdowns (`acct:main`, `4:4m`, `4: 40`), single-character ranges, and `NSRange` conversion against multi-byte text (`·`).
+- `Tests/DomainTests/Monitor/ObservationRenderSyncTests.swift` — 5 added tests for `refreshNow()`, including that it leaves observation armed so later state changes still render.


### PR DESCRIPTION
## Problem

The menu bar duration readout (`0h 98% · 4:40`) computed the correct value on every draw — `MenuBarDurationDisplay.text` is computed precisely so it reflects the current wall clock — but **nothing caused a draw on a time basis**.

The label paints through `ObservationRenderSync`, which re-runs only when an `@Observable` property it read changes, and wall-clock time is not observable. So the countdown advanced only as a side effect of something else: a probe result, a Claude Code hook event mutating `sessionMonitor.activeSession`, system wake, or opening the dropdown.

The hook path is why it *looked* like it worked — while Claude Code runs, `PreToolUse`/`PostToolUse`/`Stop` fire constantly and repaint the label many times a minute. With Claude Code idle and `app.backgroundSyncEnabled` defaulting to `false`, the label could sit visibly stale. A stale-but-plausible countdown is worse than an obviously missing one: nothing distinguishes a correct `4:40` from one frozen twenty minutes ago.

## Change

- **0.5s tick**, started/stopped by a `blinkSync` watching `menuBarDurationEnabled` (mirrors the existing `loopSync` pattern). The countdown now advances within half a second of the true minute boundary regardless of hook traffic or refresh setting. Timer runs in `RunLoop.common` mode so an open menu doesn't stall it.
- **Pulsing colon** — in H:MM range the `:` fades to 25% alpha on alternate ticks, the cadence a digital clock blinks its separator at. Applies to both the single-line and stacked layouts (sharing one phase, so the two colons pulse together).
- No new setting; the pulse rides on the existing "Show duration" toggle.

```
0.0s   0h 98% · 4:40 | Fable 22% · 2d
0.5s   0h 98% · 4 40 | Fable 22% · 2d     ← colon at 25% alpha (still drawn)
1.0s   0h 98% · 4:40 | Fable 22% · 2d
```

## Two design decisions

**The colon fades, it never disappears.** The label draws in `monospacedDigitSystemFont`, where only the *digits* are fixed-width — punctuation stays proportional. Substituting a space would change the label width twice a second and shove every menu bar item to its left. The glyph always draws at full size; only its alpha changes, so metrics are identical in both phases.

**`refreshNow()` instead of `renderNow()`.** Each `ObservationRenderSync.sync()` arms a *new* `withObservationTracking` registration, and a registration is only torn down when it fires. Ticking at 2 Hz through `renderNow()` would accumulate ~1,200 armed registrations over ten idle minutes, then fire the entire backlog in one burst on the next probe result, each spawning a Task that re-arms. `refreshNow()` re-reads and renders **without** arming a new registration — safe because the last real `sync()`'s registration is still armed and still catches changes — and keeps the equality check `renderNow()` deliberately bypasses. That check is what stops a colon-less `2d` label from repainting on every tick.

## Scope

The colon only exists in the **1h–24h** range, which is the shape `compactResetTime` emits. `45m`, `2d`, and `soon` have no separator to animate — those get the freshness fix but no pulse. Widening it would mean changing the compact time format itself, a separate decision.

## Tests

Detection logic lives in Domain because the project has no App test target (`DomainTests` / `InfrastructureTests` / `AcceptanceTests` only); the App layer keeps only the drawing.

- `CountdownColonTests` — 12 new tests: H:MM detection, dual-window labels, `45m`/`2d`/empty labels, colons that aren't countdowns (`acct:main`, `4:4m`, `4: 40`), single-character ranges, `NSRange` conversion against multi-byte text (`·`).
- `ObservationRenderSyncTests` — 5 added tests for `refreshNow()`, including that it leaves observation armed so later state changes still render.

Full suite green: **1086 tests passed**, plus the 24 in the two affected suites after the additions.

## Not verified

The 25% alpha and 0.5s cadence are visual judgments that have not been checked on screen — build and tests pass, but nobody has watched the colon pulse in a real menu bar yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a subtle blinking effect to countdown colons in menu bar duration displays.
  - Supported both single-line and stacked layouts while preserving label width.
  - Kept non-countdown formats static.

- **Documentation**
  - Added documentation covering countdown behavior, supported formats, and display refresh handling.

- **Tests**
  - Added coverage for countdown-colon detection and immediate display refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->