### PR TITLE
feat(ui): hoist shared reset and fill quota bars by usage

### DIFF
--- a/Sources/App/Views/MenuContentView.swift
+++ b/Sources/App/Views/MenuContentView.swift
@@ -24,6 +24,9 @@ struct MenuContentView: View {
     @State private var showSharePass = false
     @State private var settings = AppSettings.shared
     @State private var hasRequestedNotificationPermission = false
+    @State private var pillsOverflow = false
+    @State private var pillsContentWidth: CGFloat = 0
+    @State private var pillsViewportWidth: CGFloat = 0
 
     /// The currently selected provider ID (from monitor, which is @Observable)
     private var selectedProviderId: String {
@@ -364,10 +367,49 @@ struct MenuContentView: View {
                 }
             }
             .background(HorizontalScrollBooster())
+            .overlay {
+                GeometryReader { geo in
+                    Color.clear.preference(key: PillsContentWidthKey.self, value: geo.size.width)
+                }
+            }
+            .fixedSize(horizontal: true, vertical: false)
+        }
+        .background(
+            GeometryReader { geo in
+                Color.clear.preference(key: PillsViewportWidthKey.self, value: geo.size.width)
+            }
+        )
+        .onPreferenceChange(PillsContentWidthKey.self) { contentWidth in
+            updatePillsOverflow(contentWidth: contentWidth)
+        }
+        .onPreferenceChange(PillsViewportWidthKey.self) { viewportWidth in
+            updatePillsOverflow(viewportWidth: viewportWidth)
+        }
+        .mask {
+            HStack(spacing: 0) {
+                Rectangle().fill(.white)
+                if pillsOverflow {
+                    LinearGradient(
+                        colors: [.white, .clear],
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                    .frame(width: 28)
+                }
+            }
         }
         .opacity(animateIn ? 1 : 0)
         .offset(y: animateIn ? 0 : 10)
         .animation(.easeOut(duration: 0.5).delay(0.1), value: animateIn)
+    }
+
+    private func updatePillsOverflow(contentWidth: CGFloat? = nil, viewportWidth: CGFloat? = nil) {
+        if let contentWidth { pillsContentWidth = contentWidth }
+        if let viewportWidth { pillsViewportWidth = viewportWidth }
+        let overflows = pillsViewportWidth > 0 && pillsContentWidth > pillsViewportWidth + 1
+        if pillsOverflow != overflows {
+            pillsOverflow = overflows
+        }
     }
 
     // MARK: - Metrics Content
@@ -535,6 +577,7 @@ struct MenuContentView: View {
         // cards to collapse; the note renders inline in the header.
         let isNoteOnly = group.quotas.isEmpty
         let isCollapsed = !isNoteOnly && collapsedQuotaGroups.contains(group.id)
+        let sharedReset = group.quotas.sharedResetDescription()
         return VStack(alignment: .leading, spacing: 8) {
             Button {
                 withAnimation(.easeOut(duration: 0.15)) {
@@ -592,14 +635,36 @@ struct MenuContentView: View {
                         .foregroundStyle(theme.textTertiary)
                 }
 
+                if let sharedReset {
+                    sharedResetRow(sharedReset)
+                }
+
                 TwoColumnCardGrid(
                     items: Array(group.quotas.enumerated()),
                     id: \.element.quotaType
                 ) { entry in
-                    WrappedStatCard(quota: entry.element, delay: baseDelay + Double(entry.offset) * 0.08)
+                    WrappedStatCard(
+                        quota: entry.element,
+                        delay: baseDelay + Double(entry.offset) * 0.08,
+                        showsReset: sharedReset == nil
+                    )
                 }
             }
         }
+    }
+
+    private func sharedResetRow(_ text: String) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: "clock.fill")
+                .font(.system(size: 8))
+
+            Text(text)
+                .font(.system(size: 10, weight: .medium, design: theme.fontDesign))
+
+            Spacer(minLength: 0)
+        }
+        .foregroundStyle(theme.textTertiary)
+        .padding(.horizontal, 4)
     }
 
     @ViewBuilder
