### PR TITLE
fix(menubar): attach to the status item we can actually draw into (#258)

### DIFF
--- a/Sources/App/ClaudeBarApp.swift
+++ b/Sources/App/ClaudeBarApp.swift
@@ -152,6 +152,7 @@ struct ClaudeBarApp: App {
             sessionMonitor: sessionMonitor
         )
         statusItemDriver.startMonitoringLifecycle()
+        statusItemDriver.startAttachLifecycle()
 
         // Load user extensions from ~/.claudebar/extensions/
         let extensionRegistry = ExtensionRegistry(

--- a/Sources/App/StatusItemLabelDriver.swift
+++ b/Sources/App/StatusItemLabelDriver.swift
@@ -33,6 +33,14 @@ final class StatusItemLabelDriver {
     private var blinkSync: ObservationRenderSync<Bool>?
     private var streamConsumer: Task<Void, Never>?
     private var wakeObserver: NSObjectProtocol?
+    private var screenObserver: NSObjectProtocol?
+
+    /// Polls for a status item we can actually draw into. See
+    /// `startAttachLifecycle` for why MenuBarExtraAccess alone isn't enough.
+    private var attachWatchdog: Task<Void, Never>?
+
+    /// One-shot latch so a missing button is logged once, not twice a second.
+    private var hasLoggedMissingButton = false
 
     /// Drives the countdown: every tick re-reads the label (picking up the
     /// current wall clock) and flips `blinkPhase`. See `startBlinkTimer`.
@@ -79,13 +87,34 @@ final class StatusItemLabelDriver {
         var colonVisible: Bool = true
     }
 
-    /// Attaches to the `NSStatusItem` exposed by MenuBarExtraAccess and starts
-    /// rendering. Repeated callbacks re-assert the image (cheap, idempotent).
+    /// Attaches to an `NSStatusItem` and starts rendering. Repeated callbacks
+    /// re-assert the image (cheap, idempotent).
+    ///
+    /// Rejects an item with no `button`, because every render into it would
+    /// silently no-op and the menu bar would show nothing but the 1x1
+    /// placeholder label — an invisible, unfindable status item with no route
+    /// to Settings (issue #258).
+    ///
+    /// That is reachable through MenuBarExtraAccess, which hands over
+    /// `statusItems[0]`. With "Displays have Separate Spaces" there is one
+    /// `NSStatusBarWindow` per screen — the real item plus one replicant per
+    /// additional display — and only the real one carries a button. Before
+    /// macOS 26 the replicant was a distinct class the library filtered out;
+    /// on macOS 26 both report `NSSceneStatusItem`, so its filter keeps both
+    /// and which one lands at index 0 is left to `NSApp.windows` ordering.
     func attach(_ statusItem: NSStatusItem) {
+        guard statusItem.button != nil else {
+            AppLog.ui.warning("Status item has no button (per-display replicant); looking for the real one")
+            startAttachWatchdog()
+            return
+        }
         guard self.statusItem !== statusItem else {
             labelSync?.renderNow()
             return
         }
+        attachWatchdog?.cancel()
+        attachWatchdog = nil
+        hasLoggedMissingButton = false
         self.statusItem = statusItem
         labelSync?.stop()
 
@@ -181,7 +210,15 @@ final class StatusItemLabelDriver {
     }
 
     private func render(_ content: LabelContent) {
-        guard let button = statusItem?.button else { return }
+        guard let button = statusItem?.button else {
+            // Loud but once: the symptom is a menu bar item that is invisible
+            // and unclickable, which otherwise leaves no trace in the log.
+            if !hasLoggedMissingButton {
+                hasLoggedMissingButton = true
+                AppLog.ui.error("Status item has no button — nothing can be drawn into the menu bar")
+            }
+            return
+        }
         // Skip when nothing changed and our image is still in place —
         // re-setting an identical image redraws the button and can flicker.
         if content == lastContent, let lastImage, button.image === lastImage {
@@ -292,6 +329,87 @@ final class StatusItemLabelDriver {
         }
         composed.isTemplate = false
         return composed
+    }
+
+    // MARK: - Attachment Lifecycle
+
+    /// Retry cadence for finding the status item: fast at first (it normally
+    /// exists within a second of launch), then backing off to cover a slow
+    /// first launch. Gives up after roughly two minutes.
+    private static let attachRetryDelays: [Double] =
+        Array(repeating: 0.25, count: 20)   // first 5s
+        + Array(repeating: 1.0, count: 25)  // to 30s
+        + Array(repeating: 5.0, count: 18)  // to ~2min
+
+    /// Starts owning the status-item attachment instead of depending solely on
+    /// MenuBarExtraAccess. Call once at app startup, alongside
+    /// `startMonitoringLifecycle`.
+    ///
+    /// The library's introspection has two failure modes that both leave the
+    /// menu bar permanently blank (issue #258): it hands over `statusItems[0]`,
+    /// which on macOS 26 can be the button-less per-display replicant (see
+    /// `attach`), and it polls for only two seconds before giving up for the
+    /// rest of the app's lifetime. Since v0.4.69 every visible pixel is drawn
+    /// into `button.image` — the SwiftUI label is a 1x1 transparent
+    /// placeholder — so either failure means no icon, no width, and no way to
+    /// open Settings.
+    func startAttachLifecycle() {
+        startAttachWatchdog()
+
+        guard screenObserver == nil else { return }
+        // Attaching or detaching a display rebuilds the status bar windows, so
+        // the item we hold can turn into a replicant. Re-check on every change.
+        screenObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.revalidateAttachment() }
+        }
+    }
+
+    /// Polls for a drawable status item until one turns up. A no-op while we
+    /// already hold one, and while a poll is already running.
+    private func startAttachWatchdog() {
+        guard attachWatchdog == nil, statusItem?.button == nil else { return }
+        attachWatchdog = Task { @MainActor [weak self] in
+            // Release the slot however this ends, so a later display change can
+            // start a fresh search instead of being locked out by a spent task.
+            defer { self?.attachWatchdog = nil }
+            for delay in Self.attachRetryDelays {
+                try? await Task.sleep(for: .seconds(delay))
+                guard !Task.isCancelled, let self else { return }
+                guard self.statusItem?.button == nil else { return }
+                guard let item = Self.drawableStatusItem() else { continue }
+                AppLog.ui.notice("Attached to the status item via the watchdog")
+                self.attach(item)
+                return
+            }
+            AppLog.ui.error("No drawable status item found — the menu bar will stay blank")
+        }
+    }
+
+    /// Drops an item we can no longer draw into and goes looking for the real
+    /// one; otherwise just repaints, in case the menu bar was rebuilt stale.
+    private func revalidateAttachment() {
+        guard statusItem?.button == nil else {
+            labelSync?.renderNow()
+            return
+        }
+        statusItem = nil
+        startAttachWatchdog()
+    }
+
+    /// The app's own status items, read the way AppKit exposes them: every
+    /// `NSStatusBarWindow` carries its item under a private `statusItem` key.
+    /// Only the real item has a button — the per-display replicants do not —
+    /// so that, not position, is what identifies the one we can render into.
+    private static func drawableStatusItem() -> NSStatusItem? {
+        NSApplication.shared.windows
+            .filter { $0.className.contains("NSStatusBarWindow") }
+            .compactMap { window -> NSStatusItem? in
+                guard window.responds(to: Selector(("statusItem"))) else { return nil }
+                return window.value(forKey: "statusItem") as? NSStatusItem
+            }
+            .first { $0.button != nil }
     }
 
     // MARK: - Countdown Tick


### PR DESCRIPTION
Fixes #258.

On a multi-display Mac the menu bar item can render nothing at all — no icon, no width, no clickable surface, and therefore no way to reach Settings on first run.

## Root cause

`MenuBarExtraAccess` hands over `statusItems[0]`. With "Displays have Separate Spaces" there is one `NSStatusBarWindow` per screen — the real status item plus one replicant per additional display — and **only the real one carries a `button`**. The library's filter is meant to drop the replicants by class name, and did while they were a distinct `NSStatusItemReplicant`.

On macOS 26 both the real item and its replicants report `NSSceneStatusItem`, so the filter keeps all of them and which one lands at index 0 is left to `NSApp.windows` ordering. Confirmed with a minimal `MenuBarExtra` probe app on macOS 26.4:

```
window=NSStatusBarWindow statusItem=NSSceneStatusItem button=NSStatusBarButton   ← real
window=NSStatusBarWindow statusItem=NSSceneStatusItem button=nil                 ← replicant
```

Landing on the button-less one is terminal: `render` bails on `guard let button` and silently drops every repaint. Since v0.4.69 (#192) the SwiftUI label is a 1×1 transparent placeholder and every visible pixel is drawn into `button.image`, so nothing is left to see. Measured by driving each item in turn:

```
attach to replicant     16pt → 16pt   (never grows; transparent nothing)
attach to real item     16pt → 34pt   (icon renders)
```

Window ordering is stable per machine, which is why relaunching and a `--zap` reinstall changed nothing for the reporter.

The same symptom is reachable a second way: the library polls for 2 seconds and then gives up for the rest of the app's lifetime, so a slow launch also leaves the label undrawn forever.

### Why no reports until now

Four things have to line up, and the first only became possible 12 releases ago:

1. v0.4.69 (`4971992`) replaced the SwiftUI `StatusBarIcon` label with a 1×1 transparent placeholder. Before that the label always drew something regardless of introspection.
2. macOS 26 — pre-26 the class-name filter correctly dropped replicants.
3. Two or more displays with "Displays have Separate Spaces". Single-display users only ever have one `NSStatusBarWindow`.
4. Unlucky `NSApp.windows` ordering. On my two-display machine index 0 was the real item in 8/8 runs.

## Fix

The driver now owns its attachment rather than depending solely on the library:

- `attach` rejects an item with no button instead of accepting it and then silently dropping every render.
- `startAttachLifecycle` polls `NSApp.windows` for the status item that *has* a button — identifying it by drawability rather than by position — backing off over ~2 minutes. This covers both library failure modes.
- Re-validates on `didChangeScreenParametersNotification`, since attaching or detaching a display rebuilds the status bar windows and can turn the item you hold into a replicant.
- `render` logs once at error level when it has no button. The old guard swallowed this, which is why the reporter's log capture looked clean.

## Verification

- **Rescue path**: stubbed out the `menuBarExtraAccess` handover entirely to simulate the reporter's machine — the icon still renders, with `[INFO] [ui] Attached to the status item via the watchdog` in the log. Experiment then reverted.
- **No regression**: with the handover restored the library still wins the race and the watchdog stands down silently — no log noise, icon renders as before.
- **Fresh install**: reproduced a clean first run (removed `~/.claudebar` and the prefs domain) — the `chart.bar.fill` placeholder icon renders correctly, so the issue's "show a placeholder icon" request was already satisfied; the failure was upstream of it.
- `tuist test` passes.

## Note

`Sources/App/` has no test target, so this is verified by the reproduction harness rather than a unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012rgV2eEoXTbYGbq5bCHSUi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved menu bar item attachment reliability on macOS 26.
  - Prevented invisible or unclickable menu bar items when the initial attachment is unavailable.
  - Automatically retries attachment and refreshes the item after display configuration changes.
  - Added clearer error handling when a usable menu bar item cannot be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->