### PR TITLE
fix(opencode): fetch Go usage from the official usage API (#249)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- OpenCode Go usage now comes from the official `/zen/go/v1/usage` endpoint, so the numbers match the opencode.ai dashboard instead of a local-DB estimate that only saw this machine's messages (#249). The API key is read from `OPENCODE_API_KEY` or opencode's `auth.json`; the local-DB probe remains as a fallback when no key is configured.
+
 ---
 
 ## [0.4.82] - 2026-08-24

--- a/Sources/App/ClaudeBarApp.swift
+++ b/Sources/App/ClaudeBarApp.swift
@@ -117,7 +117,7 @@ struct ClaudeBarApp: App {
                 settingsRepository: settingsRepository
             ),
             OpenCodeProvider(
-                probe: OpenCodeUsageProbe(),
+                probe: OpenCodeAPIUsageProbe(fallback: OpenCodeUsageProbe()),
                 settingsRepository: settingsRepository
             ),
             OmpProvider(

--- a/Sources/Domain/Provider/OpenCode/OpenCodeProvider.swift
+++ b/Sources/Domain/Provider/OpenCode/OpenCodeProvider.swift
@@ -1,7 +1,8 @@
 import Foundation
 import Observation
 
-/// OpenCode Go — monitors 5h ($12), weekly ($30), monthly ($60) usage from local opencode DB.
+/// OpenCode Go — monitors rolling (5h), weekly, and monthly usage via the
+/// opencode.ai usage API, falling back to the local opencode DB when no API key is configured.
 @MainActor
 @Observable
 public final class OpenCodeProvider: AIProvider {

--- a/Sources/Infrastructure/OpenCode/OpenCodeAPIUsageProbe.swift
+++ b/Sources/Infrastructure/OpenCode/OpenCodeAPIUsageProbe.swift
@@ -1,0 +1,177 @@
+import Foundation
+import Domain
+
+/// Fetches OpenCode Go usage from the official usage endpoint
+/// (`GET https://opencode.ai/zen/go/v1/usage`, anomalyco/opencode#16513).
+///
+/// The server computes the same rolling / weekly / monthly figures the
+/// opencode.ai dashboard shows, so this replaces the local-DB estimate
+/// (which only sees this machine's messages). When no API key is configured
+/// the probe defers to an optional `fallback` (typically `OpenCodeUsageProbe`).
+///
+/// Response shape:
+/// ```json
+/// { "usage": {
+///     "rolling": { "status": "ok", "percent": 17, "resetsAt": "2026-08-24T12:00:00.000Z" },
+///     "weekly":  { ... },
+///     "monthly": { ... } } }
+/// ```
+/// `percent` is *used*; `status` is `"ok"` or `"rate-limited"`.
+public struct OpenCodeAPIUsageProbe: UsageProbe, @unchecked Sendable {
+    static let usageURL = URL(string: "https://opencode.ai/zen/go/v1/usage")!
+    static let providerId = "opencode-go"
+    private static let reloginHint = "Run `opencode auth login` and pick OpenCode Zen to refresh your API key."
+
+    private let credentialLoader: OpenCodeCredentialLoader
+    private let networkClient: any NetworkClient
+    private let fallback: (any UsageProbe)?
+    private let timeout: TimeInterval
+
+    public init(
+        credentialLoader: OpenCodeCredentialLoader = OpenCodeCredentialLoader(),
+        networkClient: any NetworkClient = URLSession.shared,
+        fallback: (any UsageProbe)? = nil,
+        timeout: TimeInterval = 15
+    ) {
+        self.credentialLoader = credentialLoader
+        self.networkClient = networkClient
+        self.fallback = fallback
+        self.timeout = timeout
+    }
+
+    // MARK: - UsageProbe
+
+    public func isAvailable() async -> Bool {
+        if credentialLoader.loadAPIKey() != nil {
+            return true
+        }
+        if let fallback {
+            return await fallback.isAvailable()
+        }
+        return false
+    }
+
+    public func probe() async throws -> UsageSnapshot {
+        guard let apiKey = credentialLoader.loadAPIKey() else {
+            if let fallback {
+                AppLog.probes.info("OpenCode: No API key found, falling back to local DB probe")
+                return try await fallback.probe()
+            }
+            AppLog.probes.error("OpenCode: No API key found")
+            throw ProbeError.authenticationRequired
+        }
+
+        let data = try await fetchUsage(apiKey: apiKey)
+        let snapshot = try Self.parseResponse(data)
+
+        let summary = snapshot.quotas
+            .map { "\($0.quotaType.displayName) \(Int($0.percentRemaining))%" }
+            .joined(separator: ", ")
+        AppLog.probes.info("OpenCode API probe success: \(summary)")
+
+        return snapshot
+    }
+
+    // MARK: - Network
+
+    private func fetchUsage(apiKey: String) async throws -> Data {
+        var request = URLRequest(url: Self.usageURL)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = timeout
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await networkClient.request(request)
+        } catch {
+            AppLog.probes.error("OpenCode: Network error: \(error.localizedDescription)")
+            throw ProbeError.executionFailed("Network error: \(error.localizedDescription)")
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ProbeError.executionFailed("Invalid response")
+        }
+
+        switch httpResponse.statusCode {
+        case 200:
+            return data
+        case 401:
+            AppLog.probes.error("OpenCode: API key rejected (HTTP 401)")
+            throw ProbeError.sessionExpired(hint: Self.reloginHint)
+        case 403:
+            AppLog.probes.error("OpenCode: No Go subscription for this key (HTTP 403)")
+            throw ProbeError.subscriptionRequired
+        default:
+            AppLog.probes.error("OpenCode: HTTP error \(httpResponse.statusCode)")
+            throw ProbeError.executionFailed("HTTP error: \(httpResponse.statusCode)")
+        }
+    }
+
+    // MARK: - Parsing (testable)
+
+    private struct Window {
+        let key: String
+        let quotaType: QuotaType
+        let duration: TimeInterval?
+    }
+
+    private static let windows: [Window] = [
+        Window(key: "rolling", quotaType: .session, duration: 5 * 3600),
+        Window(key: "weekly", quotaType: .weekly, duration: 7 * 86400),
+        Window(key: "monthly", quotaType: .timeLimit("Monthly"), duration: nil),
+    ]
+
+    static func parseResponse(_ data: Data, now: Date = Date()) throws -> UsageSnapshot {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw ProbeError.parseFailed("Failed to parse usage response as JSON")
+        }
+        guard let usage = root["usage"] as? [String: Any] else {
+            throw ProbeError.parseFailed("Missing 'usage' in response")
+        }
+
+        var quotas: [UsageQuota] = []
+        for window in windows {
+            guard let entry = usage[window.key] as? [String: Any],
+                  let percentUsed = doubleValue(entry["percent"]) else {
+                continue
+            }
+            let rateLimited = (entry["status"] as? String) == "rate-limited"
+            let remaining = rateLimited ? 0 : max(0, min(100, 100 - percentUsed))
+
+            quotas.append(UsageQuota(
+                percentRemaining: remaining,
+                quotaType: window.quotaType,
+                providerId: providerId,
+                resetsAt: parseDate(entry["resetsAt"] as? String),
+                windowDuration: window.duration
+            ))
+        }
+
+        guard !quotas.isEmpty else {
+            throw ProbeError.parseFailed("No usage windows in response")
+        }
+
+        return UsageSnapshot(providerId: providerId, quotas: quotas, capturedAt: now)
+    }
+
+    private static func doubleValue(_ value: Any?) -> Double? {
+        switch value {
+        case let d as Double: return d
+        case let i as Int: return Double(i)
+        case let n as NSNumber: return n.doubleValue
+        case let s as String: return Double(s)
+        default: return nil
+        }
+    }
+
+    private static func parseDate(_ string: String?) -> Date? {
+        guard let string else { return nil }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: string) { return date }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: string)
+    }
+}

