### PR TITLE
fix(antigravity): track quota without the desktop app running (#201)

### DIFF
--- a/Sources/Infrastructure/Antigravity/AntigravityCloudCodeClient.swift
+++ b/Sources/Infrastructure/Antigravity/AntigravityCloudCodeClient.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Domain
+
+/// Google Cloud Code endpoints Antigravity uses for quota, reachable with the user's own OAuth
+/// access token even when the desktop app is closed.
+///
+/// The stored token is used as-is: it is refreshed whenever Antigravity or `agy` runs, and this
+/// client deliberately does not perform the OAuth refresh grant (that would require embedding
+/// Antigravity's OAuth client credentials). An expired token surfaces as "sign in again".
+///
+/// Reverse-engineered from the Antigravity app; endpoints may change without notice.
+struct AntigravityCloudCodeClient: Sendable {
+
+    enum Outcome: Sendable {
+        case ok(Data)
+        /// 401/403 — the token was rejected; the same token will fail on any base URL.
+        case authFailed
+        /// Transport error or any other non-2xx (404 on builds without the RPC, 5xx, …).
+        case unavailable
+    }
+
+    static let baseURLs = [
+        "https://daily-cloudcode-pa.googleapis.com",
+        "https://cloudcode-pa.googleapis.com"
+    ]
+    static let quotaSummaryPath = "/v1internal:retrieveUserQuotaSummary"
+    static let fetchModelsPath = "/v1internal:fetchAvailableModels"
+    static let loadCodeAssistPath = "/v1internal:loadCodeAssist"
+
+    private let networkClient: any NetworkClient
+    private let timeout: TimeInterval
+
+    init(networkClient: any NetworkClient, timeout: TimeInterval = 15.0) {
+        self.networkClient = networkClient
+        self.timeout = timeout
+    }
+
+    /// POSTs a JSON body to `path` on each base URL in turn.
+    func post(path: String, token: String, body: [String: String] = [:]) async -> Outcome {
+        let payload = (try? JSONSerialization.data(withJSONObject: body)) ?? Data("{}".utf8)
+
+        for base in Self.baseURLs {
+            guard let url = URL(string: base + path) else { continue }
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.timeoutInterval = timeout
+            request.httpBody = payload
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.setValue("application/json", forHTTPHeaderField: "Accept")
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+            request.setValue("antigravity", forHTTPHeaderField: "User-Agent")
+
+            guard let (data, response) = try? await networkClient.request(request),
+                  let http = response as? HTTPURLResponse else {
+                AppLog.network.debug("Antigravity: \(base)\(path) unreachable")
+                continue
+            }
+
+            if http.statusCode == 401 || http.statusCode == 403 {
+                AppLog.network.debug("Antigravity: \(path) rejected token (HTTP \(http.statusCode))")
+                return .authFailed
+            }
+            if (200..<300).contains(http.statusCode) {
+                return .ok(data)
+            }
+            AppLog.network.debug("Antigravity: \(base)\(path) returned HTTP \(http.statusCode)")
+        }
+        return .unavailable
+    }
+}

--- a/Sources/Infrastructure/Antigravity/AntigravityKeychainCredentialLoader.swift
+++ b/Sources/Infrastructure/Antigravity/AntigravityKeychainCredentialLoader.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Domain
+
+/// OAuth credentials the Antigravity app / `agy` CLI already stored on this Mac.
+public struct AntigravityOAuthCredentials: Sendable, Equatable {
+    public let accessToken: String?
+    public let refreshToken: String?
+    public let expiresAt: Date?
+
+    /// Treat a token with less than this left as expired and refresh proactively.
+    static let refreshBuffer: TimeInterval = 60
+
+    public init(accessToken: String?, refreshToken: String?, expiresAt: Date?) {
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+        self.expiresAt = expiresAt
+    }
+
+    /// Whether the stored access token is worth sending: present and (if the expiry is known) not about to expire.
+    public func hasUsableAccessToken(at now: Date = Date()) -> Bool {
+        guard let accessToken, !accessToken.isEmpty else { return false }
+        guard let expiresAt else { return true }
+        return expiresAt.timeIntervalSince(now) > Self.refreshBuffer
+    }
+}
+
+/// Reads the Google OAuth token Antigravity / `agy` keep in the macOS Keychain
+/// (generic password, service `gemini`, account `antigravity`).
+///
+/// The item is a `go-keyring-base64:`-wrapped JSON blob of the shape
+/// `{ "token": { "access_token", "refresh_token", "expiry" }, ... }`.
+/// This loader only ever reads it — it never writes back to Antigravity's item.
+public struct AntigravityKeychainCredentialLoader: Sendable {
+    static let keychainService = "gemini"
+    static let keychainAccount = "antigravity"
+    private static let goKeyringPrefix = "go-keyring-base64:"
+
+    private let cliExecutor: any CLIExecutor
+    private let timeout: TimeInterval
+
+    public init(cliExecutor: any CLIExecutor = DefaultCLIExecutor(), timeout: TimeInterval = 8.0) {
+        self.cliExecutor = cliExecutor
+        self.timeout = timeout
+    }
+
+    /// Returns the stored credentials, or nil when the Keychain item is absent or unreadable.
+    public func load() -> AntigravityOAuthCredentials? {
+        let result: CLIResult
+        do {
+            result = try cliExecutor.execute(
+                binary: "/usr/bin/security",
+                args: ["find-generic-password", "-s", Self.keychainService, "-a", Self.keychainAccount, "-w"],
+                input: nil,
+                timeout: timeout,
+                workingDirectory: nil,
+                autoResponses: [:]
+            )
+        } catch {
+            AppLog.credentials.error("Antigravity: Keychain read failed: \(error.localizedDescription)")
+            return nil
+        }
+
+        guard result.exitCode == 0 else {
+            AppLog.credentials.debug("Antigravity: no Keychain credentials (security exit code \(result.exitCode))")
+            return nil
+        }
+
+        guard let credentials = Self.parse(raw: result.output) else {
+            AppLog.credentials.error("Antigravity: Keychain credentials are in an unrecognized format")
+            return nil
+        }
+        return credentials
+    }
+
+    // MARK: - Parsing (pure, for testability)
+
+    static func parse(raw: String) -> AntigravityOAuthCredentials? {
+        var text = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return nil }
+
+        if text.hasPrefix(goKeyringPrefix) {
+            let encoded = String(text.dropFirst(goKeyringPrefix.count)).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let data = Data(base64Encoded: encoded),
+                  let decoded = String(data: data, encoding: .utf8) else { return nil }
+            text = decoded.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        guard let object = try? JSONSerialization.jsonObject(with: Data(text.utf8)) as? [String: Any] else {
+            return nil
+        }
+        return credentials(from: object)
+    }
+
+    private static func credentials(from object: [String: Any]) -> AntigravityOAuthCredentials? {
+        let source = (object["token"] as? [String: Any]) ?? object
+        let access = firstString(source, ["access_token", "accessToken"])
+        let refresh = firstString(source, ["refresh_token", "refreshToken"])
+        let expiry = firstString(source, ["expiry", "expires_at", "expiresAt"]).flatMap(parseDate)
+
+        guard access != nil || refresh != nil else { return nil }
+        return AntigravityOAuthCredentials(accessToken: access, refreshToken: refresh, expiresAt: expiry)
+    }
+
+    private static func firstString(_ object: [String: Any], _ keys: [String]) -> String? {
+        for key in keys {
+            if let value = (object[key] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty {
+                return value
+            }
+        }
+        return nil
+    }
+
+    private static func parseDate(_ value: String) -> Date? {
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = fractional.date(from: value) { return date }
+        if let date = ISO8601DateFormatter().date(from: value) { return date }
+        if let seconds = Double(value) { return Date(timeIntervalSince1970: seconds) }
+        return nil
+    }
+}

--- a/Sources/Infrastructure/Antigravity/AntigravityQuotaSummaryParser.swift
+++ b/Sources/Infrastructure/Antigravity/AntigravityQuotaSummaryParser.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Domain
+
+/// Parses the `RetrieveUserQuotaSummary` / `v1internal:retrieveUserQuotaSummary` payload —
+/// the only Antigravity endpoint that reports the two shared pools (Gemini, and every
+/// non-Gemini model such as Claude) with both their rolling 5-hour and weekly windows.
+///
+/// Accepts both the language server envelope (`{"response": {"groups": …}}`) and the bare
+/// Cloud Code payload (`{"groups": …}`).
+enum AntigravityQuotaSummaryParser {
+
+    private static let geminiGroup = "Gemini"
+    private static let claudeGroup = "Claude & others"
+
+    /// Known buckets, matched by exact `bucketId` only, in display order.
+    private static let buckets: [(id: String, quotaType: QuotaType, group: String, compactTitle: String)] = [
+        ("gemini-5h", .session, geminiGroup, "5h"),
+        ("gemini-weekly", .weekly, geminiGroup, "7d"),
+        ("3p-5h", .modelSpecific("Claude"), claudeGroup, "5h"),
+        ("3p-weekly", .modelSpecific("Claude Weekly"), claudeGroup, "7d")
+    ]
+
+    /// Returns nil when the payload is not a quota summary at all (caller may fall back to
+    /// the legacy per-model endpoints). A non-nil result — even an empty one — is authoritative.
+    /// Buckets without a usable `remainingFraction` are dropped rather than reported as 0%.
+    static func parse(_ data: Data, providerId: String) -> [UsageQuota]? {
+        guard let envelope = try? JSONDecoder().decode(Envelope.self, from: data),
+              let groups = envelope.response?.groups ?? envelope.groups else {
+            return nil
+        }
+
+        var byID: [String: Bucket] = [:]
+        for bucket in groups.flatMap({ $0.buckets ?? [] }) {
+            guard let id = bucket.bucketId, byID[id] == nil else { continue }
+            byID[id] = bucket
+        }
+
+        return buckets.compactMap { spec in
+            guard let bucket = byID[spec.id] else { return nil }
+            guard let fraction = bucket.remainingFraction, fraction.isFinite else {
+                AppLog.probes.warning("Antigravity: quota bucket '\(spec.id)' has no remainingFraction; skipping")
+                return nil
+            }
+            return UsageQuota(
+                percentRemaining: fraction * 100,
+                quotaType: spec.quotaType,
+                providerId: providerId,
+                resetsAt: bucket.resetTime.flatMap(parseDate),
+                group: spec.group,
+                compactTitle: spec.compactTitle
+            )
+        }
+    }
+
+    private static func parseDate(_ value: String) -> Date? {
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = fractional.date(from: value) { return date }
+        if let date = ISO8601DateFormatter().date(from: value) { return date }
+        if let seconds = Double(value) { return Date(timeIntervalSince1970: seconds) }
+        return nil
+    }
+
+    // MARK: - Wire format
+
+    private struct Envelope: Decodable {
+        let response: Root?
+        let groups: [Group]?
+    }
+
+    private struct Root: Decodable {
+        let groups: [Group]?
+    }
+
+    private struct Group: Decodable {
+        let buckets: [Bucket]?
+    }
+
+    /// Lenient: a malformed bucket decodes to nil fields instead of failing the whole summary.
+    private struct Bucket: Decodable {
+        let bucketId: String?
+        let remainingFraction: Double?
+        let resetTime: String?
+
+        private enum CodingKeys: String, CodingKey { case bucketId, remainingFraction, resetTime }
+
+        init(from decoder: Decoder) {
+            let container = try? decoder.container(keyedBy: CodingKeys.self)
+            bucketId = container.flatMap { try? $0.decodeIfPresent(String.self, forKey: .bucketId) }
+            remainingFraction = container.flatMap { try? $0.decodeIfPresent(Double.self, forKey: .remainingFraction) }
+            resetTime = container.flatMap { try? $0.decodeIfPresent(String.self, forKey: .resetTime) }
+        }
+    }
+}

--- a/Sources/Infrastructure/Antigravity/AntigravityUsageProbe.swift
+++ b/Sources/Infrastructure/Antigravity/AntigravityUsageProbe.swift
@@ -1,26 +1,43 @@
 import Foundation
 import Domain
 
-/// Probes the local Antigravity language server for usage quota information.
-/// Antigravity runs as a local process and exposes quota data via a local API.
+/// Probes Antigravity for usage quota information.
+///
+/// Sources, best first:
+/// 1. The local language server of the running Antigravity app or `agy` CLI (loopback API).
+/// 2. With nothing running, the OAuth access token Antigravity / `agy` stored in the Keychain,
+///    used against Google's Cloud Code API — so the desktop app need not stay open (#201).
+///    The token is not refreshed here; once it expires the user is asked to sign in again.
 public struct AntigravityUsageProbe: UsageProbe {
 
     private let cliExecutor: any CLIExecutor
     private let networkClient: any NetworkClient
+    private let cloudClient: AntigravityCloudCodeClient
+    private let credentialLoader: AntigravityKeychainCredentialLoader
     private let timeout: TimeInterval
+    private let now: @Sendable () -> Date
 
-    // Match current and older Antigravity language server binary names.
-    private static let processNames = ["language_server", "language_server_macos", "language_server_macos_arm"]
+    // Match the app's language server (current and older names) and the `agy` CLI.
+    private static let processNames = ["language_server", "language_server_macos", "language_server_macos_arm", "agy"]
+
+    static let sessionExpiredHint = "Sign in to Antigravity or run `agy` again."
 
     public init(
         cliExecutor: (any CLIExecutor)? = nil,
         networkClient: (any NetworkClient)? = nil,
-        timeout: TimeInterval = 8.0
+        remoteNetworkClient: (any NetworkClient)? = nil,
+        timeout: TimeInterval = 8.0,
+        now: @escaping @Sendable () -> Date = Date.init
     ) {
-        self.cliExecutor = cliExecutor ?? DefaultCLIExecutor()
+        let executor = cliExecutor ?? DefaultCLIExecutor()
+        self.cliExecutor = executor
         // Use insecure client by default for self-signed localhost certificates
         self.networkClient = networkClient ?? InsecureLocalhostNetworkClient(timeout: timeout)
+        // Remote calls use full TLS validation
+        self.cloudClient = AntigravityCloudCodeClient(networkClient: remoteNetworkClient ?? URLSession.shared)
+        self.credentialLoader = AntigravityKeychainCredentialLoader(cliExecutor: executor, timeout: timeout)
         self.timeout = timeout
+        self.now = now
     }
 
     // MARK: - UsageProbe
@@ -31,9 +48,14 @@ public struct AntigravityUsageProbe: UsageProbe {
             AppLog.probes.debug("Antigravity process detected: PID=\(processInfo.pid)")
             return true
         } catch {
-            AppLog.probes.debug("Antigravity not available: \(error.localizedDescription)")
-            return false
+            AppLog.probes.debug("Antigravity process not available: \(error.localizedDescription)")
         }
+
+        if credentialLoader.load() != nil {
+            AppLog.probes.debug("Antigravity: Keychain credentials found, Cloud Code fallback available")
+            return true
+        }
+        return false
     }
 
     public func probe() async throws -> UsageSnapshot {
@@ -44,6 +66,9 @@ public struct AntigravityUsageProbe: UsageProbe {
         do {
             processInfo = try await detectProcess()
             AppLog.probes.debug("Antigravity process found: PID=\(processInfo.pid), port=\(processInfo.extensionPort ?? 0)")
+        } catch ProbeError.cliNotFound {
+            AppLog.probes.info("Antigravity not running; trying Cloud Code with stored credentials")
+            return try await probeCloudCode()
         } catch {
             AppLog.probes.error("Antigravity probe failed: \(error.localizedDescription)")
             throw error
@@ -74,15 +99,100 @@ public struct AntigravityUsageProbe: UsageProbe {
             AppLog.probes.debug("Antigravity API response: \(responseText.prefix(500))")
         }
 
-        // Step 4: Parse response
-        let snapshot = try Self.parseUserStatusResponse(data, providerId: "antigravity")
+        // Step 4: Parse response — pooled quota summary first, legacy per-model status otherwise
+        let snapshot: UsageSnapshot
+        if let quotas = AntigravityQuotaSummaryParser.parse(data, providerId: "antigravity"), !quotas.isEmpty {
+            snapshot = UsageSnapshot(providerId: "antigravity", quotas: quotas, capturedAt: now())
+        } else {
+            snapshot = try Self.parseUserStatusResponse(data, providerId: "antigravity")
+        }
 
+        logSuccess(snapshot)
+        return snapshot
+    }
+
+    private func logSuccess(_ snapshot: UsageSnapshot) {
         AppLog.probes.info("Antigravity probe success: \(snapshot.quotas.count) quotas found, email=\(snapshot.accountEmail ?? "none")")
         for quota in snapshot.quotas {
             AppLog.probes.info("  - \(quota.quotaType.displayName): \(Int(quota.percentRemaining))% remaining")
         }
+    }
 
-        return snapshot
+    // MARK: - Cloud Code Fallback (app closed)
+
+    private func probeCloudCode() async throws -> UsageSnapshot {
+        guard let credentials = credentialLoader.load() else {
+            AppLog.probes.error("Antigravity probe failed: not running and no stored credentials")
+            throw ProbeError.cliNotFound("Antigravity")
+        }
+
+        guard credentials.hasUsableAccessToken(at: now()), let token = credentials.accessToken else {
+            AppLog.probes.error("Antigravity: stored access token is expired; run Antigravity or agy to refresh it")
+            throw ProbeError.sessionExpired(hint: Self.sessionExpiredHint)
+        }
+
+        switch await fetchCloudQuota(token: token) {
+        case .snapshot(let snapshot):
+            logSuccess(snapshot)
+            return snapshot
+        case .authFailed:
+            AppLog.probes.error("Antigravity: Cloud Code rejected the stored access token")
+            throw ProbeError.sessionExpired(hint: Self.sessionExpiredHint)
+        case .unavailable:
+            AppLog.probes.error("Antigravity: Cloud Code quota endpoints unavailable")
+            throw ProbeError.executionFailed("Could not reach the Antigravity quota API")
+        }
+    }
+
+    private enum CloudQuotaResult {
+        case snapshot(UsageSnapshot)
+        case authFailed
+        case unavailable
+    }
+
+    private func fetchCloudQuota(token: String) async -> CloudQuotaResult {
+        // Authoritative: pooled summary (both pools, 5h + weekly windows)
+        switch await cloudClient.post(path: AntigravityCloudCodeClient.quotaSummaryPath, token: token) {
+        case .authFailed:
+            return .authFailed
+        case .ok(let data):
+            if let quotas = AntigravityQuotaSummaryParser.parse(data, providerId: "antigravity"), !quotas.isEmpty {
+                return .snapshot(UsageSnapshot(
+                    providerId: "antigravity",
+                    quotas: quotas,
+                    capturedAt: now(),
+                    accountTier: await loadPlan(token: token)
+                ))
+            }
+        case .unavailable:
+            break
+        }
+
+        // Legacy: per-model quotas (5h windows only)
+        switch await cloudClient.post(path: AntigravityCloudCodeClient.fetchModelsPath, token: token) {
+        case .authFailed:
+            return .authFailed
+        case .ok(let data):
+            let quotas = Self.parseAvailableModels(data, providerId: "antigravity")
+            if !quotas.isEmpty {
+                return .snapshot(UsageSnapshot(
+                    providerId: "antigravity",
+                    quotas: quotas,
+                    capturedAt: now(),
+                    accountTier: await loadPlan(token: token)
+                ))
+            }
+        case .unavailable:
+            break
+        }
+        return .unavailable
+    }
+
+    private func loadPlan(token: String) async -> AccountTier? {
+        guard case .ok(let data) = await cloudClient.post(path: AntigravityCloudCodeClient.loadCodeAssistPath, token: token) else {
+            return nil
+        }
+        return Self.parsePlanName(data).map { .custom($0.uppercased()) }
     }
 
     // MARK: - Process Detection
@@ -167,6 +277,7 @@ public struct AntigravityUsageProbe: UsageProbe {
 
     private func fetchQuota(ports: [Int], csrfToken: String, httpPort: Int?) async throws -> Data {
         let paths = [
+            "/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary",
             "/exa.language_server_pb.LanguageServerService/GetUserStatus",
             "/exa.language_server_pb.LanguageServerService/GetCommandModelConfigs"
         ]
@@ -235,6 +346,10 @@ public struct AntigravityUsageProbe: UsageProbe {
         let lower = commandLine.lowercased()
         // Check if any of the known process names are present
         guard processNames.contains(where: { lower.contains($0) }) else { return false }
+        // The `agy` CLI binary (e.g. "/opt/homebrew/bin/agy --csrf_token ...")
+        if lower.range(of: #"(^|/|\s)agy(\s|$)"#, options: .regularExpression) != nil {
+            return true
+        }
         // Check for app_data_dir flag with antigravity value
         if lower.contains("--app_data_dir") && lower.contains("antigravity") {
             return true
@@ -382,6 +497,39 @@ public struct AntigravityUsageProbe: UsageProbe {
         )
     }
 
+    // MARK: - Cloud Code Parsing (Static for testability)
+
+    /// Parses Cloud Code `fetchAvailableModels` into per-model quotas (internal models dropped).
+    static func parseAvailableModels(_ data: Data, providerId: String) -> [UsageQuota] {
+        guard let response = try? JSONDecoder().decode(AvailableModelsResponse.self, from: data),
+              let models = response.models else {
+            return []
+        }
+        return models
+            .sorted { $0.key < $1.key }
+            .compactMap { key, model -> UsageQuota? in
+                if model.isInternal == true { return nil }
+                guard let quotaInfo = model.quotaInfo else { return nil }
+                let label = [model.displayName, model.label, key]
+                    .compactMap { $0?.trimmingCharacters(in: .whitespaces) }
+                    .first { !$0.isEmpty } ?? key
+                return UsageQuota(
+                    percentRemaining: (quotaInfo.remainingFraction ?? 0.0) * 100,
+                    quotaType: .modelSpecific(label),
+                    providerId: providerId,
+                    resetsAt: quotaInfo.resetTime.flatMap { parseResetTime($0) }
+                )
+            }
+    }
+
+    /// Parses Cloud Code `loadCodeAssist` for the subscription tier name.
+    static func parsePlanName(_ data: Data) -> String? {
+        guard let response = try? JSONDecoder().decode(LoadCodeAssistResponse.self, from: data) else { return nil }
+        let name = (response.paidTier?.name ?? response.currentTier?.name)?.trimmingCharacters(in: .whitespaces)
+        guard let name, !name.isEmpty else { return nil }
+        return name
+    }
+
     // MARK: - Reset Time Parsing
 
     private static func parseResetTime(_ value: String) -> Date? {
@@ -440,4 +588,24 @@ private struct ModelAlias: Decodable {
 private struct QuotaInfo: Decodable {
     let remainingFraction: Double?
     let resetTime: String?
+}
+
+private struct AvailableModelsResponse: Decodable {
+    let models: [String: AvailableModel]?
+}
+
+private struct AvailableModel: Decodable {
+    let displayName: String?
+    let label: String?
+    let isInternal: Bool?
+    let quotaInfo: QuotaInfo?
+}
+
+private struct LoadCodeAssistResponse: Decodable {
+    let paidTier: Tier?
+    let currentTier: Tier?
+
+    struct Tier: Decodable {
+        let name: String?
+    }
 }

--- a/Tests/InfrastructureTests/Antigravity/AntigravityCloudCodeFallbackTests.swift
+++ b/Tests/InfrastructureTests/Antigravity/AntigravityCloudCodeFallbackTests.swift
@@ -1,0 +1,194 @@
+import Testing
+import Foundation
+import Mockable
+@testable import Infrastructure
+@testable import Domain
+
+/// Covers the "app closed" path (issue #201): no language server process, so the probe
+/// falls back to the Keychain OAuth token + Google Cloud Code API.
+@Suite
+struct AntigravityCloudCodeFallbackTests {
+
+    static let noProcessOutput = "12345 /path/to/some_other_binary --flag value"
+
+    static let agyProcessOutput = """
+    4242 /opt/homebrew/bin/agy --standalone --csrf_token agy-token-1 --app_data_dir antigravity
+    """
+
+    static func keychainBlob(access: String = "ya29.valid", refresh: String? = "1//refresh", expiry: String = "2030-01-01T00:00:00Z") -> String {
+        var token: [String: Any] = ["access_token": access, "expiry": expiry]
+        if let refresh { token["refresh_token"] = refresh }
+        let json = try! JSONSerialization.data(withJSONObject: ["token": token])
+        return "go-keyring-base64:" + json.base64EncodedString()
+    }
+
+    static let summaryJSON = """
+    {"groups":[{"buckets":[
+      {"bucketId":"gemini-5h","remainingFraction":0.9,"resetTime":"2025-01-01T05:00:00Z"},
+      {"bucketId":"gemini-weekly","remainingFraction":0.7},
+      {"bucketId":"3p-5h","remainingFraction":0.5},
+      {"bucketId":"3p-weekly","remainingFraction":0.3}
+    ]}]}
+    """
+
+    static let modelsJSON = """
+    {"models":{
+      "gemini-3-pro":{"displayName":"Gemini 3 Pro","quotaInfo":{"remainingFraction":0.65}},
+      "claude-sonnet":{"displayName":"Claude Sonnet","quotaInfo":{"remainingFraction":0.25}},
+      "internal":{"displayName":"Hidden","isInternal":true,"quotaInfo":{"remainingFraction":1.0}}
+    }}
+    """
+
+    // MARK: - Helpers
+
+    private func makeExecutor(process: String, keychain: CLIResult) -> MockCLIExecutor {
+        let mock = MockCLIExecutor()
+        given(mock)
+            .execute(binary: .any, args: .any, input: .any, timeout: .any, workingDirectory: .any, autoResponses: .any)
+            .willProduce { binary, _, _, _, _, _ in
+                if binary.hasSuffix("security") { return keychain }
+                return CLIResult(output: process, exitCode: 0)
+            }
+        return mock
+    }
+
+    private func http(_ status: Int, _ body: String, url: URL) -> (Data, URLResponse) {
+        (Data(body.utf8), HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)!)
+    }
+
+    // MARK: - agy CLI process
+
+    @Test
+    func `detects the agy CLI language server process`() {
+        #expect(AntigravityUsageProbe.isAntigravityProcess(Self.agyProcessOutput))
+    }
+
+    @Test
+    func `isAvailable returns true when only the agy process is running`() async {
+        let executor = makeExecutor(process: Self.agyProcessOutput, keychain: CLIResult(output: "", exitCode: 44))
+        let probe = AntigravityUsageProbe(cliExecutor: executor)
+
+        #expect(await probe.isAvailable() == true)
+    }
+
+    // MARK: - Availability
+
+    @Test
+    func `isAvailable returns true when no process but keychain credentials exist`() async {
+        let executor = makeExecutor(process: Self.noProcessOutput, keychain: CLIResult(output: Self.keychainBlob(), exitCode: 0))
+        let probe = AntigravityUsageProbe(cliExecutor: executor)
+
+        #expect(await probe.isAvailable() == true)
+    }
+
+    @Test
+    func `isAvailable returns false when no process and no keychain credentials`() async {
+        let executor = makeExecutor(process: Self.noProcessOutput, keychain: CLIResult(output: "not found", exitCode: 44))
+        let probe = AntigravityUsageProbe(cliExecutor: executor)
+
+        #expect(await probe.isAvailable() == false)
+    }
+
+    // MARK: - Cloud Code quota summary
+
+    @Test
+    func `probe returns pooled quotas from Cloud Code when app is closed`() async throws {
+        let executor = makeExecutor(process: Self.noProcessOutput, keychain: CLIResult(output: Self.keychainBlob(), exitCode: 0))
+        let remote = MockNetworkClient()
+        var authHeaders: [String] = []
+        given(remote).request(.any).willProduce { request in
+            authHeaders.append(request.value(forHTTPHeaderField: "Authorization") ?? "")
+            let url = request.url!
+            if url.path.hasSuffix("retrieveUserQuotaSummary") {
+                return self.http(200, Self.summaryJSON, url: url)
+            }
+            return self.http(404, "", url: url)
+        }
+
+        let probe = AntigravityUsageProbe(cliExecutor: executor, remoteNetworkClient: remote)
+        let snapshot = try await probe.probe()
+
+        #expect(snapshot.providerId == "antigravity")
+        #expect(snapshot.quotas.count == 4)
+        #expect(snapshot.quotas[0].quotaType == .session)
+        #expect(snapshot.quotas[0].percentRemaining == 90.0)
+        #expect(snapshot.quotas[3].quotaType == .modelSpecific("Claude Weekly"))
+        #expect(snapshot.quotas[3].percentRemaining == 30.0)
+        #expect(authHeaders.allSatisfy { $0 == "Bearer ya29.valid" })
+    }
+
+    @Test
+    func `probe falls back to fetchAvailableModels when summary endpoint is missing`() async throws {
+        let executor = makeExecutor(process: Self.noProcessOutput, keychain: CLIResult(output: Self.keychainBlob(), exitCode: 0))
+        let remote = MockNetworkClient()
+        given(remote).request(.any).willProduce { request in
+            let url = request.url!
+            if url.path.hasSuffix("fetchAvailableModels") {
+                return self.http(200, Self.modelsJSON, url: url)
+            }
+            return self.http(404, "", url: url)
+        }
+
+        let probe = AntigravityUsageProbe(cliExecutor: executor, remoteNetworkClient: remote)
+        let snapshot = try await probe.probe()
+
+        #expect(snapshot.quotas.count == 2)
+        #expect(snapshot.quotas.contains { $0.quotaType == .modelSpecific("Gemini 3 Pro") && $0.percentRemaining == 65.0 })
+        #expect(snapshot.quotas.contains { $0.quotaType == .modelSpecific("Claude Sonnet") && $0.percentRemaining == 25.0 })
+    }
+
+    // MARK: - Errors
+
+    @Test
+    func `probe throws cliNotFound when no process and no credentials`() async {
+        let executor = makeExecutor(process: Self.noProcessOutput, keychain: CLIResult(output: "not found", exitCode: 44))
+        let probe = AntigravityUsageProbe(cliExecutor: executor, remoteNetworkClient: MockNetworkClient())
+
+        await #expect(throws: ProbeError.cliNotFound("Antigravity")) {
+            try await probe.probe()
+        }
+    }
+
+    @Test
+    func `probe throws sessionExpired when stored access token is expired`() async {
+        let executor = makeExecutor(
+            process: Self.noProcessOutput,
+            keychain: CLIResult(output: Self.keychainBlob(access: "ya29.stale", expiry: "2020-01-01T00:00:00Z"), exitCode: 0)
+        )
+        let probe = AntigravityUsageProbe(cliExecutor: executor, remoteNetworkClient: MockNetworkClient())
+
+        await #expect(throws: ProbeError.sessionExpired(hint: "Sign in to Antigravity or run `agy` again.")) {
+            try await probe.probe()
+        }
+    }
+
+    @Test
+    func `probe throws sessionExpired when Cloud Code rejects the stored token`() async {
+        let executor = makeExecutor(process: Self.noProcessOutput, keychain: CLIResult(output: Self.keychainBlob(), exitCode: 0))
+        let remote = MockNetworkClient()
+        given(remote).request(.any).willProduce { request in
+            self.http(401, "", url: request.url!)
+        }
+
+        let probe = AntigravityUsageProbe(cliExecutor: executor, remoteNetworkClient: remote)
+
+        await #expect(throws: ProbeError.sessionExpired(hint: "Sign in to Antigravity or run `agy` again.")) {
+            try await probe.probe()
+        }
+    }
+
+    @Test
+    func `probe throws executionFailed when Cloud Code is unreachable`() async {
+        let executor = makeExecutor(process: Self.noProcessOutput, keychain: CLIResult(output: Self.keychainBlob(), exitCode: 0))
+        let remote = MockNetworkClient()
+        given(remote).request(.any).willProduce { request in
+            self.http(503, "", url: request.url!)
+        }
+
+        let probe = AntigravityUsageProbe(cliExecutor: executor, remoteNetworkClient: remote)
+
+        await #expect(throws: ProbeError.executionFailed("Could not reach the Antigravity quota API")) {
+            try await probe.probe()
+        }
+    }
+}

--- a/Tests/InfrastructureTests/Antigravity/AntigravityKeychainCredentialLoaderTests.swift
+++ b/Tests/InfrastructureTests/Antigravity/AntigravityKeychainCredentialLoaderTests.swift
@@ -1,0 +1,104 @@
+import Testing
+import Foundation
+import Mockable
+@testable import Infrastructure
+@testable import Domain
+
+@Suite
+struct AntigravityKeychainCredentialLoaderTests {
+
+    static let tokenJSON = """
+    {"token":{"access_token":"ya29.access","refresh_token":"1//refresh","expiry":"2030-01-01T00:00:00Z"},"email":"user@example.com"}
+    """
+
+    static var goKeyringWrapped: String {
+        "go-keyring-base64:" + Data(tokenJSON.utf8).base64EncodedString()
+    }
+
+    // MARK: - Parsing
+
+    @Test
+    func `parses go-keyring-base64 wrapped token JSON`() {
+        let creds = AntigravityKeychainCredentialLoader.parse(raw: Self.goKeyringWrapped)
+
+        #expect(creds?.accessToken == "ya29.access")
+        #expect(creds?.refreshToken == "1//refresh")
+        #expect(creds?.expiresAt == ISO8601DateFormatter().date(from: "2030-01-01T00:00:00Z"))
+    }
+
+    @Test
+    func `parses bare JSON with nested token object`() {
+        let creds = AntigravityKeychainCredentialLoader.parse(raw: Self.tokenJSON)
+
+        #expect(creds?.accessToken == "ya29.access")
+        #expect(creds?.refreshToken == "1//refresh")
+    }
+
+    @Test
+    func `parses JSON with tokens at the root`() {
+        let raw = #"{"access_token":"root-access","refresh_token":"root-refresh"}"#
+
+        let creds = AntigravityKeychainCredentialLoader.parse(raw: raw)
+
+        #expect(creds?.accessToken == "root-access")
+        #expect(creds?.refreshToken == "root-refresh")
+        #expect(creds?.expiresAt == nil)
+    }
+
+    @Test
+    func `returns nil for non-JSON keychain content`() {
+        #expect(AntigravityKeychainCredentialLoader.parse(raw: "12345 /path/to/some_other_binary") == nil)
+        #expect(AntigravityKeychainCredentialLoader.parse(raw: "") == nil)
+        #expect(AntigravityKeychainCredentialLoader.parse(raw: "go-keyring-base64:not-base64!!") == nil)
+    }
+
+    @Test
+    func `returns nil when JSON has neither access nor refresh token`() {
+        #expect(AntigravityKeychainCredentialLoader.parse(raw: #"{"email":"x@y.z"}"#) == nil)
+    }
+
+    // MARK: - Credential behavior
+
+    @Test
+    func `access token is usable only when expiry is absent or in the future`() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+
+        let fresh = AntigravityOAuthCredentials(accessToken: "a", refreshToken: nil, expiresAt: now.addingTimeInterval(3600))
+        let expiringSoon = AntigravityOAuthCredentials(accessToken: "a", refreshToken: nil, expiresAt: now.addingTimeInterval(30))
+        let expired = AntigravityOAuthCredentials(accessToken: "a", refreshToken: nil, expiresAt: now.addingTimeInterval(-10))
+        let unknown = AntigravityOAuthCredentials(accessToken: "a", refreshToken: nil, expiresAt: nil)
+        let noAccess = AntigravityOAuthCredentials(accessToken: nil, refreshToken: "r", expiresAt: nil)
+
+        #expect(fresh.hasUsableAccessToken(at: now))
+        #expect(!expiringSoon.hasUsableAccessToken(at: now))
+        #expect(!expired.hasUsableAccessToken(at: now))
+        #expect(unknown.hasUsableAccessToken(at: now))
+        #expect(!noAccess.hasUsableAccessToken(at: now))
+    }
+
+    // MARK: - Loading via security CLI
+
+    @Test
+    func `load returns credentials when security CLI succeeds`() {
+        let mockExecutor = MockCLIExecutor()
+        given(mockExecutor)
+            .execute(binary: .any, args: .any, input: .any, timeout: .any, workingDirectory: .any, autoResponses: .any)
+            .willReturn(CLIResult(output: Self.goKeyringWrapped + "\n", exitCode: 0))
+
+        let loader = AntigravityKeychainCredentialLoader(cliExecutor: mockExecutor)
+
+        #expect(loader.load()?.accessToken == "ya29.access")
+    }
+
+    @Test
+    func `load returns nil when keychain item is missing`() {
+        let mockExecutor = MockCLIExecutor()
+        given(mockExecutor)
+            .execute(binary: .any, args: .any, input: .any, timeout: .any, workingDirectory: .any, autoResponses: .any)
+            .willReturn(CLIResult(output: "security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.", exitCode: 44))
+
+        let loader = AntigravityKeychainCredentialLoader(cliExecutor: mockExecutor)
+
+        #expect(loader.load() == nil)
+    }
+}

--- a/Tests/InfrastructureTests/Antigravity/AntigravityQuotaSummaryParserTests.swift
+++ b/Tests/InfrastructureTests/Antigravity/AntigravityQuotaSummaryParserTests.swift
@@ -1,0 +1,90 @@
+import Testing
+import Foundation
+@testable import Infrastructure
+@testable import Domain
+
+@Suite
+struct AntigravityQuotaSummaryParserTests {
+
+    static let remoteSummary = """
+    {
+      "groups": [
+        {
+          "displayName": "Gemini",
+          "buckets": [
+            { "bucketId": "gemini-5h", "remainingFraction": 0.8, "resetTime": "2025-01-01T05:00:00Z" },
+            { "bucketId": "gemini-weekly", "remainingFraction": 0.6, "resetTime": "2025-01-07T00:00:00Z" }
+          ]
+        },
+        {
+          "displayName": "Claude & others",
+          "buckets": [
+            { "bucketId": "3p-5h", "remainingFraction": 0.4 },
+            { "bucketId": "3p-weekly", "remainingFraction": 0.2 },
+            { "bucketId": "gemini-image-5h", "remainingFraction": 1.0 }
+          ]
+        }
+      ]
+    }
+    """
+
+    static var languageServerSummary: String {
+        #"{"response": \#(remoteSummary)}"#
+    }
+
+    @Test
+    func `maps the four known buckets to quotas in fixed order`() throws {
+        let quotas = try #require(AntigravityQuotaSummaryParser.parse(Data(Self.remoteSummary.utf8), providerId: "antigravity"))
+
+        #expect(quotas.count == 4)
+        #expect(quotas[0].quotaType == .session)
+        #expect(quotas[0].percentRemaining == 80.0)
+        #expect(quotas[0].resetsAt == ISO8601DateFormatter().date(from: "2025-01-01T05:00:00Z"))
+        #expect(quotas[1].quotaType == .weekly)
+        #expect(quotas[1].percentRemaining == 60.0)
+        #expect(quotas[2].quotaType == .modelSpecific("Claude"))
+        #expect(quotas[2].percentRemaining == 40.0)
+        #expect(quotas[3].quotaType == .modelSpecific("Claude Weekly"))
+        #expect(quotas[3].percentRemaining == 20.0)
+        #expect(quotas.allSatisfy { $0.providerId == "antigravity" })
+    }
+
+    @Test
+    func `accepts the language server response envelope`() throws {
+        let quotas = try #require(AntigravityQuotaSummaryParser.parse(Data(Self.languageServerSummary.utf8), providerId: "antigravity"))
+
+        #expect(quotas.count == 4)
+    }
+
+    @Test
+    func `ignores unknown buckets`() throws {
+        let quotas = try #require(AntigravityQuotaSummaryParser.parse(Data(Self.remoteSummary.utf8), providerId: "antigravity"))
+
+        #expect(!quotas.contains { $0.quotaType == .modelSpecific("gemini-image-5h") })
+    }
+
+    @Test
+    func `drops a bucket without remainingFraction instead of fabricating a value`() throws {
+        let json = """
+        {"groups":[{"buckets":[{"bucketId":"gemini-5h"},{"bucketId":"gemini-weekly","remainingFraction":0.5}]}]}
+        """
+
+        let quotas = try #require(AntigravityQuotaSummaryParser.parse(Data(json.utf8), providerId: "antigravity"))
+
+        #expect(quotas.count == 1)
+        #expect(quotas[0].quotaType == .weekly)
+    }
+
+    @Test
+    func `returns nil when the payload is not a quota summary`() {
+        #expect(AntigravityQuotaSummaryParser.parse(Data("not json".utf8), providerId: "antigravity") == nil)
+        #expect(AntigravityQuotaSummaryParser.parse(Data(#"{"userStatus":{}}"#.utf8), providerId: "antigravity") == nil)
+    }
+
+    @Test
+    func `returns empty array when summary has no known buckets`() {
+        let quotas = AntigravityQuotaSummaryParser.parse(Data(#"{"groups":[]}"#.utf8), providerId: "antigravity")
+
+        #expect(quotas?.isEmpty == true)
+    }
+}


### PR DESCRIPTION
Closes #201

## Problem
ClaudeBar's Antigravity probe only had one data source: the language server process of the running desktop app (`pgrep` → CSRF token → loopback API). With the app closed — or with only the `agy` CLI installed — the provider showed as not connected.

## Fix
Mirrors the approach in [robinebers/openusage](https://github.com/robinebers/openusage)'s Antigravity provider (thanks @malhobayyeb for the pointer):

1. **`agy` CLI detection** — the `agy` language server process is now recognized alongside `language_server*`.
2. **App-closed fallback** — when no process is running, read the OAuth access token Antigravity / `agy` store in the macOS Keychain (`security find-generic-password -s gemini -a antigravity`, `go-keyring-base64`-wrapped JSON) and query Google Cloud Code directly:
   - `v1internal:retrieveUserQuotaSummary` → pooled **Gemini** and **Claude & others** quotas, each with 5h and weekly windows
   - falls back to `v1internal:fetchAvailableModels` (per-model, 5h only) on builds without the summary RPC
   - `loadCodeAssist` for the plan tier badge
3. **Pooled summary on the local path too** — `RetrieveUserQuotaSummary` is tried first against the language server, so both paths report the same quotas; legacy `GetUserStatus` / `GetCommandModelConfigs` remain as fallback.
4. **Clearer errors** — expired/rejected token → `sessionExpired` ("Sign in to Antigravity or run `agy` again."); unreachable API → `executionFailed`; no process + no credentials → `cliNotFound` as before.

### Deliberately not included
No OAuth refresh-token grant. That would require embedding Antigravity's Google OAuth client ID/secret (GitHub push protection flags them). The stored access token is refreshed whenever Antigravity or `agy` runs; once it expires ClaudeBar asks the user to sign in again.

## New files
- `Sources/Infrastructure/Antigravity/AntigravityKeychainCredentialLoader.swift`
- `Sources/Infrastructure/Antigravity/AntigravityCloudCodeClient.swift`
- `Sources/Infrastructure/Antigravity/AntigravityQuotaSummaryParser.swift`

## Tests
- `AntigravityKeychainCredentialLoaderTests` — keychain blob parsing, expiry handling, `security` CLI outcomes
- `AntigravityQuotaSummaryParserTests` — bucket mapping, envelope shapes, lenient/unknown buckets
- `AntigravityCloudCodeFallbackTests` — `agy` detection, availability, summary/models fallback, error mapping

Note: reading the Keychain item triggers a one-time macOS "ClaudeBar wants to access…" prompt. Endpoints are reverse-engineered and may change without notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3o78EpcqJJXdV443jDWZb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Antigravity usage and quota retrieval through local processes or Cloud Code when the app is unavailable.
  - Added secure credential loading from macOS Keychain, including token expiry and authentication handling.
  - Added support for Gemini and Claude quota summaries, reset times, account tiers, and fallback responses.
  - Improved handling of unavailable services, expired sessions, rejected tokens, and network failures.

- **Tests**
  - Added coverage for credential parsing, quota interpretation, authentication scenarios, and Cloud Code fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->