### PR TITLE
fix(ui): put the quota bar back on the headline number's scale (#268)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The quota bar no longer contradicts the number above it. In "Remaining" mode an 87% card drew a 13% bar, because the bar tracked usage while the headline tracked what was left. The bar again shares the headline's scale: it starts full and drains as quota is consumed, inverting only in "Used" mode. The pace tick moves back onto the same scale. (#268)
+
 ---
 
 ## [0.4.85] - 2026-08-25

--- a/Sources/Domain/Provider/UsageQuota.swift
+++ b/Sources/Domain/Provider/UsageQuota.swift
@@ -182,22 +182,25 @@ public struct UsageQuota: Sendable, Equatable, Hashable, Comparable {
 
     /// Returns the percentage to use for progress bar width.
     ///
-    /// The bar always fills left-to-right as quota is consumed (`percentUsed`),
-    /// regardless of display mode. The headline number still follows
-    /// `displayPercent`; bar color still follows remaining/status.
+    /// The bar shares the headline number's scale so the two never disagree:
+    /// `.remaining` and `.pace` start full and drain from the right as quota is
+    /// consumed, `.used` fills from the left. Bar color still follows remaining/status.
     public func displayProgressPercent(mode: UsageDisplayMode) -> Double {
         switch mode {
-        case .remaining, .used, .pace: percentUsed
+        case .remaining, .pace: percentRemaining
+        case .used: percentUsed
         }
     }
 
     /// Returns the expected progress bar position based on time elapsed.
-    /// This is the used-scale tick: where the bar should sit if usage were
-    /// spread evenly across the window. Returns nil when reset time is unknown.
+    /// This is where the bar would sit if usage were spread evenly across the
+    /// window, on the same scale as the fill it annotates. Returns nil when
+    /// reset time is unknown.
     public func expectedProgressPercent(mode: UsageDisplayMode) -> Double? {
         guard let percentTimeElapsed else { return nil }
         switch mode {
-        case .remaining, .used, .pace: return percentTimeElapsed
+        case .remaining, .pace: return 100 - percentTimeElapsed
+        case .used: return percentTimeElapsed
         }
     }
 
@@ -267,11 +270,16 @@ public struct UsageQuota: Sendable, Equatable, Hashable, Comparable {
     }
 
     /// Tooltip copy explaining the pace tick mark under the progress bar.
-    /// Describes where the used-fill bar would sit if usage were spread
+    /// Mode-aware: describes where the bar would sit if usage were spread
     /// evenly across the window. Returns nil when reset time is unknown.
     public func paceTickHelp(mode: UsageDisplayMode) -> String? {
         guard let expected = expectedProgressPercent(mode: mode) else { return nil }
-        let base = "Pace marker: steady usage would have used ~\(Int(expected.rounded()))% by now"
+        let base = switch mode {
+        case .used:
+            "Pace marker: steady usage would have used ~\(Int(expected.rounded()))% by now"
+        case .remaining, .pace:
+            "Pace marker: steady usage would leave ~\(Int(expected.rounded()))% remaining by now"
+        }
         guard let insight = paceInsight else { return base + "." }
         return base + " — " + insight.prefix(1).lowercased() + insight.dropFirst() + "."
     }

--- a/Tests/DomainTests/Provider/UsagePaceTests.swift
+++ b/Tests/DomainTests/Provider/UsagePaceTests.swift
@@ -251,13 +251,13 @@ struct UsagePaceTests {
     }
 
     @Test
-    func `displayProgressPercent in pace mode returns percentUsed`() {
+    func `displayProgressPercent in pace mode returns percentRemaining`() {
         let quota = UsageQuota(
             percentRemaining: 30,
             quotaType: .session,
             providerId: "claude"
         )
-        #expect(quota.displayProgressPercent(mode: .pace) == 70)
+        #expect(quota.displayProgressPercent(mode: .pace) == 30)
     }
 
     // MARK: - Weekly Quota Pace

--- a/Tests/DomainTests/Provider/UsageQuotaTests.swift
+++ b/Tests/DomainTests/Provider/UsageQuotaTests.swift
@@ -302,12 +302,12 @@ struct UsageQuotaTests {
     }
 
     @Test
-    func `displayProgressPercent returns percentUsed in remaining mode`() {
+    func `displayProgressPercent returns percentRemaining in remaining mode`() {
         // Given
         let quota = UsageQuota(percentRemaining: 75, quotaType: .session, providerId: "claude")
 
-        // When & Then - bar always encodes consumption
-        #expect(quota.displayProgressPercent(mode: .remaining) == 25)
+        // When & Then - bar shares the headline number's scale
+        #expect(quota.displayProgressPercent(mode: .remaining) == 75)
     }
 
     @Test
@@ -331,17 +331,28 @@ struct UsageQuotaTests {
     }
 
     @Test
-    func `displayProgressPercent returns percentUsed in pace mode`() {
+    func `displayProgressPercent returns percentRemaining in pace mode`() {
         // Given
         let quota = UsageQuota(percentRemaining: 75, quotaType: .session, providerId: "claude")
 
-        // When & Then - pace mode progress bar shows used (same as remaining/used)
-        #expect(quota.displayProgressPercent(mode: .pace) == 25)
+        // When & Then - pace mode shows the remaining number, so the bar matches it
+        #expect(quota.displayProgressPercent(mode: .pace) == 75)
     }
 
     @Test
-    func `expectedProgressPercent returns elapsed time on the used scale`() {
-        // Session is 5h. 1.25h remaining -> 75% elapsed -> tick at 75 used.
+    func `displayProgressPercent matches displayPercent in every mode`() {
+        // Given - regression for #268: an 87% Remaining card drew a 13% bar
+        let quota = UsageQuota(percentRemaining: 87, quotaType: .session, providerId: "claude")
+
+        // When & Then - the bar and the headline number never disagree
+        for mode in UsageDisplayMode.allCases {
+            #expect(quota.displayProgressPercent(mode: mode) == quota.displayPercent(mode: mode))
+        }
+    }
+
+    @Test
+    func `expectedProgressPercent puts the tick on the bar's own scale`() {
+        // Session is 5h. 1.25h remaining -> 75% elapsed -> tick at 25 remaining, 75 used.
         let quota = UsageQuota(
             percentRemaining: 43,
             quotaType: .session,
@@ -351,9 +362,9 @@ struct UsageQuotaTests {
         let expectedRemaining = quota.expectedProgressPercent(mode: .remaining)!
         let expectedUsed = quota.expectedProgressPercent(mode: .used)!
         let expectedPace = quota.expectedProgressPercent(mode: .pace)!
-        #expect(expectedRemaining > 74 && expectedRemaining < 76)
+        #expect(expectedRemaining > 24 && expectedRemaining < 26)
         #expect(expectedUsed > 74 && expectedUsed < 76)
-        #expect(expectedPace > 74 && expectedPace < 76)
+        #expect(expectedPace > 24 && expectedPace < 26)
     }
 
     // MARK: - Dollar-Based Quotas
@@ -561,8 +572,8 @@ struct UsageQuotaTests {
     }
 
     @Test
-    func `paceTickHelp explains expected used in remaining mode`() {
-        // 75% of a 5h window elapsed -> steady usage would have used ~75%.
+    func `paceTickHelp explains expected remaining in remaining mode`() {
+        // 75% of a 5h window elapsed -> steady usage would leave ~25% remaining.
         let quota = UsageQuota(
             percentRemaining: 43,
             quotaType: .timeLimit("Z.ai 5h"),
@@ -571,8 +582,8 @@ struct UsageQuotaTests {
             windowDuration: 5 * 3600
         )
         let help = quota.paceTickHelp(mode: .remaining)!
-        #expect(help.contains("~75%"))
-        #expect(help.contains("used"))
+        #expect(help.contains("~25%"))
+        #expect(help.contains("remaining"))
         // 57 used vs 75 elapsed -> below expected usage, surfaced inline.
         #expect(help.contains("below expected usage"))
     }


### PR DESCRIPTION
Fixes #268. Reverts the bar-scale half of #254; the shared reset countdown, pill fade, and Build / Chat / Imagine icons all stay.

## Summary
- Progress bars fill on the same scale as the headline number again: remaining and pace start full and drain as quota is consumed, used fills left-to-right. An `87% Remaining` card was drawing a 13% bar, so a full quota drew an empty one.
- The pace tick mirrors back onto whichever scale the bar it annotates uses, and the tooltip regains its "would leave ~N% remaining" wording in remaining and pace modes.
- All three live in `UsageQuota`, which both `QuotaCardView` and `MenuContentView` route through, so there are no view changes.
- The headline number, bar colour, and menu bar readout are untouched.
- This is what `docs/architecture/USER_BEHAVIORS.md` #9 and #10 already specify: 65% left draws a 65% bar, and only Used mode inverts it.

## Test plan
- [ ] Open the popover in Remaining mode and confirm the bar matches the number — an 87% card draws a nearly full bar, not a sliver.
- [ ] Switch to Used mode and confirm the bar inverts: the same card reads 13% Used with a 13% bar.
- [ ] Switch to Pace mode and confirm the bar tracks the remaining number it displays.
- [ ] Find a quota at 0% remaining and confirm the bar is empty in Remaining mode and full in Used mode.
- [ ] Hover the bar in Remaining mode and confirm the tooltip reads "would leave ~N% remaining"; in Used mode, "would have used ~N%".
- [ ] Confirm the pace tick sits on the same scale as the fill in every mode, including a provider with no reset time, where Pace falls back to Used.
- [ ] `tuist test ClaudeBar -- -only-testing:DomainTests`

## Note for the reviewer
Four domain tests pinned the used-scale bar and one pinned the used-scale tooltip; those are updated, plus a new `displayProgressPercent matches displayPercent in every mode`, which is the invariant the defect broke.

I could not run `tuist test` locally — this machine has Command Line Tools only, no full Xcode, so neither Tuist nor swift-testing will link. I verified every assertion in the changed tests, and all six settings-mode paths, against a harness compiled from the real `UsageQuota.swift`. Please treat CI as the gate on the suite.

The alternative direction the issue offers, keeping the used fill and relabelling every mode "Used", is deliberately not taken here — it would undo the `Remaining` wording settled on in #54.
