### PR TITLE
fix(popover): stop the popover stretching to fill a tall display

### DIFF
--- a/Sources/App/Views/MenuContentView.swift
+++ b/Sources/App/Views/MenuContentView.swift
@@ -28,6 +28,10 @@ struct MenuContentView: View {
     @State private var pillsContentWidth: CGFloat = 0
     @State private var pillsViewportWidth: CGFloat = 0
 
+    /// Measured height of the scrollable content. Zero until the first layout
+    /// pass reports it — see `PopoverContentHeight.height`.
+    @State private var metricsContentHeight: CGFloat = 0
+
     /// The currently selected provider ID (from monitor, which is @Observable)
     private var selectedProviderId: String {
         get { monitor.selectedProviderId }
@@ -89,8 +93,11 @@ struct MenuContentView: View {
                     }
                     .padding(.horizontal, 16)
                     .padding(.bottom, 16)
+                    .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { height in
+                        metricsContentHeight = height
+                    }
                 }
-                .frame(maxHeight: contentMaxHeight)
+                .frame(height: contentHeight)
                 // Recreate the scroll view when the shown content
                 // changes, so a newly selected provider starts at the
                 // top instead of inheriting the previous scroll offset.
@@ -166,13 +173,29 @@ struct MenuContentView: View {
         }
     }
 