--- a/Sources/Infrastructure/OpenCode/OpenCodeCredentialLoader.swift
+++ b/Sources/Infrastructure/OpenCode/OpenCodeCredentialLoader.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Domain
+
+/// Resolves the OpenCode Go API key that the `opencode` CLI uses for Zen.
+///
+/// Lookup order:
+/// 1. `OPENCODE_API_KEY` environment variable
+/// 2. `opencode-go` entry in opencode's auth store
+/// 3. `opencode` (shared Zen) entry in opencode's auth store
+///
+/// The auth store lives at `$XDG_DATA_HOME/opencode/auth.json`
+/// (default `~/.local/share/opencode/auth.json`) and is keyed by provider id:
+/// ```json
+/// {
+///   "opencode": { "type": "api", "key": "sk-..." },
+///   "anthropic": { "type": "oauth", "access": "...", "refresh": "...", "expires": 0 }
+/// }
+/// ```
+public struct OpenCodeCredentialLoader: Sendable {
+    static let envVar = "OPENCODE_API_KEY"
+    static let entryKeys = ["opencode-go", "opencode"]
+
+    private let homeDirectory: String
+    private let environment: [String: String]
+
+    public init(
+        homeDirectory: String = NSHomeDirectory(),
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) {
+        self.homeDirectory = homeDirectory
+        self.environment = environment
+    }
+
+    /// Path to opencode's `auth.json`.
+    public var authFilePath: String {
+        let dataHome: String
+        if let xdg = environment["XDG_DATA_HOME"], !xdg.isEmpty {
+            dataHome = xdg
+        } else {
+            dataHome = (homeDirectory as NSString).appendingPathComponent(".local/share")
+        }
+        return (dataHome as NSString).appendingPathComponent("opencode/auth.json")
+    }
+
+    /// Returns the Go API key, or nil when none is configured.
+    public func loadAPIKey() -> String? {
+        if let envKey = environment[Self.envVar]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !envKey.isEmpty {
+            return envKey
+        }
+
+        let path = authFilePath
+        guard FileManager.default.fileExists(atPath: path) else {
+            return nil
+        }
+
+        do {
+            let data = try Data(contentsOf: URL(fileURLWithPath: path))
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return nil
+            }
+            for entryKey in Self.entryKeys {
+                if let entry = json[entryKey] as? [String: Any],
+                   let key = entry["key"] as? String,
+                   !key.isEmpty {
+                    return key
+                }
+            }
+            return nil
+        } catch {
+            AppLog.credentials.error("Failed to load OpenCode credentials from file: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/Tests/InfrastructureTests/OpenCode/OpenCodeAPIUsageProbeParsingTests.swift
+++ b/Tests/InfrastructureTests/OpenCode/OpenCodeAPIUsageProbeParsingTests.swift
@@ -54,10 +54,10 @@ struct OpenCodeAPIUsageProbeParsingTests {
         let snapshot = try OpenCodeAPIUsageProbe.parseResponse(Self.usageJSON)
 
         let session = try #require(snapshot.quotas.first { $0.quotaType == .session })
-        #expect(session.windowDuration == 5 * 3600)
+        #expect(session.windowDuration == TimeInterval(5 * 3600))
 
         let weekly = try #require(snapshot.quotas.first { $0.quotaType == .weekly })
-        #expect(weekly.windowDuration == 7 * 86400)
+        #expect(weekly.windowDuration == TimeInterval(7 * 86400))
     }
 
     @Test

--- a/Tests/InfrastructureTests/OpenCode/OpenCodeAPIUsageProbeParsingTests.swift
+++ b/Tests/InfrastructureTests/OpenCode/OpenCodeAPIUsageProbeParsingTests.swift
@@ -1,0 +1,123 @@
+import Testing
+import Foundation
+@testable import Infrastructure
+@testable import Domain
+
+@Suite("OpenCodeAPIUsageProbe Parsing Tests")
+struct OpenCodeAPIUsageProbeParsingTests {
+
+    /// Shape returned by `GET https://opencode.ai/zen/go/v1/usage`
+    /// (anomalyco/opencode#16513). `percent` is *used*, `resetsAt` is absolute.
+    static let usageJSON = Data("""
+    {
+      "usage": {
+        "rolling": { "status": "ok", "percent": 1, "resetsAt": "2026-08-24T15:34:00.000Z" },
+        "weekly":  { "status": "ok", "percent": 17, "resetsAt": "2026-08-29T00:00:00.000Z" },
+        "monthly": { "status": "rate-limited", "percent": 100, "resetsAt": "2026-09-21T13:00:00.000Z" }
+      }
+    }
+    """.utf8)
+
+    @Test
+    func `parses three quotas mapping used percent to remaining`() throws {
+        let snapshot = try OpenCodeAPIUsageProbe.parseResponse(Self.usageJSON)
+
+        #expect(snapshot.providerId == "opencode-go")
+        #expect(snapshot.quotas.count == 3)
+
+        let session = try #require(snapshot.quotas.first { $0.quotaType == .session })
+        #expect(session.percentRemaining == 99)
+
+        let weekly = try #require(snapshot.quotas.first { $0.quotaType == .weekly })
+        #expect(weekly.percentRemaining == 83)
+
+        let monthly = try #require(snapshot.quotas.first { $0.quotaType == .timeLimit("Monthly") })
+        #expect(monthly.percentRemaining == 0)
+        #expect(monthly.isDepleted)
+    }
+
+    @Test
+    func `uses server-provided reset timestamps`() throws {
+        let snapshot = try OpenCodeAPIUsageProbe.parseResponse(Self.usageJSON)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        let session = try #require(snapshot.quotas.first { $0.quotaType == .session })
+        #expect(session.resetsAt == formatter.date(from: "2026-08-24T15:34:00.000Z"))
+
+        let weekly = try #require(snapshot.quotas.first { $0.quotaType == .weekly })
+        #expect(weekly.resetsAt == formatter.date(from: "2026-08-29T00:00:00.000Z"))
+    }
+
+    @Test
+    func `sets window durations so the UI can draw progress markers`() throws {
+        let snapshot = try OpenCodeAPIUsageProbe.parseResponse(Self.usageJSON)
+
+        let session = try #require(snapshot.quotas.first { $0.quotaType == .session })
+        #expect(session.windowDuration == 5 * 3600)
+
+        let weekly = try #require(snapshot.quotas.first { $0.quotaType == .weekly })
+        #expect(weekly.windowDuration == 7 * 86400)
+    }
+
+    @Test
+    func `rate-limited status clamps remaining to zero even when percent is below 100`() throws {
+        let json = Data("""
+        {"usage":{"rolling":{"status":"rate-limited","percent":98,"resetsAt":"2026-08-24T15:34:00.000Z"}}}
+        """.utf8)
+
+        let snapshot = try OpenCodeAPIUsageProbe.parseResponse(json)
+
+        let session = try #require(snapshot.quotas.first { $0.quotaType == .session })
+        #expect(session.percentRemaining == 0)
+    }
+
+    @Test
+    func `clamps over-100 usage to zero remaining`() throws {
+        let json = Data("""
+        {"usage":{"weekly":{"status":"ok","percent":130,"resetsAt":"2026-08-29T00:00:00.000Z"}}}
+        """.utf8)
+
+        let snapshot = try OpenCodeAPIUsageProbe.parseResponse(json)
+
+        #expect(snapshot.quotas.first?.percentRemaining == 0)
+    }
+
+    @Test
+    func `tolerates missing windows and fractional percents`() throws {
+        let json = Data("""
+        {"usage":{"rolling":{"status":"ok","percent":12.5,"resetsAt":"2026-08-24T15:34:00Z"}}}
+        """.utf8)
+
+        let snapshot = try OpenCodeAPIUsageProbe.parseResponse(json)
+
+        #expect(snapshot.quotas.count == 1)
+        #expect(snapshot.quotas.first?.percentRemaining == 87.5)
+        #expect(snapshot.quotas.first?.resetsAt != nil)
+    }
+
+    @Test
+    func `throws parseFailed when usage object is missing`() {
+        let json = Data(#"{"type":"error","error":{"type":"AuthError","message":"Unauthorized"}}"#.utf8)
+
+        #expect(throws: ProbeError.self) {
+            try OpenCodeAPIUsageProbe.parseResponse(json)
+        }
+    }
+
+    @Test
+    func `throws parseFailed when no windows could be parsed`() {
+        let json = Data(#"{"usage":{}}"#.utf8)
+
+        #expect(throws: ProbeError.parseFailed("No usage windows in response")) {
+            try OpenCodeAPIUsageProbe.parseResponse(json)
+        }
+    }
+
+    @Test
+    func `throws parseFailed on invalid JSON`() {
+        #expect(throws: ProbeError.self) {
+            try OpenCodeAPIUsageProbe.parseResponse(Data("<html>".utf8))
+        }
+    }
+}

--- a/Tests/InfrastructureTests/OpenCode/OpenCodeAPIUsageProbeTests.swift
+++ b/Tests/InfrastructureTests/OpenCode/OpenCodeAPIUsageProbeTests.swift
@@ -1,0 +1,163 @@
+import Testing
+import Foundation
+import Mockable
+@testable import Infrastructure
+@testable import Domain
+
+@Suite("OpenCodeAPIUsageProbe Tests")
+struct OpenCodeAPIUsageProbeTests {
+
+    // MARK: - Helpers
+
+    private func httpResponse(_ statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://opencode.ai/zen/go/v1/usage")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+
+    private func loader(apiKey: String?) -> OpenCodeCredentialLoader {
+        var env: [String: String] = ["XDG_DATA_HOME": "/nonexistent/\(UUID().uuidString)"]
+        if let apiKey { env["OPENCODE_API_KEY"] = apiKey }
+        return OpenCodeCredentialLoader(environment: env)
+    }
+
+    private static let errorJSON = Data(
+        #"{"type":"error","error":{"type":"AuthError","message":"Unauthorized"}}"#.utf8
+    )
+
+    // MARK: - isAvailable
+
+    @Test
+    func `isAvailable is true when an API key exists`() async {
+        let probe = OpenCodeAPIUsageProbe(credentialLoader: loader(apiKey: "k"), networkClient: MockNetworkClient())
+        #expect(await probe.isAvailable() == true)
+    }
+
+    @Test
+    func `isAvailable is false without a key and without a fallback`() async {
+        let probe = OpenCodeAPIUsageProbe(credentialLoader: loader(apiKey: nil), networkClient: MockNetworkClient())
+        #expect(await probe.isAvailable() == false)
+    }
+
+    @Test
+    func `isAvailable defers to fallback when no key exists`() async {
+        let fallback = MockUsageProbe()
+        given(fallback).isAvailable().willReturn(true)
+
+        let probe = OpenCodeAPIUsageProbe(
+            credentialLoader: loader(apiKey: nil),
+            networkClient: MockNetworkClient(),
+            fallback: fallback
+        )
+
+        #expect(await probe.isAvailable() == true)
+    }
+
+    // MARK: - probe
+
+    @Test
+    func `probe sends bearer key and returns parsed snapshot`() async throws {
+        let network = MockNetworkClient()
+        let captured = CapturedRequest()
+        given(network).request(.any).willProduce { request in
+            captured.set(request)
+            return (OpenCodeAPIUsageProbeParsingTests.usageJSON, self.httpResponse(200))
+        }
+
+        let probe = OpenCodeAPIUsageProbe(credentialLoader: loader(apiKey: "secret-key"), networkClient: network)
+        let snapshot = try await probe.probe()
+
+        #expect(snapshot.providerId == "opencode-go")
+        #expect(snapshot.quotas.count == 3)
+        #expect(captured.request?.url?.absoluteString == "https://opencode.ai/zen/go/v1/usage")
+        #expect(captured.request?.value(forHTTPHeaderField: "Authorization") == "Bearer secret-key")
+    }
+
+    @Test
+    func `probe throws authenticationRequired when no key and no fallback`() async {
+        let probe = OpenCodeAPIUsageProbe(credentialLoader: loader(apiKey: nil), networkClient: MockNetworkClient())
+
+        await #expect(throws: ProbeError.authenticationRequired) {
+            try await probe.probe()
+        }
+    }
+
+    @Test
+    func `probe uses fallback when no key is available`() async throws {
+        let fallback = MockUsageProbe()
+        let fallbackSnapshot = UsageSnapshot(
+            providerId: "opencode-go",
+            quotas: [UsageQuota(percentRemaining: 42, quotaType: .session, providerId: "opencode-go")],
+            capturedAt: Date()
+        )
+        given(fallback).probe().willReturn(fallbackSnapshot)
+
+        let probe = OpenCodeAPIUsageProbe(
+            credentialLoader: loader(apiKey: nil),
+            networkClient: MockNetworkClient(),
+            fallback: fallback
+        )
+        let snapshot = try await probe.probe()
+
+        #expect(snapshot.quotas.first?.percentRemaining == 42)
+    }
+
+    @Test
+    func `probe maps 401 to sessionExpired`() async {
+        let network = MockNetworkClient()
+        given(network).request(.any).willReturn((Self.errorJSON, httpResponse(401)))
+
+        let probe = OpenCodeAPIUsageProbe(credentialLoader: loader(apiKey: "stale"), networkClient: network)
+
+        await #expect(throws: ProbeError.sessionExpired()) {
+            try await probe.probe()
+        }
+    }
+
+    @Test
+    func `probe maps 403 to subscriptionRequired`() async {
+        let network = MockNetworkClient()
+        let body = Data(#"{"type":"error","error":{"type":"EntitlementError","message":"OpenCode Go subscription required."}}"#.utf8)
+        given(network).request(.any).willReturn((body, httpResponse(403)))
+
+        let probe = OpenCodeAPIUsageProbe(credentialLoader: loader(apiKey: "k"), networkClient: network)
+
+        await #expect(throws: ProbeError.subscriptionRequired) {
+            try await probe.probe()
+        }
+    }
+
+    @Test
+    func `probe maps other HTTP errors to executionFailed`() async {
+        let network = MockNetworkClient()
+        given(network).request(.any).willReturn((Data(), httpResponse(503)))
+
+        let probe = OpenCodeAPIUsageProbe(credentialLoader: loader(apiKey: "k"), networkClient: network)
+
+        await #expect(throws: ProbeError.executionFailed("HTTP error: 503")) {
+            try await probe.probe()
+        }
+    }
+
+    @Test
+    func `probe wraps transport errors as executionFailed`() async {
+        let network = MockNetworkClient()
+        given(network).request(.any).willThrow(URLError(.notConnectedToInternet))
+
+        let probe = OpenCodeAPIUsageProbe(credentialLoader: loader(apiKey: "k"), networkClient: network)
+
+        await #expect(throws: ProbeError.self) {
+            try await probe.probe()
+        }
+    }
+}
+
+private final class CapturedRequest: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _request: URLRequest?
+    var request: URLRequest? { lock.withLock { _request } }
+    func set(_ r: URLRequest) { lock.withLock { _request = r } }
+}

