### PR TITLE
Fix MiniMax usage percentage parsing

### DIFF
--- a/Sources/Domain/Provider/MiniMax/MiniMaxRegion.swift
+++ b/Sources/Domain/Provider/MiniMax/MiniMaxRegion.swift
@@ -53,6 +53,6 @@ public enum MiniMaxRegion: String, Sendable, Equatable, CaseIterable {
 
     /// Full API URL for the coding plan remains endpoint (Coding Plan 剩余额度 API URL)
     public var codingPlanRemainsURL: String {
-        "\(apiBaseURL)/v1/api/openplatform/coding_plan/remains"
+        "\(apiBaseURL)/v1/token_plan/remains"
     }
 }

--- a/Sources/Infrastructure/MiniMax/MiniMaxUsageProbe.swift
+++ b/Sources/Infrastructure/MiniMax/MiniMaxUsageProbe.swift
@@ -135,28 +135,44 @@ public struct MiniMaxUsageProbe: UsageProbe {
         }
 
         let quotas = modelRemains.map { model -> UsageQuota in
+            let legacyRemaining: Double? = {
+                let total = model.currentIntervalTotalCount
+                guard total > 0 else { return nil }
+                let clampedRemaining = min(max(model.currentIntervalUsageCount, 0), total)
+                return Double(clampedRemaining) / Double(total) * 100.0
+            }()
+
+            // Token Plan returns percentages directly. Older responses only
+            // exposed counts, so keep that path for existing installations.
+            let intervalRemaining = model.currentIntervalRemainingPercent.map(Self.clampPercentage) ?? legacyRemaining
+            let weeklyRemaining = model.currentWeeklyRemainingPercent.map(Self.clampPercentage)
+            let remaining = min(intervalRemaining ?? 0, weeklyRemaining ?? 100)
+
+            let useWeeklyWindow = if let weeklyRemaining {
+                weeklyRemaining < (intervalRemaining ?? 100)
+            } else {
+                false
+            }
+            let resetMilliseconds = useWeeklyWindow ? model.weeklyEndTime : model.endTime
+            let windowDuration = useWeeklyWindow
+                ? Self.windowDuration(start: model.weeklyStartTime, end: model.weeklyEndTime)
+                : Self.windowDuration(start: model.startTime, end: model.endTime)
+            let resetsAt = resetMilliseconds.map { Date(timeIntervalSince1970: Double($0) / 1000.0) }
+
             let total = model.currentIntervalTotalCount
-            // ⚠️ MiniMax API naming is misleading:
-            // Despite being called "current_interval_usage_count", this field
-            // actually represents the REMAINING count, not the used count.
-            // Confirmed via MiniMax dashboard: when dashboard shows "3% used",
-            // API returns usage_count=1459 out of total=1500 (i.e. 1459 remaining).
-            // (MiniMax API 命名有误导性：usage_count 实际是剩余次数，非已用次数)
-            let clampedRemaining = min(max(model.currentIntervalUsageCount, 0), total)
-            let usedCount = total - clampedRemaining
-            let remaining = total > 0 ? Double(clampedRemaining) / Double(total) * 100.0 : 0.0
-
-            // Parse end_time as millisecond timestamp (毫秒时间戳)
-            let resetsAt: Date? = model.endTime.map { Date(timeIntervalSince1970: Double($0) / 1000.0) }
-
-            let resetText = "\(usedCount)/\(total) requests"
+            let clampedRemaining = min(max(model.currentIntervalUsageCount, 0), max(total, 0))
+            let usedCount = max(total - clampedRemaining, 0)
+            let resetText = intervalRemaining != nil && model.currentIntervalRemainingPercent != nil
+                ? "\(Int((100 - remaining).rounded()))% used"
+                : "\(usedCount)/\(total) requests"
 
             return UsageQuota(
                 percentRemaining: remaining,
                 quotaType: .modelSpecific(model.modelName),
                 providerId: providerId,
                 resetsAt: resetsAt,
-                resetText: resetText
+                resetText: resetText,
+                windowDuration: windowDuration
             )
         }
 
@@ -165,6 +181,15 @@ public struct MiniMaxUsageProbe: UsageProbe {
             quotas: quotas,
             capturedAt: Date()
         )