-    /// Upper bound for the scrollable content region — see
-    /// `PopoverContentHeight` for the policy and its tests.
-    private var contentMaxHeight: CGFloat {
-        PopoverContentHeight.maxHeight(
-            visibleScreenHeight: NSScreen.main?.visibleFrame.height ?? 800,
+    /// Height for the scrollable content region — see `PopoverContentHeight`
+    /// for the policy and its tests. A `ScrollView` fills whatever frame it is
+    /// given, so this is a height rather than a maximum: without it, a single
+    /// card stretched the popover to the cap on a tall display.
+    private var contentHeight: CGFloat {
+        PopoverContentHeight.height(
+            contentHeight: metricsContentHeight,
+            visibleScreenHeight: popoverScreenHeight,
             overviewMode: settings.overviewModeEnabled
         )
+    }
+
+    /// Height of the screen the popover is on.
+    ///
+    /// `NSScreen.main` is the screen holding the *key window*, which on a
+    /// multi-display setup is often not the one the menu bar was clicked on.
+    /// The pointer is over the status item at that moment, so the screen under
+    /// it is the better answer.
+    private var popoverScreenHeight: CGFloat {
+        let pointerLocation = NSEvent.mouseLocation
+        let screen = NSScreen.screens.first { $0.frame.contains(pointerLocation) }
+            ?? NSScreen.main
+        return screen?.visibleFrame.height ?? 800
     }
 
     // MARK: - Background Orbs

--- a/Sources/Domain/Provider/PopoverContentHeight.swift
+++ b/Sources/Domain/Provider/PopoverContentHeight.swift
@@ -28,4 +28,29 @@ public enum PopoverContentHeight {
         let available = max(visibleScreenHeight - chrome, usableFloor)
         return overviewMode ? min(overviewCeiling, available) : available
     }
+
+    /// The height the scrollable region should actually take: its content's,
+    /// capped so the action bar cannot be pushed off screen.
+    ///
+    /// A `ScrollView` is greedy — offered a tall frame it fills it — so a cap
+    /// alone is not enough. On a portrait display the cap is over 2000pt, and
+    /// a provider with a single card stretched the popover to match it.
+    ///
+    /// - Parameters:
+    ///   - contentHeight: The measured height of the content. Zero or less
+    ///     means it has not been measured yet, on the first layout pass.
+    ///   - visibleScreenHeight: `NSScreen.visibleFrame.height` of the
+    ///     screen hosting the popover.
+    ///   - overviewMode: whether the popover lists all providers.
+    public static func height(
+        contentHeight: CGFloat,
+        visibleScreenHeight: CGFloat,
+        overviewMode: Bool
+    ) -> CGFloat {
+        let cap = maxHeight(visibleScreenHeight: visibleScreenHeight, overviewMode: overviewMode)
+        // Before the first measurement, prefer the cap: a scrollable popover
+        // is recoverable, one collapsed to nothing is not.
+        guard contentHeight > 0 else { return cap }
+        return min(contentHeight, cap)
+    }
 }

--- a/Tests/DomainTests/Provider/PopoverContentHeightTests.swift
+++ b/Tests/DomainTests/Provider/PopoverContentHeightTests.swift
@@ -48,6 +48,64 @@ struct PopoverContentHeightTests {
         #expect(cap == 735 - PopoverContentHeight.chrome)
     }
 
+    // MARK: - Fitting the Content
+
+    @Test
+    func `content shorter than the cap keeps its own height`() {
+        // A provider with one card must not stretch to fill the cap.
+        let height = PopoverContentHeight.height(
+            contentHeight: 180,
+            visibleScreenHeight: 982,
+            overviewMode: false
+        )
+        #expect(height == 180)
+    }
+
+    @Test
+    func `content taller than the cap is clamped to it`() {
+        let height = PopoverContentHeight.height(
+            contentHeight: 5000,
+            visibleScreenHeight: 982,
+            overviewMode: false
+        )
+        #expect(height == PopoverContentHeight.maxHeight(visibleScreenHeight: 982, overviewMode: false))
+    }
+
+    @Test
+    func `a tall display does not stretch a short popover`() {
+        // A 2560pt portrait display leaves a ~2300pt cap. Before the content
+        // height was taken into account, one small card ballooned to fill it.
+        let height = PopoverContentHeight.height(
+            contentHeight: 220,
+            visibleScreenHeight: 2530,
+            overviewMode: false
+        )
+        #expect(height == 220)
+    }
+
+    @Test(arguments: [0.0, -40.0])
+    func `an unmeasured content height falls back to the cap`(contentHeight: Double) {
+        // First layout pass, before the geometry reader has reported. Falling
+        // back to the cap keeps the popover scrollable rather than collapsing
+        // it to nothing.
+        let height = PopoverContentHeight.height(
+            contentHeight: contentHeight,
+            visibleScreenHeight: 982,
+            overviewMode: false
+        )
+        #expect(height == PopoverContentHeight.maxHeight(visibleScreenHeight: 982, overviewMode: false))
+    }
+
+    @Test
+    func `overview still respects its ceiling when content is taller`() {
+        let height = PopoverContentHeight.height(
+            contentHeight: 5000,
+            visibleScreenHeight: 982,
+            overviewMode: true
+        )
+        #expect(height == 500)
+    }
+
     // MARK: - Degenerate Displays
 
     @Test


### PR DESCRIPTION
## The bug

On a portrait display the popover opens as a mostly empty box — a single provider card floating in roughly two thousand points of nothing.

<!-- screenshot: popover on a 1440×2560 portrait display -->

## Cause

`MenuContentView.swift` constrained the scrollable region with a *maximum*:

```swift
ScrollView { ... }.frame(maxHeight: contentMaxHeight)   // = visibleScreenHeight - 260
```

A `ScrollView` fills whatever frame it is offered, so `maxHeight` only ever permitted the height — it never asked for less. On a 982pt display the cap is ~720pt and the difference rarely showed. On a 2560pt portrait display the cap is ~2270pt, and one card stretched to meet it.

A second defect sat in the same three lines: `NSScreen.main` is the screen holding the **key window**, not the one the popover is on, so a multi-display setup could size for the wrong screen.

## Fix

`PopoverContentHeight` now answers with a height rather than a ceiling:

```swift
public static func height(contentHeight:visibleScreenHeight:overviewMode:) -> CGFloat {
    let cap = maxHeight(visibleScreenHeight:overviewMode:)
    guard contentHeight > 0 else { return cap }
    return min(contentHeight, cap)
}
```

The view measures its content with `onGeometryChange` and applies that height. An unmeasured content height falls back to the cap — on the first layout pass a scrollable popover is recoverable, one collapsed to nothing is not.

The screen is now taken from under the pointer, which is over the status item at the moment the popover opens.

## Tests

Six new cases in `PopoverContentHeightTests`, including the 2530pt portrait case that reproduced this, the clamp above the cap, the unmeasured fallback, and the overview ceiling still applying. Full suite green.

## Verification

Not verified on-device by me — checking it needs the popover open on a tall display. Worth a look before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved menu popover sizing so it fits its content without stretching unnecessarily.
  - Ensured menu height limits are calculated for the screen where the popover appears.
  - Preserved appropriate height limits for tall displays and overview mode.

- **Tests**
  - Added coverage for short, tall, and unmeasured content sizing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->