--- a/Tests/InfrastructureTests/OpenCode/OpenCodeCredentialLoaderTests.swift
+++ b/Tests/InfrastructureTests/OpenCode/OpenCodeCredentialLoaderTests.swift
@@ -1,0 +1,137 @@
+import Testing
+import Foundation
+@testable import Infrastructure
+@testable import Domain
+
+@Suite("OpenCodeCredentialLoader Tests")
+struct OpenCodeCredentialLoaderTests {
+
+    // MARK: - Helpers
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("opencode-credential-loader-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        return tempDir
+    }
+
+    /// Writes `<dataDir>/opencode/auth.json` — the layout opencode uses under `$XDG_DATA_HOME`.
+    private func writeAuthFile(dataDirectory: URL, json: [String: Any]) throws {
+        let dir = dataDirectory.appendingPathComponent("opencode", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let data = try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted])
+        try data.write(to: dir.appendingPathComponent("auth.json"))
+    }
+
+    // MARK: - Path resolution
+
+    @Test
+    func `defaults to ~/.local/share/opencode/auth.json`() {
+        let loader = OpenCodeCredentialLoader(homeDirectory: "/Users/alice", environment: [:])
+        #expect(loader.authFilePath == "/Users/alice/.local/share/opencode/auth.json")
+    }
+
+    @Test
+    func `honors XDG_DATA_HOME`() {
+        let loader = OpenCodeCredentialLoader(
+            homeDirectory: "/Users/alice",
+            environment: ["XDG_DATA_HOME": "/custom/data"]
+        )
+        #expect(loader.authFilePath == "/custom/data/opencode/auth.json")
+    }
+
+    // MARK: - Key resolution
+
+    @Test
+    func `loads api key from opencode-go entry`() throws {
+        let tempDir = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try writeAuthFile(dataDirectory: tempDir, json: [
+            "opencode-go": ["type": "api", "key": "go-key-123"]
+        ])
+
+        let loader = OpenCodeCredentialLoader(environment: ["XDG_DATA_HOME": tempDir.path])
+
+        #expect(loader.loadAPIKey() == "go-key-123")
+    }
+
+    @Test
+    func `falls back to shared opencode zen entry`() throws {
+        let tempDir = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try writeAuthFile(dataDirectory: tempDir, json: [
+            "anthropic": ["type": "oauth", "access": "a", "refresh": "r", "expires": 0],
+            "opencode": ["type": "api", "key": "zen-key-456"]
+        ])
+
+        let loader = OpenCodeCredentialLoader(environment: ["XDG_DATA_HOME": tempDir.path])
+
+        #expect(loader.loadAPIKey() == "zen-key-456")
+    }
+
+    @Test
+    func `prefers opencode-go entry over opencode entry`() throws {
+        let tempDir = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try writeAuthFile(dataDirectory: tempDir, json: [
+            "opencode": ["type": "api", "key": "zen-key"],
+            "opencode-go": ["type": "api", "key": "go-key"]
+        ])
+
+        let loader = OpenCodeCredentialLoader(environment: ["XDG_DATA_HOME": tempDir.path])
+
+        #expect(loader.loadAPIKey() == "go-key")
+    }
+
+    @Test
+    func `OPENCODE_API_KEY env var wins over auth file`() throws {
+        let tempDir = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try writeAuthFile(dataDirectory: tempDir, json: [
+            "opencode-go": ["type": "api", "key": "file-key"]
+        ])
+
+        let loader = OpenCodeCredentialLoader(
+            environment: ["XDG_DATA_HOME": tempDir.path, "OPENCODE_API_KEY": "env-key"]
+        )
+
+        #expect(loader.loadAPIKey() == "env-key")
+    }
+
+    @Test
+    func `returns nil when auth file missing`() throws {
+        let tempDir = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let loader = OpenCodeCredentialLoader(environment: ["XDG_DATA_HOME": tempDir.path])
+
+        #expect(loader.loadAPIKey() == nil)
+    }
+
+    @Test
+    func `returns nil when entries have no usable key`() throws {
+        let tempDir = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try writeAuthFile(dataDirectory: tempDir, json: [
+            "opencode": ["type": "api", "key": ""],
+            "openai": ["type": "api", "key": "unrelated"]
+        ])
+
+        let loader = OpenCodeCredentialLoader(environment: ["XDG_DATA_HOME": tempDir.path])
+
+        #expect(loader.loadAPIKey() == nil)
+    }
+
+    @Test
+    func `returns nil when auth file is not valid JSON`() throws {
+        let tempDir = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let dir = tempDir.appendingPathComponent("opencode", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try Data("not json".utf8).write(to: dir.appendingPathComponent("auth.json"))
+
+        let loader = OpenCodeCredentialLoader(environment: ["XDG_DATA_HOME": tempDir.path])
+
+        #expect(loader.loadAPIKey() == nil)
+    }
+}