+    }
+
+    private static func windowDuration(start: Int64?, end: Int64?) -> TimeInterval? {
+        guard let start, let end, end > start else { return nil }
+        return Double(end - start) / 1000.0
+    }
+
+    private static func clampPercentage(_ value: Double) -> Double {
+        min(max(value, 0), 100)
     }
 }
 
@@ -184,6 +209,11 @@ struct ModelRemain: Decodable {
     let modelName: String
     let currentIntervalTotalCount: Int
     let currentIntervalUsageCount: Int
+    let currentIntervalRemainingPercent: Double?
+    let currentWeeklyRemainingPercent: Double?
     let remainsTime: Int?
+    let startTime: Int64?
     let endTime: Int64?
+    let weeklyStartTime: Int64?
+    let weeklyEndTime: Int64?
 }

--- a/Tests/DomainTests/Provider/MiniMax/MiniMaxRegionTests.swift
+++ b/Tests/DomainTests/Provider/MiniMax/MiniMaxRegionTests.swift
@@ -73,13 +73,13 @@ struct MiniMaxRegionTests {
     @Test
     func `international codingPlanRemainsURL`() {
         #expect(MiniMaxRegion.international.codingPlanRemainsURL ==
-            "https://api.minimax.io/v1/api/openplatform/coding_plan/remains")
+            "https://api.minimax.io/v1/token_plan/remains")
     }
 
     @Test
     func `china codingPlanRemainsURL`() {
         #expect(MiniMaxRegion.china.codingPlanRemainsURL ==
-            "https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains")
+            "https://api.minimaxi.com/v1/token_plan/remains")
     }
 
     // MARK: - rawValue & allCases

