### PR TITLE
fix(codex): stop passing an approval policy the CLI rejects (#259)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Codex usage could not be retrieved at all ("Could not find usage limits in Codex output"). The Codex CLI dropped `untrusted` from `--ask-for-approval`, so both the app-server and the TTY fallback exited at argument parsing. (#259)
+- The header badge no longer shows a green "HEALTHY" for a provider that failed to probe; it now reads "UNAVAILABLE", or "NO DATA" before the first refresh. (#259)
+
 ---
 
 ## [0.4.82] - 2026-08-24

--- a/Sources/App/Views/MenuContentView.swift
+++ b/Sources/App/Views/MenuContentView.swift
@@ -284,13 +284,24 @@ struct MenuContentView: View {
         }
     }
 
-    /// Status of the currently selected provider
-    private var selectedProviderStatus: QuotaStatus {
-        guard let snapshot = selectedProvider?.snapshot else { return .healthy }
+    /// Status of the currently selected provider, nil when it has no snapshot.
+    private var selectedProviderStatus: QuotaStatus? {
+        guard let snapshot = selectedProvider?.snapshot else { return nil }
         if settings.burnRateWarningEnabled {
             return snapshot.paceAwareOverallStatus(burnRateThreshold: settings.burnRateThreshold)
         }
         return snapshot.overallStatus
+    }
+
+    /// What the header pill says. A provider that failed to probe reads as
+    /// "UNAVAILABLE" rather than borrowing a green "HEALTHY" it has no data
+    /// for (#259).
+    private var selectedProviderBadge: ProviderBadgeState {
+        ProviderBadgeState(
+            isSyncing: isSelectedProviderSyncing,
+            quotaStatus: selectedProviderStatus,
+            hasError: selectedProvider?.lastError != nil
+        )
     }
 
     /// Whether the selected provider is currently syncing
@@ -299,7 +310,7 @@ struct MenuContentView: View {
     }
 
     private var statusBadge: some View {
-        let statusColor = theme.statusColor(for: selectedProviderStatus)
+        let statusColor = selectedProviderBadge.badgeColor(theme)
 
         return HStack(spacing: 6) {
             // Animated pulse dot
@@ -325,8 +336,7 @@ struct MenuContentView: View {
     }
 
     private var statusText: String {
-        if isSelectedProviderSyncing { return "Syncing..." }
-        return selectedProviderStatus.badgeText
+        selectedProviderBadge.badgeText
     }
 
     /// Help text for settings button, includes update info if available

--- a/Sources/App/Views/Theme.swift
+++ b/Sources/App/Views/Theme.swift
@@ -854,6 +854,31 @@ extension QuotaStatus {
     }
 }
 
+// MARK: - ProviderBadgeState Theme Extension
+
+extension ProviderBadgeState {
+    /// Text for the header pill. States without data say so rather than
+    /// borrowing "HEALTHY" from a snapshot that does not exist (#259).
+    var badgeText: String {
+        switch self {
+        case .syncing: "Syncing..."
+        case .unavailable: "UNAVAILABLE"
+        case .awaitingData: "NO DATA"
+        case .quota(let status): status.badgeText
+        }
+    }
+
+    /// Pill accent color, resolved against the active theme.
+    func badgeColor(_ theme: any AppThemeProvider) -> Color {
+        switch self {
+        case .syncing, .awaitingData: theme.textTertiary
+        // Matches the warning triangle on the "Unavailable" card below it.
+        case .unavailable: theme.statusWarning
+        case .quota(let status): theme.statusColor(for: status)
+        }
+    }
+}
+
 // MARK: - UsagePace Theme Extension
 
 extension UsagePace {

--- a/Sources/Domain/Provider/ProviderBadgeState.swift
+++ b/Sources/Domain/Provider/ProviderBadgeState.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// What the header badge should say about one provider.
+///
+/// A provider with no snapshot used to fall back to `.healthy`, so a failed
+/// probe showed a green "HEALTHY" pill above a card reading "Codex
+/// Unavailable" (#259). Absence of data is its own state here, distinct from
+/// data that says everything is fine.
+public enum ProviderBadgeState: Equatable, Sendable {
+    /// A refresh is in flight.
+    case syncing
+    /// The last probe failed, so there are no numbers to show.
+    case unavailable
+    /// No probe has produced data yet (first launch, provider just enabled).
+    case awaitingData
+    /// We have numbers, and this is what they say.
+    case quota(QuotaStatus)
+
+    /// - Parameters:
+    ///   - isSyncing: whether a refresh is currently running.
+    ///   - quotaStatus: status derived from the latest snapshot, nil when there is none.
+    ///   - hasError: whether the last probe attempt failed.
+    public init(isSyncing: Bool, quotaStatus: QuotaStatus?, hasError: Bool) {
+        if isSyncing {
+            self = .syncing
+        } else if let quotaStatus {
+            // Stale numbers still beat no numbers, so a snapshot wins over an
+            // error from a later failed refresh.
+            self = .quota(quotaStatus)
+        } else if hasError {
+            self = .unavailable
+        } else {
+            self = .awaitingData
+        }
+    }
+
+    /// Whether this state represents real usage data.
+    public var hasData: Bool {
+        if case .quota = self { return true }
+        return false
+    }
+}

--- a/Sources/Infrastructure/Codex/DefaultCodexRPCClient.swift
+++ b/Sources/Infrastructure/Codex/DefaultCodexRPCClient.swift
@@ -26,6 +26,17 @@ public final class DefaultCodexRPCClient: CodexRPCClient, @unchecked Sendable {
         self.transport = transport
     }
 
+    /// Arguments every Codex invocation gets, for both the app-server and the
+    /// TTY fallback.
+    ///
+    /// `--ask-for-approval` must stay a value the CLI still knows: Codex dropped
+    /// `untrusted` (leaving `on-request` and `never`), and an unknown value makes
+    /// the CLI exit at argument parsing — which took out the RPC path *and* the
+    /// TTY fallback at once (#259). `never` is accepted by old and new builds
+    /// alike, and cannot stall a non-interactive pipe on an approval prompt.
+    /// The read-only sandbox still keeps anything Codex might run boxed in.
+    static let baseArguments = ["-s", "read-only", "-a", "never"]
+
     public func isAvailable() -> Bool {
         let binaryName = executable
         if cliExecutor.locate(binaryName) != nil {
@@ -62,7 +73,7 @@ public final class DefaultCodexRPCClient: CodexRPCClient, @unchecked Sendable {
             let factory = transportFactory ?? { exec, args in
                 try ProcessRPCTransport(executable: exec, arguments: args)
             }
-            activeTransport = try factory(executable, ["-s", "read-only", "-a", "untrusted", "app-server"])
+            activeTransport = try factory(executable, Self.baseArguments + ["app-server"])
             ownsTransport = true
         }
         defer {
@@ -126,7 +137,7 @@ public final class DefaultCodexRPCClient: CodexRPCClient, @unchecked Sendable {
 
         let result = try cliExecutor.execute(
             binary: executable,
-            args: ["-s", "read-only", "-a", "untrusted"],
+            args: Self.baseArguments,
             input: "/status\n",
             timeout: 20.0,
             workingDirectory: nil,

--- a/Tests/DomainTests/Provider/ProviderBadgeStateTests.swift
+++ b/Tests/DomainTests/Provider/ProviderBadgeStateTests.swift
@@ -1,0 +1,44 @@
+import Testing
+import Foundation
+@testable import Domain
+
+@Suite("ProviderBadgeState Tests")
+struct ProviderBadgeStateTests {
+
+    @Test
+    func `a failed probe with no snapshot is unavailable, not healthy`() {
+        let state = ProviderBadgeState(isSyncing: false, quotaStatus: nil, hasError: true)
+
+        #expect(state == .unavailable)
+        #expect(!state.hasData)
+    }
+
+    @Test
+    func `no snapshot and no error yet is awaiting data, not healthy`() {
+        let state = ProviderBadgeState(isSyncing: false, quotaStatus: nil, hasError: false)
+
+        #expect(state == .awaitingData)
+        #expect(!state.hasData)
+    }
+
+    @Test
+    func `a snapshot reports its own quota status`() {
+        let state = ProviderBadgeState(isSyncing: false, quotaStatus: .warning, hasError: false)
+
+        #expect(state == .quota(.warning))
+        #expect(state.hasData)
+    }
+
+    @Test
+    func `stale numbers still show when a later refresh failed`() {
+        let state = ProviderBadgeState(isSyncing: false, quotaStatus: .critical, hasError: true)
+
+        #expect(state == .quota(.critical))
+    }
+
+    @Test
+    func `syncing wins over every other state`() {
+        #expect(ProviderBadgeState(isSyncing: true, quotaStatus: nil, hasError: true) == .syncing)
+        #expect(ProviderBadgeState(isSyncing: true, quotaStatus: .healthy, hasError: false) == .syncing)
+    }
+}

--- a/Tests/InfrastructureTests/Codex/DefaultCodexRPCClientTests.swift
+++ b/Tests/InfrastructureTests/Codex/DefaultCodexRPCClientTests.swift
@@ -309,4 +309,65 @@ struct DefaultCodexRPCClientTests {
         // Then - transport must still be closed despite the error
         verify(mockTransport).close().called(.atLeastOnce)
     }
+
+    // MARK: - CLI Argument Compatibility (#259)
+
+    /// Codex removed `untrusted` from `--ask-for-approval` (only `on-request`
+    /// and `never` remain), so passing it makes the CLI exit at argument
+    /// parsing — killing the RPC path *and* the TTY fallback at once.
+    @Test
+    func `spawns app-server with an approval policy the Codex CLI still accepts`() async throws {
+        let mockTransport = MockRPCTransport()
+        let mockExecutor = MockCLIExecutor()
+        setupMockTransport(mockTransport, rateLimitsResponse: """
+        {"id":2,"result":{"rateLimits":{"planType":"pro","primary":{"usedPercent":30,"resetsAt":1735000000}}}}
+        """)
+
+        var spawnedArgs: [String] = []
+        let client = DefaultCodexRPCClient(executable: "codex", cliExecutor: mockExecutor)
+        client.transportFactory = { _, args in
+            spawnedArgs = args
+            return mockTransport
+        }
+
+        _ = try await client.fetchRateLimits()
+
+        let approval = approvalPolicy(in: spawnedArgs)
+        #expect(approval == "never")
+        #expect(!spawnedArgs.contains("untrusted"))
+        #expect(spawnedArgs.contains("app-server"))
+    }
+
+    @Test
+    func `TTY fallback uses an approval policy the Codex CLI still accepts`() async throws {
+        let mockTransport = MockRPCTransport()
+        let mockExecutor = MockCLIExecutor()
+        given(mockTransport).send(.any).willReturn(())
+        given(mockTransport).receive().willThrow(ProbeError.executionFailed("RPC failed"))
+        given(mockTransport).close().willReturn(())
+
+        var ttyArgs: [String] = []
+        given(mockExecutor).execute(binary: .any, args: .any, input: .any, timeout: .any, workingDirectory: .any, autoResponses: .any)
+            .willProduce { _, args, _, _, _, _ in
+                ttyArgs = args
+                return CLIResult(output: "5h limit\n[####------] 40% left", exitCode: 0)
+            }
+
+        let client = DefaultCodexRPCClient(executable: "codex", cliExecutor: mockExecutor)
+        client.transportFactory = { _, _ in mockTransport }
+
+        _ = try await client.fetchRateLimits()
+
+        #expect(approvalPolicy(in: ttyArgs) == "never")
+        #expect(!ttyArgs.contains("untrusted"))
+    }
+
+    /// Value passed to `-a` / `--ask-for-approval`, if any.
+    private func approvalPolicy(in args: [String]) -> String? {
+        guard let flagIndex = args.firstIndex(where: { $0 == "-a" || $0 == "--ask-for-approval" }),
+              args.indices.contains(flagIndex + 1) else {
+            return nil
+        }
+        return args[flagIndex + 1]
+    }
 }


### PR DESCRIPTION
Closes #259

## Problem

Codex usage stopped resolving entirely — the card reads **"Failed to parse output: Could not find usage limits in Codex output"**.

ClaudeBar launched Codex with `-a untrusted`, a value the CLI no longer knows:

```
$ codex -s read-only -a untrusted app-server
error: invalid value 'untrusted' for '--ask-for-approval <APPROVAL_POLICY>'
  [possible values: on-request, never]
```

The CLI exits at argument parsing, which takes out **both** paths at once — so the fallback can't save it:

- **RPC** — the process dies before the handshake → `Process closed unexpectedly`
- **TTY fallback** — codex prints clap's usage error instead of `/status` output → no `5h limit` / `Weekly limit` to parse → the message on the card

Reproduced against `codex-cli 0.149.1`; matches the reporter's timeline (broke ~Aug 22, unaffected by restarts, Codex itself working fine).

## Fix

Pull the shared arguments into `DefaultCodexRPCClient.baseArguments` and use `-a never`:

- accepted by both old and new Codex builds, so it isn't a version-gated fix
- cannot stall a non-interactive pipe waiting on an approval prompt, which `on-request` could
- `-s read-only` is unchanged, so anything Codex might run stays sandboxed

Same handshake with the fixed args returns live data:

```json
{"id":2,"result":{"rateLimits":{"primary":{"usedPercent":2,"windowDurationMins":10080,"resetsAt":1788157237},"secondary":null,"planType":"plus"}}}
```

## Also fixed: the green HEALTHY pill

The reporter's second point — *"It shows HEALTHY even when usage data cannot be retrieved"*. `selectedProviderStatus` fell back to `.healthy` whenever the snapshot was nil, so a failed probe showed a green pill directly above an "Unavailable" card.

`ProviderBadgeState` makes absence its own state rather than borrowing `.healthy`:

| Situation | Badge |
|---|---|
| Refresh in flight | `Syncing...` |
| Probe failed, no snapshot | `UNAVAILABLE` |
| Nothing probed yet | `NO DATA` |
| Snapshot present | its quota status (unchanged) |

Stale numbers still win over a later failed refresh — a snapshot plus an error keeps showing the numbers.

The reporter's third point (error text not wrapping, on 0.4.81) already appears fixed — `emptyState` has no `lineLimit`.

## Tests

- `DefaultCodexRPCClientTests` — asserts the approval policy passed to the app-server *and* the TTY fallback is one the CLI still accepts, and that `untrusted` is gone. Both failed before the fix.
- `ProviderBadgeStateTests` — error → `.unavailable`, nothing yet → `.awaitingData`, snapshot → `.quota`, stale-numbers-beat-error, syncing wins.

Full suite green locally (71 + 711 + 1112). Verified end-to-end in the running app: `[probes] Codex probe success: 1 quotas found` via RPC, no TTY fallback.

## Out of scope, noticed here

The live response has `primary.windowDurationMins: 10080` (weekly) with `secondary: null`, while `mapRateLimitsToSnapshot` hardcodes primary→`.session`. That's #239 — the data needed to fix it is now visible in the payload.

`StatusItemLabelDriver.effectiveSelectedProviderStatus` has the same `.healthy` fallback for the menu bar icon; left alone since a red menu bar icon on a transient probe failure is a louder UX change than this issue asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XivnBrDEpEsmpTa1rJgiev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Codex usage retrieval now works with the latest CLI approval options.
  * Provider health badges no longer incorrectly show **HEALTHY** when data is unavailable or has not loaded.
  * Badges now clearly distinguish syncing, unavailable, awaiting data, and quota conditions.
* **Tests**
  * Added coverage for provider status displays and Codex CLI compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->