### PR TITLE
fix(claude): preserve unmodelled claudeAiOauth fields on write-back (#256)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Refreshing the Claude OAuth token no longer strips fields ClaudeBar does not model (notably `scopes`) from `claudeAiOauth`. The credential is shared with Claude Code, so a write-back handed it back an incomplete record. (#256)
+
 ---
 
 ## [0.4.84] - 2026-08-25

--- a/Sources/Infrastructure/Claude/ClaudeCredentialLoader.swift
+++ b/Sources/Infrastructure/Claude/ClaudeCredentialLoader.swift
@@ -133,10 +133,11 @@ public struct ClaudeCredentialLoader: Sendable {
 
         var updatedData = result.fullData
 
-        // Update the OAuth section
-        var oauthDict: [String: Any] = [
-            "accessToken": result.oauth.accessToken
-        ]
+        // Merge into the existing OAuth section so fields we do not model
+        // (e.g. `scopes`) survive the write-back — the file is shared with
+        // Claude Code, which reads them.
+        var oauthDict = (result.fullData["claudeAiOauth"] as? [String: Any]) ?? [:]
+        oauthDict["accessToken"] = result.oauth.accessToken
         if let refreshToken = result.oauth.refreshToken {
             oauthDict["refreshToken"] = refreshToken
         }

--- a/Tests/InfrastructureTests/Claude/ClaudeCredentialLoaderTests.swift
+++ b/Tests/InfrastructureTests/Claude/ClaudeCredentialLoaderTests.swift
@@ -225,6 +225,37 @@ struct ClaudeCredentialLoaderTests {
     }
 
     @Test
+    func `saveCredentials preserves claudeAiOauth fields it does not model`() throws {
+        let tempDir = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let claudeDir = tempDir.appendingPathComponent(".claude", isDirectory: true)
+        try FileManager.default.createDirectory(at: claudeDir, withIntermediateDirectories: true)
+        let credentials: [String: Any] = [
+            "claudeAiOauth": [
+                "accessToken": "old-token",
+                "refreshToken": "old-refresh",
+                "expiresAt": 1_748_276_587_173,
+                "scopes": ["user:inference", "user:profile"]
+            ]
+        ]
+        let filePath = claudeDir.appendingPathComponent(".credentials.json")
+        try JSONSerialization.data(withJSONObject: credentials, options: []).write(to: filePath)
+
+        let loader = ClaudeCredentialLoader(homeDirectory: tempDir.path, useKeychain: false)
+        var result = loader.loadCredentials()!
+        result.oauth.accessToken = "new-token"
+
+        loader.saveCredentials(result)
+
+        let data = try Data(contentsOf: filePath)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let oauth = json?["claudeAiOauth"] as? [String: Any]
+        #expect(oauth?["accessToken"] as? String == "new-token")
+        #expect(oauth?["scopes"] as? [String] == ["user:inference", "user:profile"])
+    }
+
+    @Test
     func `keychain save arguments update existing item for account`() {
         let password = """
         {


### PR DESCRIPTION
Fixes #256.

## Problem

`ClaudeCredentialLoader.saveCredentials` rebuilt the `claudeAiOauth` object from a four-field whitelist (`accessToken`, `refreshToken`, `expiresAt`, `subscriptionType`), so any other nested field was silently dropped when a token refresh wrote the credential back. Top-level keys survived via `result.fullData`, but nested ones did not — `scopes` being the notable casualty.

`~/.claude/.credentials.json` is shared with Claude Code, so every ClaudeBar write-back handed the next reader a credential with `scopes` missing.

## Fix

Merge into the existing dictionary rather than rebuilding it:

```swift
var oauthDict = (result.fullData["claudeAiOauth"] as? [String: Any]) ?? [:]
oauthDict["accessToken"] = result.oauth.accessToken
```

This sits upstream of the `.file` / `.keychain` branch, so both write paths are covered.

## Test

Added `saveCredentials preserves claudeAiOauth fields it does not model` — writes a credential file containing `scopes`, refreshes the access token, saves, and re-reads the raw JSON. It fails on `main` and passes with this change.

Full suite: 1180 tests in 97 suites, all passing.

## Notes

- #255 (pretty-printed JSON returned hex-encoded by `security -w` on macOS 26) is a separate defect on the same credential and is **not** addressed here.
- `CodexCredentialLoader` and `GrokCredentialLoader` already merge into their existing nested dictionaries, so they do not have this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQGXX2rREboK2LVb75uT5n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Claude OAuth token refresh now preserves additional credential details, such as granted scopes, when saving updated access tokens.
  - Prevents incomplete Claude Code credentials from being written back to shared credential storage.

- **Tests**
  - Added coverage to verify that token updates retain existing OAuth fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->