### PR DESCRIPTION
Closes #249

## Problem
ClaudeBar's OpenCode Go card showed 2% / 5% / 8% used while the opencode.ai dashboard showed 1% / 17% / 29%. The reset timers matched, so the window math was fine — the *cost* was wrong. `OpenCodeUsageProbe` sums `message.cost` from the local `opencode db`, so it only sees this machine's messages and has to guess the server's limits and pricing.

## Fix
opencode now exposes `GET https://opencode.ai/zen/go/v1/usage` (anomalyco/opencode#16513, merged 2026-08-11) returning the same `rolling` / `weekly` / `monthly` `{status, percent, resetsAt}` the dashboard renders.

- **`OpenCodeCredentialLoader`** — resolves the Go API key from `OPENCODE_API_KEY`, else the `opencode-go` / `opencode` entry in `$XDG_DATA_HOME/opencode/auth.json` (default `~/.local/share/opencode/auth.json`).
- **`OpenCodeAPIUsageProbe`** — bearer-auth GET; maps `percent` (used) → `percentRemaining`, honors server `resetsAt`, `rate-limited` → 0% remaining; `401` → `sessionExpired`, `403` → `subscriptionRequired`.
- **Fallback** — when no key is configured the probe defers to the existing local-DB `OpenCodeUsageProbe`, so users on older opencode builds keep working.
- Wired in `ClaudeBarApp`: `OpenCodeAPIUsageProbe(fallback: OpenCodeUsageProbe())`.

## Tests
- `OpenCodeCredentialLoaderTests` — path resolution (default + `XDG_DATA_HOME`), key precedence, missing/invalid file.
- `OpenCodeAPIUsageProbeParsingTests` — percent mapping, reset dates, window durations, rate-limited/over-100 clamping, error bodies.
- `OpenCodeAPIUsageProbeTests` — bearer header, fallback behavior, 401/403/5xx/transport-error mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdVhUZgY4SKaYkuxdqR3AY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenCode Go usage now reflects official dashboard data from the OpenCode API.
  * API credentials are detected automatically from the environment or OpenCode settings.
  * Local usage tracking remains available as a fallback when no API key is configured.
  * Usage windows, remaining quotas, reset dates, and rate limits are supported.

* **Bug Fixes**
  * Corrected usage totals that previously reflected only activity on the current device.

* **Documentation**
  * Updated OpenCode Go usage monitoring documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->