@@ -609,12 +674,26 @@ struct MenuContentView: View {
             // account lacks quota data (note-only sections must still render).
             if snapshot.hasQuotaGroups {
                 quotaGroupSections(snapshot: snapshot)
-            } else if !snapshot.quotas.isEmpty {
+            }
+
+            if !snapshot.hasQuotaGroups, !snapshot.quotas.isEmpty {
+                let sharedReset = snapshot.quotas.sharedResetDescription()
+                if let sharedReset {
+                    sharedResetRow(sharedReset)
+                }
+            }
+
+            if !snapshot.hasQuotaGroups, !snapshot.quotas.isEmpty {
+                let sharedReset = snapshot.quotas.sharedResetDescription()
                 TwoColumnCardGrid(
                     items: Array(snapshot.quotas.enumerated()),
                     id: \.element.quotaType
                 ) { entry in
-                    WrappedStatCard(quota: entry.element, delay: Double(entry.offset) * 0.08)
+                    WrappedStatCard(
+                        quota: entry.element,
+                        delay: Double(entry.offset) * 0.08,
+                        showsReset: sharedReset == nil
+                    )
                 }
             }
 
@@ -920,6 +999,22 @@ struct ProviderPill: View {
     }
 }
 
+// MARK: - Provider Pill Overflow
+
+private struct PillsContentWidthKey: PreferenceKey {
+    static var defaultValue: CGFloat { 0 }
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
+private struct PillsViewportWidthKey: PreferenceKey {
+    static var defaultValue: CGFloat { 0 }
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
+
 // MARK: - Two-Column Card Grid
 
 /// Non-lazy two-column grid for popover cards.
@@ -994,6 +1089,7 @@ struct TwoColumnCardGrid<Item, ID: Hashable, Cell: View>: View {
 struct WrappedStatCard: View {
     let quota: UsageQuota
     let delay: Double
+    var showsReset: Bool = true
 
     @Environment(\.appTheme) private var theme
     @State private var isHovering = false
@@ -1084,12 +1180,12 @@ struct WrappedStatCard: View {
                 } else {
                     HStack(alignment: .firstTextBaseline, spacing: 1) {
                         Text("\(Int(quota.displayPercent(mode: effectiveDisplayMode)))")
-                            .font(.system(size: 32, weight: .bold, design: theme.fontDesign))
+                            .font(.system(size: 26, weight: .bold, design: theme.fontDesign))
                             .foregroundStyle(effectiveDisplayMode == .pace ? paceColor : theme.textPrimary)
                             .contentTransition(.numericText())
 
                         Text("%")
-                            .font(.system(size: 16, weight: .medium, design: theme.fontDesign))
+                            .font(.system(size: 13, weight: .medium, design: theme.fontDesign))
                             .foregroundStyle(effectiveDisplayMode == .pace ? paceColor.opacity(0.7) : theme.textTertiary)
                     }
                 }
@@ -1100,18 +1196,6 @@ struct WrappedStatCard: View {
                     .font(.system(size: isCappedSpend ? 10 : 12, weight: .medium, design: theme.fontDesign))
                     .fixedSize()
                     .foregroundStyle(effectiveDisplayMode == .pace ? paceColor.opacity(0.8) : theme.textTertiary)
-            }
-
-            // Pace insight line
-            if effectiveDisplayMode == .pace, let insight = quota.paceInsight {
-                HStack(spacing: 3) {
-                    Image(systemName: "lightbulb.fill")
-                        .font(.system(size: 7))
-                    Text(insight)
-                        .font(.system(size: 8, weight: .medium, design: theme.fontDesign))
-                }
-                .foregroundStyle(paceColor.opacity(0.8))
-                .lineLimit(1)
             }
 
             // Progress bar with gradient and pace tick
@@ -1151,8 +1235,8 @@ struct WrappedStatCard: View {
             }
             .help(quota.paceTickHelp(mode: effectiveDisplayMode) ?? "")
 
-            // Reset info
-            if let resetText = quota.resetTimestampDescription ?? quota.resetText ?? quota.resetDescription {
+            // Reset info (hidden when the grid hoisted a shared countdown)
+            if showsReset, let resetText = quota.resetTimestampDescription ?? quota.resetText ?? quota.resetDescription {
                 HStack(spacing: 3) {
                     Image(systemName: "clock.fill")
                         .font(.system(size: 7))
@@ -1183,6 +1267,11 @@ struct WrappedStatCard: View {
     }
 
     private var iconName: String {
+        let title = (quota.compactTitle ?? quota.quotaType.displayName).lowercased()
+        if title.contains("build") { return "hammer.fill" }
+        if title.contains("chat") { return "bubble.left.fill" }
+        if title.contains("imagine") { return "sparkles" }
+
         switch quota.quotaType {
         case .session: return "bolt.fill"
         case .weekly: return "calendar.badge.clock"

--- a/Sources/Domain/Provider/UsageQuota.swift
+++ b/Sources/Domain/Provider/UsageQuota.swift
@@ -180,26 +180,24 @@ public struct UsageQuota: Sendable, Equatable, Hashable, Comparable {
         }
     }
 
-    /// Returns the percentage to use for progress bar width based on the display mode.
-    /// - In `.remaining` mode: bar fills from right to left as quota depletes
-    /// - In `.used` mode: bar fills from left to right as quota is consumed
-    /// - In `.pace` mode: bar shows remaining (same as remaining mode)
+    /// Returns the percentage to use for progress bar width.
+    ///
+    /// The bar always fills left-to-right as quota is consumed (`percentUsed`),
+    /// regardless of display mode. The headline number still follows
+    /// `displayPercent`; bar color still follows remaining/status.
     public func displayProgressPercent(mode: UsageDisplayMode) -> Double {
         switch mode {
-        case .remaining: percentRemaining
-        case .used: percentUsed
-        case .pace: percentRemaining
+        case .remaining, .used, .pace: percentUsed
         }
     }
 
-    /// Returns the expected progress bar position based on time elapsed and display mode.
-    /// This represents where the bar "should be" if usage were perfectly on pace.
-    /// Returns nil when reset time is unknown.
+    /// Returns the expected progress bar position based on time elapsed.
+    /// This is the used-scale tick: where the bar should sit if usage were
+    /// spread evenly across the window. Returns nil when reset time is unknown.
     public func expectedProgressPercent(mode: UsageDisplayMode) -> Double? {
         guard let percentTimeElapsed else { return nil }
         switch mode {
-        case .remaining, .pace: return 100 - percentTimeElapsed
-        case .used: return percentTimeElapsed
+        case .remaining, .used, .pace: return percentTimeElapsed
         }
     }
 
@@ -269,16 +267,11 @@ public struct UsageQuota: Sendable, Equatable, Hashable, Comparable {
     }
 
     /// Tooltip copy explaining the pace tick mark under the progress bar.
-    /// Mode-aware: describes where the bar would sit if usage were spread
+    /// Describes where the used-fill bar would sit if usage were spread
     /// evenly across the window. Returns nil when reset time is unknown.
     public func paceTickHelp(mode: UsageDisplayMode) -> String? {
         guard let expected = expectedProgressPercent(mode: mode) else { return nil }
-        let base = switch mode {
-        case .used:
-            "Pace marker: steady usage would have used ~\(Int(expected.rounded()))% by now"
-        case .remaining, .pace:
-            "Pace marker: steady usage would leave ~\(Int(expected.rounded()))% remaining by now"
-        }
+        let base = "Pace marker: steady usage would have used ~\(Int(expected.rounded()))% by now"
         guard let insight = paceInsight else { return base + "." }
         return base + " — " + insight.prefix(1).lowercased() + insight.dropFirst() + "."
     }
@@ -344,5 +337,23 @@ public struct UsageQuota: Sendable, Equatable, Hashable, Comparable {
 
     public static func < (lhs: UsageQuota, rhs: UsageQuota) -> Bool {
         lhs.percentRemaining < rhs.percentRemaining
+    }
+}
+
+public extension Collection where Element == UsageQuota {
+    /// Shared reset countdown when every quota resets at the same time.
+    ///
+    /// Returns a single `resetTimestampDescription` when there are at least two
+    /// quotas, every quota has a `resetsAt`, and those timestamps sit within
+    /// 60 seconds of each other. Otherwise nil — callers should keep per-card clocks.
+    func sharedResetDescription() -> String? {
+        guard count >= 2 else { return nil }
+        let dates = compactMap(\.resetsAt)
+        guard dates.count == count,
+              let earliest = dates.min(),
+              let latest = dates.max(),
+              latest.timeIntervalSince(earliest) <= 60
+        else { return nil }
+        return first?.resetTimestampDescription
     }
 }

--- a/Tests/DomainTests/Provider/UsagePaceTests.swift
+++ b/Tests/DomainTests/Provider/UsagePaceTests.swift
@@ -251,13 +251,13 @@ struct UsagePaceTests {
     }
 
     @Test
-    func `displayProgressPercent in pace mode returns percentRemaining`() {
+    func `displayProgressPercent in pace mode returns percentUsed`() {
         let quota = UsageQuota(
             percentRemaining: 30,
             quotaType: .session,
             providerId: "claude"
         )
-        #expect(quota.displayProgressPercent(mode: .pace) == 30)
+        #expect(quota.displayProgressPercent(mode: .pace) == 70)
     }
 
     // MARK: - Weekly Quota Pace

--- a/Tests/DomainTests/Provider/UsageQuotaTests.swift
+++ b/Tests/DomainTests/Provider/UsageQuotaTests.swift
@@ -302,12 +302,12 @@ struct UsageQuotaTests {
     }
 
     @Test
-    func `displayProgressPercent returns percentRemaining in remaining mode`() {
+    func `displayProgressPercent returns percentUsed in remaining mode`() {
         // Given
         let quota = UsageQuota(percentRemaining: 75, quotaType: .session, providerId: "claude")
 
-        // When & Then
-        #expect(quota.displayProgressPercent(mode: .remaining) == 75)
+        // When & Then - bar always encodes consumption
+        #expect(quota.displayProgressPercent(mode: .remaining) == 25)
     }
 
     @Test
@@ -331,12 +331,29 @@ struct UsageQuotaTests {
     }
 
     @Test
-    func `displayProgressPercent returns percentRemaining in pace mode`() {
+    func `displayProgressPercent returns percentUsed in pace mode`() {
         // Given
         let quota = UsageQuota(percentRemaining: 75, quotaType: .session, providerId: "claude")
 
-        // When & Then - pace mode progress bar shows remaining (same as remaining mode)
-        #expect(quota.displayProgressPercent(mode: .pace) == 75)
+        // When & Then - pace mode progress bar shows used (same as remaining/used)
+        #expect(quota.displayProgressPercent(mode: .pace) == 25)
+    }
+
+    @Test
+    func `expectedProgressPercent returns elapsed time on the used scale`() {
+        // Session is 5h. 1.25h remaining -> 75% elapsed -> tick at 75 used.
+        let quota = UsageQuota(
+            percentRemaining: 43,
+            quotaType: .session,
+            providerId: "claude",
+            resetsAt: Date().addingTimeInterval(1.25 * 3600)
+        )
+        let expectedRemaining = quota.expectedProgressPercent(mode: .remaining)!
+        let expectedUsed = quota.expectedProgressPercent(mode: .used)!
+        let expectedPace = quota.expectedProgressPercent(mode: .pace)!
+        #expect(expectedRemaining > 74 && expectedRemaining < 76)
+        #expect(expectedUsed > 74 && expectedUsed < 76)
+        #expect(expectedPace > 74 && expectedPace < 76)
     }
 
     // MARK: - Dollar-Based Quotas
@@ -544,8 +561,8 @@ struct UsageQuotaTests {
     }
 
     @Test
-    func `paceTickHelp explains expected remaining in remaining mode`() {
-        // 75% of a 5h window elapsed -> steady usage would leave ~25%.
+    func `paceTickHelp explains expected used in remaining mode`() {
+        // 75% of a 5h window elapsed -> steady usage would have used ~75%.
         let quota = UsageQuota(
             percentRemaining: 43,
             quotaType: .timeLimit("Z.ai 5h"),
@@ -554,7 +571,8 @@ struct UsageQuotaTests {
             windowDuration: 5 * 3600
         )
         let help = quota.paceTickHelp(mode: .remaining)!
-        #expect(help.contains("~25% remaining"))
+        #expect(help.contains("~75%"))
+        #expect(help.contains("used"))
         // 57 used vs 75 elapsed -> below expected usage, surfaced inline.
         #expect(help.contains("below expected usage"))
     }
@@ -581,5 +599,67 @@ struct UsageQuotaTests {
             providerId: "zai"
         )
         #expect(quota.paceTickHelp(mode: .remaining) == nil)
+    }
+
+    // MARK: - Shared Reset Description
+
+    @Test
+    func `sharedResetDescription returns countdown when all quotas share a reset`() {
+        let resetsAt = Date().addingTimeInterval(2.0 * 86400 + 5.0 * 3600 + 30.0 * 60 + 30)
+        let quotas = [
+            UsageQuota(percentRemaining: 0, quotaType: .weekly, providerId: "claude", resetsAt: resetsAt),
+            UsageQuota(percentRemaining: 13, quotaType: .timeLimit("Build"), providerId: "claude", resetsAt: resetsAt),
+            UsageQuota(percentRemaining: 93, quotaType: .timeLimit("Chat"), providerId: "claude", resetsAt: resetsAt)
+        ]
+
+        #expect(quotas.sharedResetDescription() == "Resets in 2d 5h 30m")
+    }
+
+    @Test
+    func `sharedResetDescription returns countdown when resets are within 60 seconds`() {
+        let base = Date().addingTimeInterval(3.0 * 3600 + 15.0 * 60 + 30)
+        let quotas = [
+            UsageQuota(percentRemaining: 10, quotaType: .weekly, providerId: "claude", resetsAt: base),
+            UsageQuota(percentRemaining: 20, quotaType: .timeLimit("Build"), providerId: "claude", resetsAt: base.addingTimeInterval(30))
+        ]
+
+        #expect(quotas.sharedResetDescription() == "Resets in 3h 15m")
+    }
+
+    @Test
+    func `sharedResetDescription is nil when reset windows differ`() {
+        let weekly = Date().addingTimeInterval(3 * 86400)
+        let session = Date().addingTimeInterval(4 * 3600)
+        let quotas = [
+            UsageQuota(percentRemaining: 10, quotaType: .weekly, providerId: "claude", resetsAt: weekly),
+            UsageQuota(percentRemaining: 80, quotaType: .session, providerId: "claude", resetsAt: session)
+        ]
+
+        #expect(quotas.sharedResetDescription() == nil)
+    }
+
+    @Test
+    func `sharedResetDescription is nil for a single quota`() {
+        let quotas = [
+            UsageQuota(
+                percentRemaining: 10,
+                quotaType: .weekly,
+                providerId: "claude",
+                resetsAt: Date().addingTimeInterval(86400)
+            )
+        ]
+
+        #expect(quotas.sharedResetDescription() == nil)
+    }
+
+    @Test
+    func `sharedResetDescription is nil when any quota lacks resetsAt`() {
+        let resetsAt = Date().addingTimeInterval(86400)
+        let quotas = [
+            UsageQuota(percentRemaining: 10, quotaType: .weekly, providerId: "claude", resetsAt: resetsAt),
+            UsageQuota(percentRemaining: 80, quotaType: .session, providerId: "claude")
+        ]
+
+        #expect(quotas.sharedResetDescription() == nil)
     }
 }


### PR DESCRIPTION
## Summary
- Hoist a shared reset countdown above the quota grid when all cards share the same window; keep per-card clocks when windows differ.
- Progress bars now fill by usage (left-to-right consumption) while the headline number stays remaining; pace insight moves to the bar tooltip.
- Add a trailing fade on overflowing provider pills and distinct icons for Build / Chat / Imagine.

## Test plan
- [ ] Open the Claude popover in pace mode with Weekly / Build / Chat / Imagine sharing a weekly reset — countdown appears once, not on every card.
- [ ] Confirm remaining % is unchanged and the bar grows as usage grows (0% remaining = full critical bar).
- [ ] Switch to a provider with session + weekly windows and confirm each card still shows its own reset.
- [ ] Hover the bar and confirm the pace insight is in the tooltip only.
- [ ] Enable enough providers that pills overflow and confirm a trailing fade.
- [ ] `tuist test ClaudeBar -- -only-testing:DomainTests`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider pills now show a fade indicator when additional options are hidden.
  * Quota cards can display a shared reset description when reset times align.
  * Quota icons now better reflect build, chat, and image-generation usage.

* **Improvements**
  * Progress bars and pace indicators now consistently show consumed usage.
  * Simplified quota card text and reduced percentage typography for improved readability.

* **Tests**
  * Added coverage for shared reset descriptions and updated usage-progress behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->