### PR TITLE
fix(claude): stop writing Keychain payloads security cannot read back (#255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Refreshing the Claude OAuth token no longer strips fields ClaudeBar does not model (notably `scopes`) from `claudeAiOauth`. The credential is shared with Claude Code, so a write-back handed it back an incomplete record. (#256)
+- Claude credentials stored in the Keychain could not be read back on macOS 26, leaving the API probe reporting "No credentials found" until the next `claude` login. `security -w` returns any password holding a non-printable-ASCII byte as hex, and the pretty-printed JSON ClaudeBar wrote contained newlines. Payloads are now written compact, and hex-encoded items left behind by earlier builds are decoded on read. (#255)
 
 ---
 

--- a/Sources/Infrastructure/Claude/ClaudeCredentialLoader.swift
+++ b/Sources/Infrastructure/Claude/ClaudeCredentialLoader.swift
@@ -72,6 +72,49 @@ public struct ClaudeCredentialLoader: Sendable {
         ]
     }
 
+    /// Serializes credentials for the Keychain.
+    ///
+    /// Deliberately compact: `security find-generic-password -w` on macOS 26
+    /// returns any password containing a byte outside printable ASCII as a hex
+    /// string rather than raw text, and pretty-printing's newlines are enough
+    /// to trigger it — leaving a password we can write but not read back (#255).
+    static func keychainPayload(from data: [String: Any]) -> String? {
+        guard let jsonData = try? JSONSerialization.data(withJSONObject: data, options: []) else {
+            return nil
+        }
+        return String(data: jsonData, encoding: .utf8)
+    }
+
+    /// Decodes a password read back from `security find-generic-password -w`,
+    /// undoing the macOS 26 hex encoding when present.
+    ///
+    /// A payload written by an older ClaudeBar build comes back hex-encoded;
+    /// this keeps those users working instead of stranding them until their
+    /// next `claude` login. Valid JSON always starts with `{`, which is not a
+    /// hex digit, so an all-hex payload is unambiguously the encoded form.
+    static func decodeKeychainPayload(_ raw: String) -> Data? {
+        if let decoded = hexDecoded(raw) {
+            return decoded
+        }
+        return raw.data(using: .utf8)
+    }
+
+    private static func hexDecoded(_ string: String) -> Data? {
+        guard !string.isEmpty, string.count % 2 == 0 else { return nil }
+
+        var bytes = [UInt8]()
+        bytes.reserveCapacity(string.count / 2)
+
+        var index = string.startIndex
+        while index < string.endIndex {
+            let next = string.index(index, offsetBy: 2)
+            guard let byte = UInt8(string[index..<next], radix: 16) else { return nil }
+            bytes.append(byte)
+            index = next
+        }
+        return Data(bytes)
+    }
+
     public init(
         homeDirectory: String = NSHomeDirectory(),
         keychainService: String = "Claude Code-credentials",
@@ -247,7 +290,7 @@ public struct ClaudeCredentialLoader: Sendable {
                 .trimmingCharacters(in: .whitespacesAndNewlines),
                   !jsonString.isEmpty else { return nil }
 
-            guard let jsonData = jsonString.data(using: .utf8),
+            guard let jsonData = Self.decodeKeychainPayload(jsonString),
                   let json = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
                   let oauthDict = json["claudeAiOauth"] as? [String: Any],
                   let rawAccessToken = oauthDict["accessToken"] as? String else {
@@ -272,8 +315,7 @@ public struct ClaudeCredentialLoader: Sendable {
     }
 
     private func saveToKeychain(_ data: [String: Any]) {
-        guard let jsonData = try? JSONSerialization.data(withJSONObject: data, options: [.prettyPrinted]),
-              let jsonString = String(data: jsonData, encoding: .utf8) else {
+        guard let jsonString = Self.keychainPayload(from: data) else {
             AppLog.credentials.error("Failed to serialize Claude credentials for Keychain")
             return
         }

--- a/Tests/InfrastructureTests/Claude/ClaudeCredentialLoaderTests.swift
+++ b/Tests/InfrastructureTests/Claude/ClaudeCredentialLoaderTests.swift
@@ -256,6 +256,42 @@ struct ClaudeCredentialLoaderTests {
     }
 
     @Test
+    func `keychain payload is compact so security does not hex-encode it`() throws {
+        let data: [String: Any] = [
+            "claudeAiOauth": [
+                "accessToken": "token",
+                "scopes": ["user:inference", "user:profile"]
+            ]
+        ]
+
+        let payload = try #require(ClaudeCredentialLoader.keychainPayload(from: data))
+
+        // `security find-generic-password -w` hex-encodes any password holding a
+        // byte outside printable ASCII, so the payload must stay printable.
+        #expect(payload.allSatisfy { $0.isASCII && $0.asciiValue.map { (0x20...0x7e).contains($0) } == true })
+        #expect(!payload.contains("\n"))
+    }
+
+    @Test
+    func `loadCredentials decodes hex-encoded keychain payload from an older build`() throws {
+        let json = #"{"claudeAiOauth":{"accessToken":"hex-token"}}"#
+        let hex = json.utf8.map { String(format: "%02x", $0) }.joined()
+
+        let decoded = try #require(ClaudeCredentialLoader.decodeKeychainPayload(hex))
+
+        #expect(String(data: decoded, encoding: .utf8) == json)
+    }
+
+    @Test
+    func `keychain payload that is already plain JSON is passed through unchanged`() throws {
+        let json = #"{"claudeAiOauth":{"accessToken":"plain-token"}}"#
+
+        let decoded = try #require(ClaudeCredentialLoader.decodeKeychainPayload(json))
+
+        #expect(String(data: decoded, encoding: .utf8) == json)
+    }
+
+    @Test
     func `keychain save arguments update existing item for account`() {
         let password = """
         {


### PR DESCRIPTION
Fixes #255. Independent of #264 (issue #256) — different defect, different lines of the same file.

## Problem

On macOS 26, `security find-generic-password -w` returns any password containing a byte outside printable ASCII as a lowercase hex string instead of raw text. `saveToKeychain` wrote **pretty-printed** JSON, and the indentation newlines alone are enough to trigger it — so `loadFromKeychain` could not parse back what ClaudeBar had just written.

The result: after the next token refresh, every probe logs `No credentials found` until a fresh `claude` login rewrites the item.

## Reproduced

macOS 26.4 (25E246), throwaway keychain, fake tokens:

```
compact : wrote 156 chars, read back 156 bytes -> parses OK
pretty  : wrote 207 chars, read back 414 bytes -> parses FAILS   (414 == 2*207, hex expansion)
          head: 7b0a202022636c6175646541694f61757468223a207b0a...
```

The trigger is the byte range, not JSON: printable ASCII (spaces included) comes back raw; newline, tab, `0x7f`, non-ASCII and emoji all come back hex-encoded.

## Fix

Two halves, both needed:

1. **`keychainPayload(from:)`** — serialize compact (`options: []`) so the encoding is not triggered for normal credentials.
2. **`decodeKeychainPayload(_:)`** — decode a hex payload on read, so items already written by an earlier build recover on next launch rather than stranding the user until their next `claude` login.

Detection is unambiguous: valid JSON always starts with `{`, which is not a hex digit, so an all-hex, even-length payload can only be the encoded form.

The second half also covers the residual case compact JSON can't prevent — Swift's `JSONSerialization` emits non-ASCII raw rather than `\uXXXX`-escaped, so a credential carrying a non-ASCII character would still hex-encode on write.

## Verification

Against the real `security(1)` binary in a throwaway keychain:

```
normal credential : wrote 141  read 141  raw  -> round-trip OK
non-ASCII value   : wrote  80  read 168  hex  -> round-trip OK
```

Unit tests added for compact-payload printability and hex round-trip. Full suite: 1182 tests in 97 suites, all passing.

## Note for the reviewer

The issue also states Claude Code is left holding a rotated-away token and prompts for re-login. I could not confirm that half: the Keychain item ClaudeBar writes is *valid*, and as the issue itself notes, native `SecKeychainFindGenericPassword` reads it back fine — it's specifically the `security(1)` `-w` path that breaks. What is confirmed is that **ClaudeBar's own probe** goes dead until the next `claude` login. The fix is the same either way.

Minor: the `[Unreleased]` changelog entry sits where #264 adds one too, so whichever merges second may need a one-line rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQGXX2rREboK2LVb75uT5n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Claude credentials failing to load from the macOS Keychain on macOS 26.
  * Existing hex-encoded credentials are now recognized and decoded automatically.
  * New credentials use a compatible compact format to prevent readback failures.
  * Preserved additional OAuth credential fields during token refresh.

* **Tests**
  * Added coverage for compact storage and plain or hex-encoded credential compatibility.

* **Documentation**
  * Documented these Keychain and credential preservation fixes in the unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->