--- a/Tests/InfrastructureTests/MiniMax/MiniMaxUsageProbeParsingTests.swift
+++ b/Tests/InfrastructureTests/MiniMax/MiniMaxUsageProbeParsingTests.swift
@@ -23,6 +23,36 @@ struct MiniMaxUsageProbeParsingTests {
     }
     """
 
+    static let sampleTokenPlanResponse = """
+    {
+      "base_resp": { "status_code": 0, "status_msg": "success" },
+      "model_remains": [
+        {
+          "model_name": "general",
+          "current_interval_total_count": 0,
+          "current_interval_usage_count": 0,
+          "current_interval_remaining_percent": 100,
+          "current_weekly_remaining_percent": 98,
+          "start_time": 1787673600000,
+          "end_time": 1787691600000,
+          "weekly_start_time": 1787500800000,
+          "weekly_end_time": 1788105600000
+        },
+        {
+          "model_name": "video",
+          "current_interval_total_count": 0,
+          "current_interval_usage_count": 0,
+          "current_interval_remaining_percent": 100,
+          "current_weekly_remaining_percent": 100,
+          "start_time": 1787673600000,
+          "end_time": 1787760000000,
+          "weekly_start_time": 1787500800000,
+          "weekly_end_time": 1788105600000
+        }
+      ]
+    }
+    """
+
     static let sampleMultiModelResponse = """
     {
       "base_resp": { "status_code": 0, "status_msg": "success" },
@@ -100,6 +130,19 @@ struct MiniMaxUsageProbeParsingTests {
         // Then
         let expected = Double(255) / Double(1500) * 100.0
         #expect(snapshot.quotas[0].percentRemaining == expected)
+    }
+
+    @Test
+    func `uses token plan remaining percentages when count totals are zero`() throws {
+        let data = Data(Self.sampleTokenPlanResponse.utf8)
+
+        let snapshot = try MiniMaxUsageProbe.parseResponse(data, providerId: "minimax")
+
+        #expect(snapshot.quotas.count == 2)
+        #expect(snapshot.quotas[0].percentRemaining == 98)
+        #expect(snapshot.quotas[0].resetText == "2% used")
+        #expect(snapshot.quotas[0].windowDuration == 604_800.0)
+        #expect(snapshot.quotas[1].percentRemaining == 100)
     }
 
     @Test

--- a/Tests/InfrastructureTests/MiniMax/MiniMaxUsageProbeTests.swift
+++ b/Tests/InfrastructureTests/MiniMax/MiniMaxUsageProbeTests.swift
@@ -77,7 +77,7 @@ struct MiniMaxUsageProbeTests {
         let mockNetwork = MockNetworkClient()
         let responseData = Data(Self.sampleApiResponse.utf8)
         let httpResponse = HTTPURLResponse(
-            url: URL(string: "https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains")!,
+            url: URL(string: "https://api.minimaxi.com/v1/token_plan/remains")!,
             statusCode: 200,
             httpVersion: nil,
             headerFields: nil
@@ -113,7 +113,7 @@ struct MiniMaxUsageProbeTests {
         // Given
         let mockNetwork = MockNetworkClient()
         let httpResponse = HTTPURLResponse(
-            url: URL(string: "https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains")!,
+            url: URL(string: "https://api.minimaxi.com/v1/token_plan/remains")!,
             statusCode: 401,
             httpVersion: nil,
             headerFields: nil
@@ -135,7 +135,7 @@ struct MiniMaxUsageProbeTests {
         // Given
         let mockNetwork = MockNetworkClient()
         let httpResponse = HTTPURLResponse(
-            url: URL(string: "https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains")!,
+            url: URL(string: "https://api.minimaxi.com/v1/token_plan/remains")!,
             statusCode: 500,
             httpVersion: nil,
             headerFields: nil
@@ -160,7 +160,7 @@ struct MiniMaxUsageProbeTests {
         let probe = makeProbe(apiKey: "test-key", region: nil)
 
         // Then: falls back to china for backward compatibility (兼容旧版默认中国区)
-        #expect(probe.apiURL == "https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains")
+        #expect(probe.apiURL == "https://api.minimaxi.com/v1/token_plan/remains")
     }
 
     @Test
@@ -169,7 +169,7 @@ struct MiniMaxUsageProbeTests {
         let probe = makeProbe(apiKey: "test-key", region: .china)
 
         // Then
-        #expect(probe.apiURL == "https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains")
+        #expect(probe.apiURL == "https://api.minimaxi.com/v1/token_plan/remains")
     }
 
     @Test
@@ -178,7 +178,7 @@ struct MiniMaxUsageProbeTests {
         let probe = makeProbe(apiKey: "test-key", region: .international)
 
         // Then
-        #expect(probe.apiURL == "https://api.minimax.io/v1/api/openplatform/coding_plan/remains")
+        #expect(probe.apiURL == "https://api.minimax.io/v1/token_plan/remains")
     }
 
     @Test
@@ -187,7 +187,7 @@ struct MiniMaxUsageProbeTests {
         let mockNetwork = MockNetworkClient()
         let responseData = Data(Self.sampleApiResponse.utf8)
         let httpResponse = HTTPURLResponse(
-            url: URL(string: "https://api.minimax.io/v1/api/openplatform/coding_plan/remains")!,
+            url: URL(string: "https://api.minimax.io/v1/token_plan/remains")!,
             statusCode: 200,
             httpVersion: nil,
             headerFields: nil
@@ -210,6 +210,6 @@ struct MiniMaxUsageProbeTests {
         #expect(snapshot.quotas.count == 1)
         #expect(snapshot.providerId == "minimax")
         // Verify the request was sent to international endpoint (验证请求发送到国际版端点)
-        #expect(capturedRequest?.url?.absoluteString == "https://api.minimax.io/v1/api/openplatform/coding_plan/remains")
+        #expect(capturedRequest?.url?.absoluteString == "https://api.minimax.io/v1/token_plan/remains")
     }
 }


### PR DESCRIPTION
## Summary\n- Use MiniMax's current token plan remains endpoint.\n- Prefer current interval and weekly remaining percentage fields when returned.\n- Keep the legacy count-based fallback for older responses.\n- Add parsing and endpoint tests.\n\n## Verification\n-  passed.\n- Swift syntax check and a self-check against the live redacted response shape passed.\n- Full Swift tests could not run because this checkout is a Tuist project and no usable Tuist executable is currently installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated MiniMax quota retrieval to use the current token-plan endpoint.
  * Improved usage reporting for percentage-based and weekly quotas.
  * Quota windows now select the more restrictive limit and show estimated reset times.
  * Preserved count-based usage reporting when percentage data is unavailable.
* **Tests**
  * Added coverage for percentage-based quota responses, weekly windows, endpoint updates, and regional behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->