### PR TITLE
feat(notch): render Claude Code session and quota state in the notch

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -85,6 +85,8 @@ let project = Project(
                 .target(name: "Infrastructure"),
                 .external(name: "Sparkle"),
                 .external(name: "MenuBarExtraAccess"),
+                .external(name: "GlowEffectKit"),
+                .external(name: "Matrix"),
             ],
             settings: .settings(
                 base: [

--- a/Project.swift
+++ b/Project.swift
@@ -85,7 +85,6 @@ let project = Project(
                 .target(name: "Infrastructure"),
                 .external(name: "Sparkle"),
                 .external(name: "MenuBarExtraAccess"),
-                .external(name: "GlowEffectKit"),
                 .external(name: "Matrix"),
             ],
             settings: .settings(

--- a/Sources/App/ClaudeBarApp.swift
+++ b/Sources/App/ClaudeBarApp.swift
@@ -24,6 +24,10 @@ struct ClaudeBarApp: App {
     /// permanently stop re-evaluating after system sleep (issue #192).
     private let statusItemDriver: StatusItemLabelDriver
 
+    /// Draws Claude Code session and quota state into the notch. Comes up and
+    /// goes down with `app.notchEnabled`; does nothing until it is turned on.
+    private let notchDriver: NotchWindowDriver
+
     /// Binding required by `.menuBarExtraAccess`; also enables programmatic
     /// dropdown control if ever needed.
     @State private var isMenuPresented = false
@@ -153,6 +157,13 @@ struct ClaudeBarApp: App {
         )
         statusItemDriver.startMonitoringLifecycle()
         statusItemDriver.startAttachLifecycle()
+
+        notchDriver = NotchWindowDriver(
+            monitor: monitor,
+            sessionMonitor: sessionMonitor,
+            settings: AppSettings.shared
+        )
+        notchDriver.start()
 
         // Load user extensions from ~/.claudebar/extensions/
         let extensionRegistry = ExtensionRegistry(

--- a/Sources/App/Notch/NotchPanelView.swift
+++ b/Sources/App/Notch/NotchPanelView.swift
@@ -1,0 +1,139 @@
+import SwiftUI
+import Domain
+
+/// The panel that hangs below the notch on hover.
+///
+/// Themed, unlike the notch bar above it: the bar is simulating physical glass
+/// and stays black, while this is ordinary app surface.
+struct NotchPanelView: View {
+    let activity: NotchActivity
+
+    @Environment(\.appTheme) private var theme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            switch activity {
+            case .working(let session),
+                 .agentsWorking(let session),
+                 .awaitingInput(let session),
+                 .finished(let session):
+                sessionDetail(session)
+            case .quotaThreshold(let quota):
+                quotaDetail(quota)
+            }
+        }
+        .padding(.horizontal, 18)
+        .padding(.top, 4)
+        .padding(.bottom, 16)
+    }
+
+    // MARK: - Session
+
+    private func sessionDetail(_ session: ClaudeSession) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 9) {
+                Text("Claude Code")
+                    .font(.system(size: 13, weight: .semibold, design: theme.fontDesign))
+                    .foregroundStyle(.white)
+
+                Text(session.phase.label)
+                    .font(.system(size: 9.5, weight: .bold, design: theme.fontDesign))
+                    .textCase(.uppercase)
+                    .kerning(0.5)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Capsule().fill(session.phase.color.opacity(0.18)))
+                    .foregroundStyle(session.phase.color)
+
+                Spacer()
+
+                Text(session.durationDescription)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(.white.opacity(0.55))
+            }
+
+            HStack(spacing: 10) {
+                Image(systemName: "folder.fill")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.white.opacity(0.4))
+                Text(session.repoName)
+                    .font(.system(size: 11.5, design: .monospaced))
+                    .foregroundStyle(.white.opacity(0.85))
+                    .lineLimit(1)
+                    .truncationMode(.head)
+                Spacer()
+            }
+
+            if let prompt = session.pendingPrompt {
+                Text(prompt)
+                    .font(.system(size: 11.5, design: theme.fontDesign))
+                    .foregroundStyle(.yellow.opacity(0.95))
+                    .lineLimit(2)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 11)
+                    .padding(.vertical, 8)
+                    .background(
+                        RoundedRectangle(cornerRadius: 9)
+                            .fill(.yellow.opacity(0.1))
+                            .strokeBorder(.yellow.opacity(0.3))
+                    )
+            }
+
+            HStack(spacing: 14) {
+                if session.completedTaskCount > 0 {
+                    statistic("\(session.completedTaskCount)", label: "tasks")
+                }
+                if session.activeSubagentCount > 0 {
+                    statistic("\(session.activeSubagentCount)", label: "agents")
+                }
+                Spacer()
+            }
+        }
+    }
+
+    // MARK: - Quota
+
+    private func quotaDetail(_ quota: UsageQuota) -> some View {
+        let status = QuotaStatus.from(percentRemaining: quota.percentRemaining)
+
+        return VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 9) {
+                Text(quota.quotaType.displayName)
+                    .font(.system(size: 13, weight: .semibold, design: theme.fontDesign))
+                    .foregroundStyle(.white)
+                Spacer()
+                Text("\(Int(quota.percentRemaining))%")
+                    .font(.system(size: 15, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(theme.statusColor(for: status))
+            }
+
+            Capsule()
+                .fill(.white.opacity(0.14))
+                .frame(height: 6)
+                .overlay(alignment: .leading) {
+                    GeometryReader { geometry in
+                        Capsule()
+                            .fill(theme.statusColor(for: status))
+                            .frame(width: geometry.size.width * max(0, min(1, quota.percentRemaining / 100)))
+                    }
+                }
+
+            if let reset = quota.resetText ?? quota.compactResetTime {
+                Text(reset)
+                    .font(.system(size: 11, design: theme.fontDesign))
+                    .foregroundStyle(.white.opacity(0.5))
+            }
+        }
+    }
+
+    private func statistic(_ value: String, label: String) -> some View {
+        HStack(spacing: 4) {
+            Text(value)
+                .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                .foregroundStyle(.white.opacity(0.9))
+            Text(label)
+                .font(.system(size: 10.5, design: theme.fontDesign))
+                .foregroundStyle(.white.opacity(0.5))
+        }
+    }
+}

--- a/Sources/App/Notch/NotchPanelView.swift
+++ b/Sources/App/Notch/NotchPanelView.swift
@@ -34,7 +34,7 @@ struct NotchPanelView: View {
 
     private var header: some View {
         HStack(spacing: 9) {
-            Text("Claude Code")
+            Text(title)
                 .font(.system(size: 13, weight: .semibold, design: theme.fontDesign))
                 .foregroundStyle(.white)
 
@@ -59,6 +59,12 @@ struct NotchPanelView: View {
         }
     }
 
+    /// Named for what the panel is about right now: a session when one is
+    /// running, otherwise the usage the notch exists to report.
+    private var title: String {
+        content.sessions.isEmpty ? "Usage" : "Claude Code"
+    }
+
     private var headlineBadge: (text: String, color: Color)? {
         switch content.activity {
         case .awaitingInput: ("Needs you", .yellow)
@@ -66,7 +72,7 @@ struct NotchPanelView: View {
         case .working: ("Active", .green)
         case .finished: ("Done", .green)
         case .quotaThreshold: ("Low quota", .orange)
-        case nil: nil
+        case .quotaGlance, nil: nil
         }
     }
 

--- a/Sources/App/Notch/NotchPanelView.swift
+++ b/Sources/App/Notch/NotchPanelView.swift
@@ -1,139 +1,249 @@
 import SwiftUI
 import Domain
 
-/// The panel that hangs below the notch on hover.
-///
-/// Themed, unlike the notch bar above it: the bar is simulating physical glass
-/// and stays black, while this is ordinary app surface.
+/// The panel that hangs below the notch on hover: what is running, what is
+/// nearly out, and what you can do about it.
 struct NotchPanelView: View {
-    let activity: NotchActivity
+    let content: NotchContent
+    var refresh: (() -> Void)?
+    var snooze: (() -> Void)?
 
     @Environment(\.appTheme) private var theme
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            switch activity {
-            case .working(let session),
-                 .agentsWorking(let session),
-                 .awaitingInput(let session),
-                 .finished(let session):
-                sessionDetail(session)
-            case .quotaThreshold(let quota):
-                quotaDetail(quota)
+            header
+
+            if !content.sessions.isEmpty {
+                sessionList
             }
+
+            if let prompt = blockedPrompt {
+                permissionPrompt(prompt)
+            }
+
+            if !content.quotas.isEmpty {
+                quotaCards
+            }
+
+            actions
         }
-        .padding(.horizontal, 18)
-        .padding(.top, 4)
-        .padding(.bottom, 16)
     }
 
-    // MARK: - Session
+    // MARK: - Header
 
-    private func sessionDetail(_ session: ClaudeSession) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(spacing: 9) {
-                Text("Claude Code")
-                    .font(.system(size: 13, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(.white)
+    private var header: some View {
+        HStack(spacing: 9) {
+            Text("Claude Code")
+                .font(.system(size: 13, weight: .semibold, design: theme.fontDesign))
+                .foregroundStyle(.white)
 
-                Text(session.phase.label)
+            if let badge = headlineBadge {
+                Text(badge.text)
                     .font(.system(size: 9.5, weight: .bold, design: theme.fontDesign))
                     .textCase(.uppercase)
                     .kerning(0.5)
                     .padding(.horizontal, 6)
                     .padding(.vertical, 2)
-                    .background(Capsule().fill(session.phase.color.opacity(0.18)))
-                    .foregroundStyle(session.phase.color)
+                    .background(Capsule().fill(badge.color.opacity(0.18)))
+                    .foregroundStyle(badge.color)
+            }
 
-                Spacer()
+            Spacer()
 
-                Text(session.durationDescription)
+            if let summary = todaySummary {
+                Text(summary)
                     .font(.system(size: 11, design: .monospaced))
-                    .foregroundStyle(.white.opacity(0.55))
-            }
-
-            HStack(spacing: 10) {
-                Image(systemName: "folder.fill")
-                    .font(.system(size: 10))
-                    .foregroundStyle(.white.opacity(0.4))
-                Text(session.repoName)
-                    .font(.system(size: 11.5, design: .monospaced))
-                    .foregroundStyle(.white.opacity(0.85))
-                    .lineLimit(1)
-                    .truncationMode(.head)
-                Spacer()
-            }
-
-            if let prompt = session.pendingPrompt {
-                Text(prompt)
-                    .font(.system(size: 11.5, design: theme.fontDesign))
-                    .foregroundStyle(.yellow.opacity(0.95))
-                    .lineLimit(2)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, 11)
-                    .padding(.vertical, 8)
-                    .background(
-                        RoundedRectangle(cornerRadius: 9)
-                            .fill(.yellow.opacity(0.1))
-                            .strokeBorder(.yellow.opacity(0.3))
-                    )
-            }
-
-            HStack(spacing: 14) {
-                if session.completedTaskCount > 0 {
-                    statistic("\(session.completedTaskCount)", label: "tasks")
-                }
-                if session.activeSubagentCount > 0 {
-                    statistic("\(session.activeSubagentCount)", label: "agents")
-                }
-                Spacer()
-            }
-        }
-    }
-
-    // MARK: - Quota
-
-    private func quotaDetail(_ quota: UsageQuota) -> some View {
-        let status = QuotaStatus.from(percentRemaining: quota.percentRemaining)
-
-        return VStack(alignment: .leading, spacing: 10) {
-            HStack(spacing: 9) {
-                Text(quota.quotaType.displayName)
-                    .font(.system(size: 13, weight: .semibold, design: theme.fontDesign))
-                    .foregroundStyle(.white)
-                Spacer()
-                Text("\(Int(quota.percentRemaining))%")
-                    .font(.system(size: 15, weight: .semibold, design: .monospaced))
-                    .foregroundStyle(theme.statusColor(for: status))
-            }
-
-            Capsule()
-                .fill(.white.opacity(0.14))
-                .frame(height: 6)
-                .overlay(alignment: .leading) {
-                    GeometryReader { geometry in
-                        Capsule()
-                            .fill(theme.statusColor(for: status))
-                            .frame(width: geometry.size.width * max(0, min(1, quota.percentRemaining / 100)))
-                    }
-                }
-
-            if let reset = quota.resetText ?? quota.compactResetTime {
-                Text(reset)
-                    .font(.system(size: 11, design: theme.fontDesign))
                     .foregroundStyle(.white.opacity(0.5))
             }
         }
     }
 
-    private func statistic(_ value: String, label: String) -> some View {
-        HStack(spacing: 4) {
-            Text(value)
-                .font(.system(size: 12, weight: .semibold, design: .monospaced))
-                .foregroundStyle(.white.opacity(0.9))
-            Text(label)
-                .font(.system(size: 10.5, design: theme.fontDesign))
-                .foregroundStyle(.white.opacity(0.5))
+    private var headlineBadge: (text: String, color: Color)? {
+        switch content.activity {
+        case .awaitingInput: ("Needs you", .yellow)
+        case .agentsWorking(let session): ("\(session.activeSubagentCount) agents", .blue)
+        case .working: ("Active", .green)
+        case .finished: ("Done", .green)
+        case .quotaThreshold: ("Low quota", .orange)
+        case nil: nil
         }
+    }
+
+    private var todaySummary: String? {
+        guard let today = content.today else { return nil }
+        return "Today · \(today.formattedWorkingTime) · \(today.formattedCost)"
+    }
+
+    private var blockedPrompt: String? {
+        guard case .awaitingInput(let session) = content.activity else { return nil }
+        return session.pendingPrompt
+    }
+
+    // MARK: - Sessions
+
+    private var sessionList: some View {
+        VStack(spacing: 1) {
+            ForEach(content.sessions, id: \.id) { session in
+                HStack(spacing: 10) {
+                    Circle()
+                        .fill(session.phase.color)
+                        .frame(width: 7, height: 7)
+
+                    Text(session.repoName)
+                        .font(.system(size: 11.5, design: .monospaced))
+                        .foregroundStyle(.white.opacity(0.9))
+                        .lineLimit(1)
+                        .truncationMode(.head)
+
+                    Spacer(minLength: 12)
+
+                    Text(statusText(for: session))
+                        .font(.system(size: 10.5, design: theme.fontDesign))
+                        .foregroundStyle(.white.opacity(0.5))
+                        .lineLimit(1)
+
+                    Text(session.durationDescription)
+                        .font(.system(size: 10.5, design: .monospaced))
+                        .foregroundStyle(.white.opacity(0.38))
+                }
+                .padding(.horizontal, 11)
+                .padding(.vertical, 7)
+                .background(Color.white.opacity(0.04))
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 9))
+    }
+
+    private func statusText(for session: ClaudeSession) -> String {
+        switch session.phase {
+        case .awaitingInput:
+            session.pendingPrompt ?? "Waiting for you"
+        case .subagentsWorking:
+            "\(session.activeSubagentCount) agents working"
+        case .active:
+            session.completedTaskCount > 0 ? "Active · \(session.completedTaskCount) tasks" : "Active"
+        case .stopped:
+            "Turn finished"
+        case .ended:
+            session.completedTaskCount > 0 ? "Ended · \(session.completedTaskCount) tasks" : "Ended"
+        }
+    }
+
+    // MARK: - Permission prompt
+
+    private func permissionPrompt(_ prompt: String) -> some View {
+        Text(prompt)
+            .font(.system(size: 11.5, design: theme.fontDesign))
+            .foregroundStyle(.yellow.opacity(0.95))
+            .lineLimit(2)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 11)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 9)
+                    .fill(.yellow.opacity(0.1))
+                    .strokeBorder(.yellow.opacity(0.3))
+            )
+    }
+
+    // MARK: - Quotas
+
+    private var quotaCards: some View {
+        HStack(spacing: 9) {
+            ForEach(Array(content.quotas.enumerated()), id: \.offset) { _, quota in
+                quotaCard(quota)
+            }
+        }
+    }
+
+    private func quotaCard(_ quota: UsageQuota) -> some View {
+        let status = QuotaStatus.from(percentRemaining: quota.percentRemaining)
+        let color = theme.statusColor(for: status)
+
+        return VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Text(quota.compactTitle ?? quota.quotaType.shortLabel)
+                    .font(.system(size: 10.5, weight: .semibold, design: theme.fontDesign))
+                    .foregroundStyle(.white.opacity(0.72))
+                    .lineLimit(1)
+                Spacer(minLength: 4)
+                Text("\(Int(quota.percentRemaining))%")
+                    .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(color)
+            }
+
+            GeometryReader { geometry in
+                Capsule()
+                    .fill(.white.opacity(0.14))
+                    .overlay(alignment: .leading) {
+                        Capsule()
+                            .fill(color)
+                            .frame(width: geometry.size.width * progress(quota))
+                    }
+            }
+            .frame(height: 4)
+
+            Text(quota.compactResetTime.map { "resets \($0)" } ?? " ")
+                .font(.system(size: 9.5, design: theme.fontDesign))
+                .foregroundStyle(.white.opacity(0.4))
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 9)
+                .fill(.white.opacity(0.055))
+                .strokeBorder(.white.opacity(0.07))
+        )
+    }
+
+    private func progress(_ quota: UsageQuota) -> Double {
+        max(0, min(1, quota.percentRemaining / 100))
+    }
+
+    // MARK: - Actions
+
+    private var actions: some View {
+        HStack(spacing: 7) {
+            NotchActionButton(title: "Refresh quotas", isProminent: true) { refresh?() }
+            NotchActionButton(title: "Snooze 30m") { snooze?() }
+            Spacer()
+        }
+    }
+}
+
+private struct NotchActionButton: View {
+    let title: String
+    var isProminent: Bool = false
+    let action: () -> Void
+
+    @State private var isHovering = false
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 10.5, weight: .semibold))
+                .foregroundStyle(isProminent ? Color(red: 0.90, green: 0.82, blue: 1.0) : .white.opacity(0.78))
+                .padding(.horizontal, 10)
+                .padding(.vertical, 4.5)
+                .background(
+                    RoundedRectangle(cornerRadius: 7)
+                        .fill(fill)
+                        .strokeBorder(stroke)
+                )
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovering = $0 }
+    }
+
+    private var fill: Color {
+        let base = isProminent ? Color.purple.opacity(0.24) : Color.white.opacity(0.08)
+        return isHovering ? base.opacity(0.9) : base
+    }
+
+    private var stroke: Color {
+        isProminent ? .purple.opacity(0.45) : .white.opacity(0.1)
     }
 }

--- a/Sources/App/Notch/NotchRootView.swift
+++ b/Sources/App/Notch/NotchRootView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 import Domain
+import GlowEffectKit
+import Matrix
 
 /// The notch's contents: two lanes flanking the physical cutout when collapsed,
 /// a panel underneath when expanded.
@@ -58,6 +60,18 @@ struct NotchRootView: View {
                 // Extend past the content so the flares have somewhere to go.
                 .padding(.horizontal, -topCornerRadius)
         }
+        // A refresh is the one moment the numbers are known to be stale, so it
+        // gets said out loud. peakScale stays at 1 — the notch is anchored to
+        // the top edge of the screen and must not breathe against it.
+        .glowEffect(
+            isActive: state.content.isRefreshing,
+            shape: NotchShape(topCornerRadius: topCornerRadius, bottomCornerRadius: bottomCornerRadius),
+            peakScale: 1.0,
+            duration: 1.4,
+            glowOpacity: 0.30,
+            glowColors: [theme.accentPrimary, theme.accentSecondary, theme.accentPrimary],
+            lineWidth: 3
+        )
         // The notch is physical glass; it is black in every theme. Only the
         // panel hanging below it follows the app's theme.
         .environment(\.colorScheme, .dark)
@@ -93,7 +107,7 @@ struct NotchRootView: View {
             }
         case .agentsWorking(let session):
             NotchLane {
-                AgentDots()
+                DotmSquare3(size: 15, color: .blue)
                 NotchLabel(session.repoName)
             }
         case .awaitingInput:
@@ -127,11 +141,15 @@ struct NotchRootView: View {
     private var trailing: some View {
         switch state.activity {
         case .working(let session):
-            ElapsedLabel(session: session)
+            NotchLane {
+                ElapsedLabel(session: session).fixedSize()
+                headlineGauge
+            }
         case .agentsWorking(let session):
             NotchLane {
                 NotchMeta("\(session.activeSubagentCount) agents")
                 ElapsedLabel(session: session)
+                headlineGauge
             }
         case .awaitingInput(let session):
             NotchMeta(session.pendingPrompt ?? "Waiting for you")
@@ -144,16 +162,43 @@ struct NotchRootView: View {
                     NotchMeta("\(session.completedTaskCount) tasks")
                 }
                 NotchMeta(session.durationDescription)
+                headlineGauge
             }
         case .quotaThreshold(let quota), .quotaGlance(let quota):
             NotchLane {
-                QuotaBar(percentRemaining: quota.percentRemaining, color: quotaColor(quota))
+                if state.content.isRefreshing {
+                    DotmSquare3(size: 12, color: quotaColor(quota))
+                } else {
+                    QuotaBar(percentRemaining: quota.percentRemaining, color: quotaColor(quota))
+                }
                 if let reset = quota.compactResetTime {
-                    NotchMeta(reset)
+                    NotchMeta(reset).fixedSize()
                 }
             }
         case nil:
             EmptyView()
+        }
+    }
+
+    /// The quota reading, carried alongside whatever else the notch is saying.
+    /// A session running is not a reason to stop showing how much is left.
+    @ViewBuilder
+    private var headlineGauge: some View {
+        if let quota = state.content.headline {
+            HStack(spacing: 6) {
+                Rectangle()
+                    .fill(.white.opacity(0.18))
+                    .frame(width: 1, height: 11)
+
+                NotchMeta("\(quota.compactTitle ?? quota.quotaType.shortLabel) \(Int(quota.percentRemaining))%")
+                    .fixedSize()
+
+                if state.content.isRefreshing {
+                    DotmSquare3(size: 11, color: quotaColor(quota))
+                } else {
+                    QuotaBar(percentRemaining: quota.percentRemaining, color: quotaColor(quota))
+                }
+            }
         }
     }
 
@@ -232,28 +277,6 @@ private struct PhaseDot: View {
                     isBreathing = true
                 }
             }
-    }
-}
-
-private struct AgentDots: View {
-    @State private var phase = false
-
-    var body: some View {
-        HStack(spacing: 3) {
-            ForEach(0..<3, id: \.self) { index in
-                Circle()
-                    .fill(.blue)
-                    .frame(width: 5, height: 5)
-                    .offset(y: phase ? -1.5 : 1.5)
-                    .animation(
-                        .easeInOut(duration: 0.55)
-                            .repeatForever(autoreverses: true)
-                            .delay(Double(index) * 0.15),
-                        value: phase
-                    )
-            }
-        }
-        .onAppear { phase = true }
     }
 }
 

--- a/Sources/App/Notch/NotchRootView.swift
+++ b/Sources/App/Notch/NotchRootView.swift
@@ -110,9 +110,9 @@ struct NotchRootView: View {
                     .foregroundStyle(.green)
                 NotchLabel(session.repoName)
             }
-        case .quotaThreshold(let quota):
+        case .quotaThreshold(let quota), .quotaGlance(let quota):
             NotchLane {
-                NotchLabel(quota.quotaType.shortLabel)
+                NotchLabel(quota.compactTitle ?? quota.quotaType.shortLabel)
                 Text("\(Int(quota.percentRemaining))%")
                     .font(.system(size: 11, weight: .semibold))
                     .monospacedDigit()
@@ -145,7 +145,7 @@ struct NotchRootView: View {
                 }
                 NotchMeta(session.durationDescription)
             }
-        case .quotaThreshold(let quota):
+        case .quotaThreshold(let quota), .quotaGlance(let quota):
             NotchLane {
                 QuotaBar(percentRemaining: quota.percentRemaining, color: quotaColor(quota))
                 if let reset = quota.compactResetTime {

--- a/Sources/App/Notch/NotchRootView.swift
+++ b/Sources/App/Notch/NotchRootView.swift
@@ -25,6 +25,16 @@ struct NotchRootView: View {
     private var barHeight: CGFloat { state.metrics.closedSize.height }
 
     var body: some View {
+        // Nothing to report draws nothing at all — not even the closed shape.
+        // See NotchWindowController.update(content:).
+        if state.activity == nil {
+            Color.clear.frame(width: 0, height: 0)
+        } else {
+            notch
+        }
+    }
+
+    private var notch: some View {
         VStack(spacing: 0) {
             collapsedBar
             if state.isExpanded {

--- a/Sources/App/Notch/NotchRootView.swift
+++ b/Sources/App/Notch/NotchRootView.swift
@@ -27,11 +27,18 @@ struct NotchRootView: View {
     var body: some View {
         VStack(spacing: 0) {
             collapsedBar
-            if state.isExpanded, let activity = state.activity {
-                NotchPanelView(activity: activity)
-                    .environment(\.appTheme, theme)
-                    .frame(width: 520)
-                    .transition(.opacity.combined(with: .move(edge: .top)))
+            if state.isExpanded {
+                NotchPanelView(
+                    content: state.content,
+                    refresh: state.refresh,
+                    snooze: state.snooze
+                )
+                .environment(\.appTheme, theme)
+                .padding(.horizontal, 18)
+                .padding(.top, 6)
+                .padding(.bottom, 16)
+                .frame(width: 600)
+                .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
         .fixedSize()

--- a/Sources/App/Notch/NotchRootView.swift
+++ b/Sources/App/Notch/NotchRootView.swift
@@ -22,25 +22,26 @@ struct NotchRootView: View {
         )
     }
 
-    /// The refresh bloom.
+    /// The refresh bloom — GlowEffectKit's documented configuration, with the
+    /// line width from its own 160pt example since the notch is a comparable
+    /// size.
     ///
-    /// `glowOpacity` is passed at its floor on purpose: GlowEffectKit renders
-    /// the border at `max(glowOpacity, 0.72)`, so anything lower is silently
-    /// ignored. Spread is controlled by `lineWidth` (its blur radius is fixed
-    /// internally) and falloff by `amplitude` — those are the knobs that work.
+    /// `peakScale` is deliberately left above 1. It drives the only repeating
+    /// `.animation` in the modifier, and pinning it to 1 (to stop the notch
+    /// breathing against the screen edge) left the colour sweep looking frozen.
+    /// At 1.02 the notch widens by a couple of points at the peak.
     ///
-    /// The colours are the library's own defaults rather than the app accent:
-    /// a single hue reads as a flat outline, while the full sweep is what makes
-    /// it read as light rather than as a border.
-    ///
-    /// `peakScale` stays at 1 — the notch is anchored to the top edge of the
-    /// screen and must not breathe against it.
+    /// `glowOpacity` is the library's documented value, but note it cannot dim
+    /// the effect: the border renders at `max(glowOpacity, 0.72)`. Spread comes
+    /// from `lineWidth` — its blur radius is fixed internally — and falloff
+    /// from `amplitude`.
     private static let refreshGlow = GlowEffectConfiguration(
-        peakScale: 1.0,
-        duration: 1.9,
-        glowOpacity: 0.72,
-        lineWidth: 9,
-        amplitude: 3.4
+        peakScale: 1.02,
+        duration: 2.0,
+        glowOpacity: 0.24,
+        lineWidth: 8,
+        amplitude: 2.5,
+        minimumTimelineInterval: 1.0 / 30.0
     )
 
     private var topCornerRadius: CGFloat { state.isExpanded ? 12 : 6 }

--- a/Sources/App/Notch/NotchRootView.swift
+++ b/Sources/App/Notch/NotchRootView.swift
@@ -1,0 +1,257 @@
+import SwiftUI
+import Domain
+
+/// The notch's contents: two lanes flanking the physical cutout when collapsed,
+/// a panel underneath when expanded.
+///
+/// The middle of the collapsed bar is deliberately kept clear — on a display
+/// with a real notch that space is the cutout, and anything drawn there is
+/// invisible.
+struct NotchRootView: View {
+    @Bindable var state: NotchViewState
+
+    /// Resolved here rather than injected, so the notch follows a theme change
+    /// without the window having to be torn down and rebuilt. Reading the
+    /// observable setting inside `body` is what registers that tracking.
+    private var theme: any AppThemeProvider {
+        ThemeRegistry.shared.resolveTheme(
+            for: AppSettings.shared.themeMode,
+            systemColorScheme: .dark
+        )
+    }
+
+    private var topCornerRadius: CGFloat { state.isExpanded ? 12 : 6 }
+    private var bottomCornerRadius: CGFloat { state.isExpanded ? 22 : 14 }
+    private var barHeight: CGFloat { state.metrics.closedSize.height }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            collapsedBar
+            if state.isExpanded, let activity = state.activity {
+                NotchPanelView(activity: activity)
+                    .environment(\.appTheme, theme)
+                    .frame(width: 520)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .fixedSize()
+        .background {
+            NotchShape(topCornerRadius: topCornerRadius, bottomCornerRadius: bottomCornerRadius)
+                .fill(.black)
+                // Extend past the content so the flares have somewhere to go.
+                .padding(.horizontal, -topCornerRadius)
+        }
+        // The notch is physical glass; it is black in every theme. Only the
+        // panel hanging below it follows the app's theme.
+        .environment(\.colorScheme, .dark)
+        .onGeometryChange(for: CGSize.self) { $0.size } action: { size in
+            state.contentSize = size
+        }
+        .animation(.spring(response: 0.34, dampingFraction: 0.82), value: state.isExpanded)
+        .animation(.spring(response: 0.42, dampingFraction: 0.85), value: state.activity)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+
+    private var collapsedBar: some View {
+        HStack(spacing: 0) {
+            leading
+                .padding(.leading, state.activity == nil ? 0 : 12)
+            // Reserve the cutout itself — on a display with a real notch this
+            // space is the hole, and anything drawn in it is invisible.
+            Color.clear
+                .frame(width: state.metrics.closedSize.width)
+            trailing
+                .padding(.trailing, state.activity == nil ? 0 : 12)
+        }
+        .frame(height: barHeight)
+    }
+
+    @ViewBuilder
+    private var leading: some View {
+        switch state.activity {
+        case .working(let session):
+            NotchLane {
+                PhaseDot(color: .green, pulsing: true)
+                NotchLabel(session.repoName)
+            }
+        case .agentsWorking(let session):
+            NotchLane {
+                AgentDots()
+                NotchLabel(session.repoName)
+            }
+        case .awaitingInput:
+            NotchLane {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.yellow)
+                NotchLabel("Needs you")
+            }
+        case .finished(let session):
+            NotchLane {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.green)
+                NotchLabel(session.repoName)
+            }
+        case .quotaThreshold(let quota):
+            NotchLane {
+                NotchLabel(quota.quotaType.shortLabel)
+                Text("\(Int(quota.percentRemaining))%")
+                    .font(.system(size: 11, weight: .semibold))
+                    .monospacedDigit()
+                    .foregroundStyle(quotaColor(quota))
+            }
+        case nil:
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private var trailing: some View {
+        switch state.activity {
+        case .working(let session):
+            ElapsedLabel(session: session)
+        case .agentsWorking(let session):
+            NotchLane {
+                NotchMeta("\(session.activeSubagentCount) agents")
+                ElapsedLabel(session: session)
+            }
+        case .awaitingInput(let session):
+            NotchMeta(session.pendingPrompt ?? "Waiting for you")
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .frame(maxWidth: 220)
+        case .finished(let session):
+            NotchLane {
+                if session.completedTaskCount > 0 {
+                    NotchMeta("\(session.completedTaskCount) tasks")
+                }
+                NotchMeta(session.durationDescription)
+            }
+        case .quotaThreshold(let quota):
+            NotchLane {
+                QuotaBar(percentRemaining: quota.percentRemaining, color: quotaColor(quota))
+                if let reset = quota.compactResetTime {
+                    NotchMeta(reset)
+                }
+            }
+        case nil:
+            EmptyView()
+        }
+    }
+
+    private func quotaColor(_ quota: UsageQuota) -> Color {
+        theme.statusColor(for: QuotaStatus.from(percentRemaining: quota.percentRemaining))
+    }
+}
+
+// MARK: - Pieces
+
+private struct NotchLane<Content: View>: View {
+    @ViewBuilder var content: Content
+
+    var body: some View {
+        HStack(spacing: 7) { content }
+    }
+}
+
+private struct NotchLabel: View {
+    let text: String
+    init(_ text: String) { self.text = text }
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 11.5, weight: .semibold))
+            .foregroundStyle(.white.opacity(0.92))
+            .lineLimit(1)
+    }
+}
+
+private struct NotchMeta: View {
+    let text: String
+    init(_ text: String) { self.text = text }
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 11, weight: .medium))
+            .monospacedDigit()
+            .foregroundStyle(.white.opacity(0.62))
+            .lineLimit(1)
+    }
+}
+
+/// Ticks once a second so the elapsed time stays true without the rest of the
+/// app having to repaint.
+private struct ElapsedLabel: View {
+    let session: ClaudeSession
+
+    var body: some View {
+        TimelineView(.periodic(from: .now, by: 1)) { _ in
+            NotchMeta(session.durationDescription)
+        }
+    }
+}
+
+private struct PhaseDot: View {
+    let color: Color
+    var pulsing: Bool = false
+
+    @State private var isBreathing = false
+
+    var body: some View {
+        Circle()
+            .fill(color)
+            .frame(width: 8, height: 8)
+            .overlay {
+                Circle()
+                    .fill(color.opacity(0.35))
+                    .frame(width: 16, height: 16)
+                    .scaleEffect(isBreathing ? 1.0 : 0.6)
+                    .opacity(isBreathing ? 0.1 : 0.4)
+            }
+            .onAppear {
+                guard pulsing else { return }
+                withAnimation(.easeInOut(duration: 1.9).repeatForever(autoreverses: true)) {
+                    isBreathing = true
+                }
+            }
+    }
+}
+
+private struct AgentDots: View {
+    @State private var phase = false
+
+    var body: some View {
+        HStack(spacing: 3) {
+            ForEach(0..<3, id: \.self) { index in
+                Circle()
+                    .fill(.blue)
+                    .frame(width: 5, height: 5)
+                    .offset(y: phase ? -1.5 : 1.5)
+                    .animation(
+                        .easeInOut(duration: 0.55)
+                            .repeatForever(autoreverses: true)
+                            .delay(Double(index) * 0.15),
+                        value: phase
+                    )
+            }
+        }
+        .onAppear { phase = true }
+    }
+}
+
+private struct QuotaBar: View {
+    let percentRemaining: Double
+    let color: Color
+
+    var body: some View {
+        Capsule()
+            .fill(.white.opacity(0.16))
+            .frame(width: 52, height: 4)
+            .overlay(alignment: .leading) {
+                Capsule()
+                    .fill(color)
+                    .frame(width: 52 * max(0, min(1, percentRemaining / 100)))
+            }
+    }
+}

--- a/Sources/App/Notch/NotchRootView.swift
+++ b/Sources/App/Notch/NotchRootView.swift
@@ -55,23 +55,27 @@ struct NotchRootView: View {
         }
         .fixedSize()
         .background {
+            // The glow is applied here, before the negative padding, so it
+            // traces the same rect the black shape is drawn in. Applied outside
+            // the background it would stroke the content frame instead — a
+            // silhouette 2×topCornerRadius narrower than the notch it outlines.
+            //
+            // peakScale stays at 1: the notch is anchored to the top edge of the
+            // screen and must not breathe against it.
             NotchShape(topCornerRadius: topCornerRadius, bottomCornerRadius: bottomCornerRadius)
                 .fill(.black)
+                .glowEffect(
+                    isActive: state.content.isRefreshing,
+                    shape: NotchShape(topCornerRadius: topCornerRadius, bottomCornerRadius: bottomCornerRadius),
+                    peakScale: 1.0,
+                    duration: 1.6,
+                    glowOpacity: 0.16,
+                    glowColors: [theme.accentPrimary, theme.accentSecondary, theme.accentPrimary],
+                    lineWidth: 2
+                )
                 // Extend past the content so the flares have somewhere to go.
                 .padding(.horizontal, -topCornerRadius)
         }
-        // A refresh is the one moment the numbers are known to be stale, so it
-        // gets said out loud. peakScale stays at 1 — the notch is anchored to
-        // the top edge of the screen and must not breathe against it.
-        .glowEffect(
-            isActive: state.content.isRefreshing,
-            shape: NotchShape(topCornerRadius: topCornerRadius, bottomCornerRadius: bottomCornerRadius),
-            peakScale: 1.0,
-            duration: 1.4,
-            glowOpacity: 0.30,
-            glowColors: [theme.accentPrimary, theme.accentSecondary, theme.accentPrimary],
-            lineWidth: 3
-        )
         // The notch is physical glass; it is black in every theme. Only the
         // panel hanging below it follows the app's theme.
         .environment(\.colorScheme, .dark)

--- a/Sources/App/Notch/NotchRootView.swift
+++ b/Sources/App/Notch/NotchRootView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import Domain
-import GlowEffectKit
 import Matrix
 
 /// The notch's contents: two lanes flanking the physical cutout when collapsed,
@@ -54,26 +53,13 @@ struct NotchRootView: View {
             }
         }
         .fixedSize()
+        // Room for the flares, so the notch's frame is the notch's silhouette.
+        // Everything downstream then lines up on one rect: the shape fills it
+        // and onGeometryChange measures it.
+        .padding(.horizontal, topCornerRadius)
         .background {
-            // Applied here, inside the background and before the negative
-            // padding, so the glow traces the same rect the black shape is
-            // drawn in. Outside it would stroke the content frame — a
-            // silhouette 2×topCornerRadius narrower than the notch it outlines.
-            //
-            // The glow follows the open contour, so light comes off the visible
-            // underside instead of boxing the notch in.
             NotchShape(topCornerRadius: topCornerRadius, bottomCornerRadius: bottomCornerRadius)
                 .fill(.black)
-                .glowEffect(
-                    isActive: state.content.isRefreshing,
-                    shape: NotchGlowContour(
-                        topCornerRadius: topCornerRadius,
-                        bottomCornerRadius: bottomCornerRadius
-                    ),
-                    lineWidth: 8
-                )
-                // Extend past the content so the flares have somewhere to go.
-                .padding(.horizontal, -topCornerRadius)
         }
         // The notch is physical glass; it is black in every theme. Only the
         // panel hanging below it follows the app's theme.

--- a/Sources/App/Notch/NotchRootView.swift
+++ b/Sources/App/Notch/NotchRootView.swift
@@ -22,28 +22,6 @@ struct NotchRootView: View {
         )
     }
 
-    /// The refresh bloom — GlowEffectKit's documented configuration, with the
-    /// line width from its own 160pt example since the notch is a comparable
-    /// size.
-    ///
-    /// `peakScale` is deliberately left above 1. It drives the only repeating
-    /// `.animation` in the modifier, and pinning it to 1 (to stop the notch
-    /// breathing against the screen edge) left the colour sweep looking frozen.
-    /// At 1.02 the notch widens by a couple of points at the peak.
-    ///
-    /// `glowOpacity` is the library's documented value, but note it cannot dim
-    /// the effect: the border renders at `max(glowOpacity, 0.72)`. Spread comes
-    /// from `lineWidth` — its blur radius is fixed internally — and falloff
-    /// from `amplitude`.
-    private static let refreshGlow = GlowEffectConfiguration(
-        peakScale: 1.02,
-        duration: 2.0,
-        glowOpacity: 0.24,
-        lineWidth: 8,
-        amplitude: 2.5,
-        minimumTimelineInterval: 1.0 / 30.0
-    )
-
     private var topCornerRadius: CGFloat { state.isExpanded ? 12 : 6 }
     private var bottomCornerRadius: CGFloat { state.isExpanded ? 22 : 14 }
     private var barHeight: CGFloat { state.metrics.closedSize.height }
@@ -92,7 +70,7 @@ struct NotchRootView: View {
                         topCornerRadius: topCornerRadius,
                         bottomCornerRadius: bottomCornerRadius
                     ),
-                    configuration: Self.refreshGlow
+                    lineWidth: 8
                 )
                 // Extend past the content so the flares have somewhere to go.
                 .padding(.horizontal, -topCornerRadius)

--- a/Sources/App/Notch/NotchRootView.swift
+++ b/Sources/App/Notch/NotchRootView.swift
@@ -22,6 +22,27 @@ struct NotchRootView: View {
         )
     }
 
+    /// The refresh bloom.
+    ///
+    /// `glowOpacity` is passed at its floor on purpose: GlowEffectKit renders
+    /// the border at `max(glowOpacity, 0.72)`, so anything lower is silently
+    /// ignored. Spread is controlled by `lineWidth` (its blur radius is fixed
+    /// internally) and falloff by `amplitude` — those are the knobs that work.
+    ///
+    /// The colours are the library's own defaults rather than the app accent:
+    /// a single hue reads as a flat outline, while the full sweep is what makes
+    /// it read as light rather than as a border.
+    ///
+    /// `peakScale` stays at 1 — the notch is anchored to the top edge of the
+    /// screen and must not breathe against it.
+    private static let refreshGlow = GlowEffectConfiguration(
+        peakScale: 1.0,
+        duration: 1.9,
+        glowOpacity: 0.72,
+        lineWidth: 9,
+        amplitude: 3.4
+    )
+
     private var topCornerRadius: CGFloat { state.isExpanded ? 12 : 6 }
     private var bottomCornerRadius: CGFloat { state.isExpanded ? 22 : 14 }
     private var barHeight: CGFloat { state.metrics.closedSize.height }
@@ -55,23 +76,22 @@ struct NotchRootView: View {
         }
         .fixedSize()
         .background {
-            // The glow is applied here, before the negative padding, so it
-            // traces the same rect the black shape is drawn in. Applied outside
-            // the background it would stroke the content frame instead — a
+            // Applied here, inside the background and before the negative
+            // padding, so the glow traces the same rect the black shape is
+            // drawn in. Outside it would stroke the content frame — a
             // silhouette 2×topCornerRadius narrower than the notch it outlines.
             //
-            // peakScale stays at 1: the notch is anchored to the top edge of the
-            // screen and must not breathe against it.
+            // The glow follows the open contour, so light comes off the visible
+            // underside instead of boxing the notch in.
             NotchShape(topCornerRadius: topCornerRadius, bottomCornerRadius: bottomCornerRadius)
                 .fill(.black)
                 .glowEffect(
                     isActive: state.content.isRefreshing,
-                    shape: NotchShape(topCornerRadius: topCornerRadius, bottomCornerRadius: bottomCornerRadius),
-                    peakScale: 1.0,
-                    duration: 1.6,
-                    glowOpacity: 0.16,
-                    glowColors: [theme.accentPrimary, theme.accentSecondary, theme.accentPrimary],
-                    lineWidth: 2
+                    shape: NotchGlowContour(
+                        topCornerRadius: topCornerRadius,
+                        bottomCornerRadius: bottomCornerRadius
+                    ),
+                    configuration: Self.refreshGlow
                 )
                 // Extend past the content so the flares have somewhere to go.
                 .padding(.horizontal, -topCornerRadius)

--- a/Sources/App/Notch/NotchShape.swift
+++ b/Sources/App/Notch/NotchShape.swift
@@ -27,25 +27,6 @@ struct NotchShape: Shape {
     }
 
     func path(in rect: CGRect) -> Path {
-        var path = Self.visibleContour(
-            in: rect,
-            topCornerRadius: topCornerRadius,
-            bottomCornerRadius: bottomCornerRadius
-        )
-        // Close it back along the top, which the fill needs and the silhouette
-        // does not.
-        path.addLine(to: CGPoint(x: rect.minX, y: rect.minY))
-        return path
-    }
-
-    /// The contour a person can actually see: down the left flare, around the
-    /// bottom, back up the right. Open at the top, because that edge runs along
-    /// the screen bezel.
-    static func visibleContour(
-        in rect: CGRect,
-        topCornerRadius: CGFloat,
-        bottomCornerRadius: CGFloat
-    ) -> Path {
         var path = Path()
 
         path.move(to: CGPoint(x: rect.minX, y: rect.minY))
@@ -78,33 +59,9 @@ struct NotchShape: Shape {
             control: CGPoint(x: rect.maxX - topCornerRadius, y: rect.minY)
         )
 
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.minY))
+
         return path
-    }
-}
-
-/// The notch's visible silhouette, as an open path.
-///
-/// Glowing the closed `NotchShape` lights the top edge too — an edge that runs
-/// along the screen bezel where nobody can see it, and which makes the effect
-/// read as a box drawn around the notch rather than light coming off it.
-struct NotchGlowContour: Shape {
-    var topCornerRadius: CGFloat
-    var bottomCornerRadius: CGFloat
-
-    var animatableData: AnimatablePair<CGFloat, CGFloat> {
-        get { AnimatablePair(topCornerRadius, bottomCornerRadius) }
-        set {
-            topCornerRadius = newValue.first
-            bottomCornerRadius = newValue.second
-        }
-    }
-
-    func path(in rect: CGRect) -> Path {
-        NotchShape.visibleContour(
-            in: rect,
-            topCornerRadius: topCornerRadius,
-            bottomCornerRadius: bottomCornerRadius
-        )
     }
 }
 

--- a/Sources/App/Notch/NotchShape.swift
+++ b/Sources/App/Notch/NotchShape.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+/// The notch silhouette: concave flares at the top where it meets the menu bar,
+/// convex corners at the bottom where it hangs into the desktop.
+///
+/// Adapted from boring.notch's `NotchShape`, itself descended from
+/// MrKai77/DynamicNotchKit. Both radii are animatable, so the corners round out
+/// as the notch grows — that easing is most of what sells the morph.
+///
+/// The path spans the whole rect, with the body inset by `topCornerRadius` on
+/// each side to leave room for the flares.
+struct NotchShape: Shape {
+    var topCornerRadius: CGFloat
+    var bottomCornerRadius: CGFloat
+
+    init(topCornerRadius: CGFloat = 6, bottomCornerRadius: CGFloat = 14) {
+        self.topCornerRadius = topCornerRadius
+        self.bottomCornerRadius = bottomCornerRadius
+    }
+
+    var animatableData: AnimatablePair<CGFloat, CGFloat> {
+        get { AnimatablePair(topCornerRadius, bottomCornerRadius) }
+        set {
+            topCornerRadius = newValue.first
+            bottomCornerRadius = newValue.second
+        }
+    }
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+
+        path.move(to: CGPoint(x: rect.minX, y: rect.minY))
+
+        // Concave flare into the left edge of the body.
+        path.addQuadCurve(
+            to: CGPoint(x: rect.minX + topCornerRadius, y: rect.minY + topCornerRadius),
+            control: CGPoint(x: rect.minX + topCornerRadius, y: rect.minY)
+        )
+
+        path.addLine(to: CGPoint(x: rect.minX + topCornerRadius, y: rect.maxY - bottomCornerRadius))
+
+        path.addQuadCurve(
+            to: CGPoint(x: rect.minX + topCornerRadius + bottomCornerRadius, y: rect.maxY),
+            control: CGPoint(x: rect.minX + topCornerRadius, y: rect.maxY)
+        )
+
+        path.addLine(to: CGPoint(x: rect.maxX - topCornerRadius - bottomCornerRadius, y: rect.maxY))
+
+        path.addQuadCurve(
+            to: CGPoint(x: rect.maxX - topCornerRadius, y: rect.maxY - bottomCornerRadius),
+            control: CGPoint(x: rect.maxX - topCornerRadius, y: rect.maxY)
+        )
+
+        path.addLine(to: CGPoint(x: rect.maxX - topCornerRadius, y: rect.minY + topCornerRadius))
+
+        // Concave flare out to the right edge.
+        path.addQuadCurve(
+            to: CGPoint(x: rect.maxX, y: rect.minY),
+            control: CGPoint(x: rect.maxX - topCornerRadius, y: rect.minY)
+        )
+
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.minY))
+
+        return path
+    }
+}
+
+#Preview {
+    NotchShape(topCornerRadius: 8, bottomCornerRadius: 16)
+        .fill(.black)
+        .frame(width: 320, height: 44)
+        .padding(40)
+        .background(.gray)
+}

--- a/Sources/App/Notch/NotchShape.swift
+++ b/Sources/App/Notch/NotchShape.swift
@@ -27,6 +27,25 @@ struct NotchShape: Shape {
     }
 
     func path(in rect: CGRect) -> Path {
+        var path = Self.visibleContour(
+            in: rect,
+            topCornerRadius: topCornerRadius,
+            bottomCornerRadius: bottomCornerRadius
+        )
+        // Close it back along the top, which the fill needs and the silhouette
+        // does not.
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.minY))
+        return path
+    }
+
+    /// The contour a person can actually see: down the left flare, around the
+    /// bottom, back up the right. Open at the top, because that edge runs along
+    /// the screen bezel.
+    static func visibleContour(
+        in rect: CGRect,
+        topCornerRadius: CGFloat,
+        bottomCornerRadius: CGFloat
+    ) -> Path {
         var path = Path()
 
         path.move(to: CGPoint(x: rect.minX, y: rect.minY))
@@ -59,9 +78,33 @@ struct NotchShape: Shape {
             control: CGPoint(x: rect.maxX - topCornerRadius, y: rect.minY)
         )
 
-        path.addLine(to: CGPoint(x: rect.minX, y: rect.minY))
-
         return path
+    }
+}
+
+/// The notch's visible silhouette, as an open path.
+///
+/// Glowing the closed `NotchShape` lights the top edge too — an edge that runs
+/// along the screen bezel where nobody can see it, and which makes the effect
+/// read as a box drawn around the notch rather than light coming off it.
+struct NotchGlowContour: Shape {
+    var topCornerRadius: CGFloat
+    var bottomCornerRadius: CGFloat
+
+    var animatableData: AnimatablePair<CGFloat, CGFloat> {
+        get { AnimatablePair(topCornerRadius, bottomCornerRadius) }
+        set {
+            topCornerRadius = newValue.first
+            bottomCornerRadius = newValue.second
+        }
+    }
+
+    func path(in rect: CGRect) -> Path {
+        NotchShape.visibleContour(
+            in: rect,
+            topCornerRadius: topCornerRadius,
+            bottomCornerRadius: bottomCornerRadius
+        )
     }
 }
 

--- a/Sources/App/Notch/NotchViewState.swift
+++ b/Sources/App/Notch/NotchViewState.swift
@@ -19,6 +19,13 @@ struct NotchContent: Equatable {
     /// Today's usage, for the panel header.
     var today: DailyUsageStat?
 
+    /// The quota the user chose to watch. Kept even while a session has the
+    /// notch, so the gauge never disappears just because Claude is busy.
+    var headline: UsageQuota?
+
+    /// Whether a probe is in flight, which the notch shows rather than hides.
+    var isRefreshing = false
+
     static let empty = NotchContent()
 }
 

--- a/Sources/App/Notch/NotchViewState.swift
+++ b/Sources/App/Notch/NotchViewState.swift
@@ -2,17 +2,36 @@ import Foundation
 import Observation
 import Domain
 
+/// Everything the notch draws, in one Equatable value.
+///
+/// The driver resolves this from the monitors and hands it over whole, so the
+/// window never reaches back into app state.
+struct NotchContent: Equatable {
+    /// The single activity worth showing, resolved by `NotchActivityResolver`.
+    var activity: NotchActivity?
+
+    /// Sessions worth listing in the expanded panel, most relevant first.
+    var sessions: [ClaudeSession] = []
+
+    /// The quotas closest to running out, most depleted first.
+    var quotas: [UsageQuota] = []
+
+    /// Today's usage, for the panel header.
+    var today: DailyUsageStat?
+
+    static let empty = NotchContent()
+}
+
 /// What the notch is currently showing, and how big it came out.
 ///
-/// The window controller writes `activity` and `metrics`; the SwiftUI content
+/// The window controller writes `content` and `metrics`; the SwiftUI content
 /// writes `contentSize` back once it has laid itself out, which is what the
 /// window uses to decide which clicks belong to the notch and which fall
 /// through to the menu bar.
 @MainActor
 @Observable
 final class NotchViewState {
-    /// The single activity worth showing, resolved by `NotchActivityResolver`.
-    var activity: NotchActivity?
+    var content: NotchContent = .empty
 
     /// The measured notch region for the display the window sits on.
     var metrics: NotchMetrics = NotchMetrics(
@@ -26,8 +45,10 @@ final class NotchViewState {
     /// Size of the drawn notch, reported by the content after layout.
     var contentSize: CGSize = .zero
 
-    /// Nothing to say and nothing to hover: the notch is just the notch.
-    var isIdle: Bool {
-        activity == nil && !isExpanded
-    }
+    /// What the panel does when its buttons are pressed. Supplied by the driver
+    /// so the view stays free of app plumbing.
+    var refresh: (() -> Void)?
+    var snooze: (() -> Void)?
+
+    var activity: NotchActivity? { content.activity }
 }

--- a/Sources/App/Notch/NotchViewState.swift
+++ b/Sources/App/Notch/NotchViewState.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Observation
+import Domain
+
+/// What the notch is currently showing, and how big it came out.
+///
+/// The window controller writes `activity` and `metrics`; the SwiftUI content
+/// writes `contentSize` back once it has laid itself out, which is what the
+/// window uses to decide which clicks belong to the notch and which fall
+/// through to the menu bar.
+@MainActor
+@Observable
+final class NotchViewState {
+    /// The single activity worth showing, resolved by `NotchActivityResolver`.
+    var activity: NotchActivity?
+
+    /// The measured notch region for the display the window sits on.
+    var metrics: NotchMetrics = NotchMetrics(
+        closedSize: CGSize(width: NotchMetrics.defaultWidth, height: NotchMetrics.defaultHeight),
+        isPhysicalNotch: false
+    )
+
+    /// Whether the pointer is over the notch, expanding it into a panel.
+    var isExpanded = false
+
+    /// Size of the drawn notch, reported by the content after layout.
+    var contentSize: CGSize = .zero
+
+    /// Nothing to say and nothing to hover: the notch is just the notch.
+    var isIdle: Bool {
+        activity == nil && !isExpanded
+    }
+}

--- a/Sources/App/Notch/NotchWindow.swift
+++ b/Sources/App/Notch/NotchWindow.swift
@@ -1,0 +1,71 @@
+import AppKit
+import SwiftUI
+
+/// The panel the notch is drawn in.
+///
+/// A fixed, oversized, transparent canvas anchored to the top of the screen —
+/// the notch animates *inside* it rather than the window resizing, which is how
+/// both boring.notch and DynamicNotch avoid visible resize jank.
+///
+/// `canBecomeKey` and `canBecomeMain` stay false on purpose. ClaudeBar's notch
+/// has nothing to type into, and it must never pull focus from the terminal the
+/// user is working in.
+final class NotchWindow: NSPanel {
+    init(contentRect: NSRect) {
+        super.init(
+            contentRect: contentRect,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+
+        isFloatingPanel = true
+        isOpaque = false
+        backgroundColor = .clear
+        hasShadow = false
+        isMovable = false
+        isMovableByWindowBackground = false
+        hidesOnDeactivate = false
+        animationBehavior = .none
+        acceptsMouseMovedEvents = true
+        // The canvas is far wider than the notch and sits over the menu bar.
+        // It stays transparent to the mouse until the pointer is actually over
+        // the notch — see NotchWindowController.updateMouseTracking.
+        ignoresMouseEvents = true
+        isReleasedWhenClosed = false
+        titleVisibility = .hidden
+        titlebarAppearsTransparent = true
+
+        // Above the menu bar. Both reference implementations converged here.
+        level = .mainMenu + 3
+
+        collectionBehavior = [
+            .canJoinAllSpaces,
+            .stationary,
+            .ignoresCycle,
+            .fullScreenAuxiliary,
+        ]
+    }
+
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+}
+
+/// Hosts the notch content and decides which clicks are the notch's.
+///
+/// The canvas is far larger than the drawn notch, and it sits directly over the
+/// menu bar. Without this, the transparent remainder of the window would
+/// swallow every click aimed at a menu bar item near the centre of the screen.
+///
+/// This view is the window's `contentView`, so `hitTest(_:)` receives points in
+/// window coordinates — no conversion, and no dependence on flippedness.
+final class NotchHostingView<Content: View>: NSHostingView<Content> {
+    /// The live notch region, in window coordinates. Everything outside it
+    /// falls through to whatever is behind the window.
+    var interactiveRect: CGRect = .zero
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard interactiveRect.contains(point) else { return nil }
+        return super.hitTest(point)
+    }
+}

--- a/Sources/App/Notch/NotchWindowController.swift
+++ b/Sources/App/Notch/NotchWindowController.swift
@@ -29,7 +29,12 @@ final class NotchWindowController {
     /// the window accepts and whether the pointer counts as hovering.
     private var interactiveRect: CGRect = .zero
 
+    /// Last known answer to "is the pointer over the notch". Kept so the
+    /// tracking callback can bail out without touching observable state.
+    private var isPointerOverNotch = false
+
     private(set) var isRunning = false
+
 
     // MARK: - Lifecycle
 
@@ -82,13 +87,19 @@ final class NotchWindowController {
 
     // MARK: - Content
 
-    /// Hands the notch the activity to display, or nil to retract it.
-    func update(activity: NotchActivity?) {
+    /// Hands the notch everything it draws, in one go.
+    func update(content: NotchContent) {
         guard isRunning else { return }
-        state.activity = activity
-        if activity == nil {
+        state.content = content
+        if content.activity == nil, state.isExpanded {
             state.isExpanded = false
         }
+    }
+
+    /// Wires the panel's buttons to the app.
+    func setActions(refresh: @escaping () -> Void, snooze: @escaping () -> Void) {
+        state.refresh = refresh
+        state.snooze = snooze
     }
 
     // MARK: - Placement
@@ -150,6 +161,13 @@ final class NotchWindowController {
         }
     }
 
+    /// Called for every mouse-moved event anywhere on screen, so it must do
+    /// nothing at all in the common case.
+    ///
+    /// `@Observable` has no equality check: assigning the same value still
+    /// fires observers, so writing `isExpanded` unconditionally here would
+    /// invalidate the notch's SwiftUI tree on every pointer movement across the
+    /// entire display.
     private func updateMouseTracking() {
         guard let window else { return }
 
@@ -158,9 +176,13 @@ final class NotchWindowController {
             y: NSEvent.mouseLocation.y - window.frame.origin.y
         )
         let isOverNotch = interactiveRect.contains(mouseInWindow)
+        let shouldExpand = isOverNotch && state.activity != nil
 
+        guard isOverNotch != isPointerOverNotch || shouldExpand != state.isExpanded else { return }
+
+        isPointerOverNotch = isOverNotch
         window.ignoresMouseEvents = !isOverNotch
-        state.isExpanded = isOverNotch && state.activity != nil
+        state.isExpanded = shouldExpand
     }
 
     private func updateInteractiveRect() {
@@ -171,6 +193,7 @@ final class NotchWindowController {
             interactiveRect = .zero
             hostingView.interactiveRect = .zero
             window.ignoresMouseEvents = true
+            isPointerOverNotch = false
             return
         }
 

--- a/Sources/App/Notch/NotchWindowController.swift
+++ b/Sources/App/Notch/NotchWindowController.swift
@@ -55,7 +55,6 @@ final class NotchWindowController {
         observeContentSize()
         observeMouse()
         reposition()
-        window.orderFrontRegardless()
 
         AppLog.ui.info("Notch window started")
     }
@@ -88,12 +87,31 @@ final class NotchWindowController {
     // MARK: - Content
 
     /// Hands the notch everything it draws, in one go.
+    ///
+    /// With nothing to say the window is ordered out rather than left on screen
+    /// drawing a closed notch. On a display with a real cutout that shape is
+    /// invisible, but on the virtual notch every other display gets it is a
+    /// black box sitting in the menu bar that cannot be opened.
     func update(content: NotchContent) {
         guard isRunning else { return }
         state.content = content
-        if content.activity == nil, state.isExpanded {
-            state.isExpanded = false
+
+        guard content.activity != nil else {
+            if state.isExpanded { state.isExpanded = false }
+            hide()
+            return
         }
+
+        // Re-pick the display each time the notch has something new to say, so
+        // it appears where the user is rather than wherever they were at launch.
+        reposition()
+        window?.orderFrontRegardless()
+    }
+
+    private func hide() {
+        window?.orderOut(nil)
+        isPointerOverNotch = false
+        window?.ignoresMouseEvents = true
     }
 
     /// Wires the panel's buttons to the app.

--- a/Sources/App/Notch/NotchWindowController.swift
+++ b/Sources/App/Notch/NotchWindowController.swift
@@ -1,0 +1,190 @@
+import AppKit
+import SwiftUI
+import Domain
+import Infrastructure
+
+/// Owns the notch window: where it sits, which display it is on, and which part
+/// of it accepts the mouse.
+///
+/// Everything about *what* to show is decided upstream by
+/// `NotchActivityResolver`; this only puts pixels on a screen.
+@MainActor
+final class NotchWindowController {
+    /// A canvas comfortably larger than any notch state, so the window never
+    /// has to resize while the notch animates inside it.
+    private static let canvasSize = CGSize(width: 900, height: 420)
+
+    /// Forgiveness around the drawn notch, so hover does not drop out on the
+    /// exact boundary.
+    private static let hoverPadding: CGFloat = 6
+
+    private let state = NotchViewState()
+    private var window: NotchWindow?
+    private var hostingView: NotchHostingView<AnyView>?
+    private var screenObserver: NSObjectProtocol?
+    private var contentSizeSync: ObservationRenderSync<CGSize>?
+    private var mouseMonitor: Any?
+
+    /// The live notch region in window coordinates. Drives both which clicks
+    /// the window accepts and whether the pointer counts as hovering.
+    private var interactiveRect: CGRect = .zero
+
+    private(set) var isRunning = false
+
+    // MARK: - Lifecycle
+
+    func start() {
+        guard !isRunning else { return }
+        isRunning = true
+
+        let window = NotchWindow(contentRect: NSRect(origin: .zero, size: Self.canvasSize))
+        let hostingView = NotchHostingView(
+            rootView: AnyView(NotchRootView(state: state))
+        )
+        window.contentView = hostingView
+
+        self.window = window
+        self.hostingView = hostingView
+
+        observeScreenChanges()
+        observeContentSize()
+        observeMouse()
+        reposition()
+        window.orderFrontRegardless()
+
+        AppLog.ui.info("Notch window started")
+    }
+
+    func stop() {
+        guard isRunning else { return }
+        isRunning = false
+
+        contentSizeSync?.stop()
+        contentSizeSync = nil
+
+        if let mouseMonitor {
+            NSEvent.removeMonitor(mouseMonitor)
+            self.mouseMonitor = nil
+        }
+
+        if let screenObserver {
+            NotificationCenter.default.removeObserver(screenObserver)
+            self.screenObserver = nil
+        }
+
+        window?.orderOut(nil)
+        window?.contentView = nil
+        window = nil
+        hostingView = nil
+
+        AppLog.ui.info("Notch window stopped")
+    }
+
+    // MARK: - Content
+
+    /// Hands the notch the activity to display, or nil to retract it.
+    func update(activity: NotchActivity?) {
+        guard isRunning else { return }
+        state.activity = activity
+        if activity == nil {
+            state.isExpanded = false
+        }
+    }
+
+    // MARK: - Placement
+
+    private func observeScreenChanges() {
+        screenObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.reposition()
+            }
+        }
+    }
+
+    /// Re-measures the display and re-anchors the canvas to the top of it.
+    private func reposition() {
+        guard let window, let screen = NSScreen.preferredNotchScreen else { return }
+
+        state.metrics = screen.notchMetrics
+
+        let frame = NSRect(
+            x: screen.frame.midX - Self.canvasSize.width / 2,
+            y: screen.frame.maxY - Self.canvasSize.height,
+            width: Self.canvasSize.width,
+            height: Self.canvasSize.height
+        )
+        window.setFrame(frame, display: true, animate: false)
+        updateInteractiveRect()
+    }
+
+    /// Tracks the size SwiftUI actually laid the notch out at, and turns it into
+    /// the window-coordinate rect that `NotchHostingView` hit-tests against.
+    private func observeContentSize() {
+        let sync = ObservationRenderSync<CGSize>(
+            read: { [state] in state.contentSize },
+            render: { [weak self] _ in self?.updateInteractiveRect() }
+        )
+        contentSizeSync = sync
+        sync.start()
+    }
+
+    /// Tracks the pointer so the window can get out of the way.
+    ///
+    /// `hitTest` returning nil is *not* click-through: the window still
+    /// swallows the event rather than passing it to whatever is behind. The
+    /// only mechanism that genuinely lets a click reach the menu bar below is
+    /// `ignoresMouseEvents`, so the window ignores the mouse by default and
+    /// only accepts it while the pointer is actually over the notch.
+    ///
+    /// A global monitor for `.mouseMoved` needs no Accessibility permission —
+    /// unlike keyboard monitors — so this stays sandbox- and MAS-safe.
+    private func observeMouse() {
+        mouseMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.mouseMoved]) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.updateMouseTracking()
+            }
+        }
+    }
+
+    private func updateMouseTracking() {
+        guard let window else { return }
+
+        let mouseInWindow = CGPoint(
+            x: NSEvent.mouseLocation.x - window.frame.origin.x,
+            y: NSEvent.mouseLocation.y - window.frame.origin.y
+        )
+        let isOverNotch = interactiveRect.contains(mouseInWindow)
+
+        window.ignoresMouseEvents = !isOverNotch
+        state.isExpanded = isOverNotch && state.activity != nil
+    }
+
+    private func updateInteractiveRect() {
+        guard let hostingView, let window else { return }
+
+        let size = state.contentSize
+        guard size.width > 0, size.height > 0 else {
+            interactiveRect = .zero
+            hostingView.interactiveRect = .zero
+            window.ignoresMouseEvents = true
+            return
+        }
+
+        // The content is centred horizontally and pinned to the top of the
+        // canvas. Window coordinates are y-up, so the top edge is the canvas
+        // height.
+        let rect = CGRect(
+            x: (Self.canvasSize.width - size.width) / 2,
+            y: Self.canvasSize.height - size.height,
+            width: size.width,
+            height: size.height
+        )
+        interactiveRect = rect.insetBy(dx: -Self.hoverPadding, dy: -Self.hoverPadding)
+        hostingView.interactiveRect = interactiveRect
+        updateMouseTracking()
+    }
+}

--- a/Sources/App/Notch/NotchWindowDriver.swift
+++ b/Sources/App/Notch/NotchWindowDriver.swift
@@ -122,7 +122,7 @@ final class NotchWindowDriver {
             quotas: Array(quotas.sorted { $0.percentRemaining < $1.percentRemaining }.prefix(3)),
             today: snapshots.compactMap(\.dailyUsageReport).first?.today,
             headline: headline,
-            isRefreshing: monitor.isRefreshing
+            isRefreshing: isRefreshing(headline)
         )
     }
 
@@ -133,6 +133,17 @@ final class NotchWindowDriver {
             providerId: settings.menuBarPercentageProviderId,
             quotaKey: settings.menuBarPercentageQuotaKey
         ) ?? monitor.lowestQuota()
+    }
+
+    /// Whether the number currently on screen is being refetched.
+    ///
+    /// Deliberately narrower than `QuotaMonitor.isRefreshing`, which is true if
+    /// *any* provider is syncing — including disabled ones. Across nineteen
+    /// providers that is true often enough, and stays true if any one of them
+    /// hangs, that the notch would glow permanently and mean nothing.
+    private func isRefreshing(_ headline: UsageQuota?) -> Bool {
+        guard let headline else { return false }
+        return monitor.provider(for: headline.providerId)?.isSyncing ?? false
     }
 
     private func refreshQuotas() {

--- a/Sources/App/Notch/NotchWindowDriver.swift
+++ b/Sources/App/Notch/NotchWindowDriver.swift
@@ -17,11 +17,23 @@ final class NotchWindowDriver {
     private let controller = NotchWindowController()
     private let resolver = NotchActivityResolver()
 
-    private var activitySync: ObservationRenderSync<NotchActivity?>?
+    private var contentSync: ObservationRenderSync<NotchContent>?
     private var enabledSync: ObservationRenderSync<Bool>?
 
-    /// Retracts the "done" flash, which expires on a clock rather than on state.
-    private var expiryTimer: Timer?
+    /// Re-resolves the content at a moment nothing else will: the end of the
+    /// "done" flash, or the end of a snooze.
+    private var wakeTimer: Timer?
+
+    /// While set, the notch stays retracted. Snoozing is time-boxed on purpose —
+    /// a dismissal that never comes back is indistinguishable from a broken
+    /// feature.
+    private var snoozedUntil: Date?
+
+    /// How long the snooze button silences the notch for.
+    private static let snoozeDuration: TimeInterval = 30 * 60
+
+    /// How long a finished session stays worth listing in the panel.
+    private static let recentSessionWindow: TimeInterval = 10 * 60
 
     init(monitor: QuotaMonitor, sessionMonitor: SessionMonitor, settings: AppSettings) {
         self.monitor = monitor
@@ -37,9 +49,13 @@ final class NotchWindowDriver {
                 guard let self else { return }
                 if enabled {
                     controller.start()
-                    startActivitySync()
+                    controller.setActions(
+                        refresh: { [weak self] in self?.refreshQuotas() },
+                        snooze: { [weak self] in self?.snooze() }
+                    )
+                    startContentSync()
                 } else {
-                    stopActivitySync()
+                    stopContentSync()
                     controller.stop()
                 }
             }
@@ -50,53 +66,108 @@ final class NotchWindowDriver {
 
     // MARK: - Private
 
-    private func startActivitySync() {
-        guard activitySync == nil else { return }
+    private func startContentSync() {
+        guard contentSync == nil else { return }
 
-        let sync = ObservationRenderSync<NotchActivity?>(
-            read: { [weak self] in self?.currentActivity() ?? nil },
-            render: { [weak self] activity in
-                self?.controller.update(activity: activity)
-                self?.scheduleExpiry(for: activity)
+        let sync = ObservationRenderSync<NotchContent>(
+            read: { [weak self] in self?.currentContent() ?? .empty },
+            render: { [weak self] content in
+                self?.controller.update(content: content)
+                self?.scheduleWake(for: content.activity)
             }
         )
-        activitySync = sync
+        contentSync = sync
         sync.start()
     }
 
-    private func stopActivitySync() {
-        activitySync?.stop()
-        activitySync = nil
-        expiryTimer?.invalidate()
-        expiryTimer = nil
+    private func stopContentSync() {
+        contentSync?.stop()
+        contentSync = nil
+        wakeTimer?.invalidate()
+        wakeTimer = nil
     }
 
     /// Reads everything the notch depends on. Every `@Observable` property
-    /// touched here is tracked, so any change re-resolves the activity.
-    private func currentActivity() -> NotchActivity? {
-        let sessions = [sessionMonitor.activeSession].compactMap { $0 }
-            + sessionMonitor.recentSessions
-        let quotas = monitor.enabledProviders.compactMap(\.snapshot).flatMap(\.quotas)
+    /// touched here is tracked, so any change re-resolves the content.
+    private func currentContent() -> NotchContent {
+        let now = Date()
 
-        return resolver.resolve(sessions: sessions, quotas: quotas, now: Date())
+        // A session that finished ten minutes ago is history, not status. Left
+        // unfiltered it would sit in the panel for the rest of the day.
+        let sessions = [sessionMonitor.activeSession].compactMap { $0 }
+            + sessionMonitor.recentSessions.filter { session in
+                guard let finishedAt = session.finishedAt else { return true }
+                return now.timeIntervalSince(finishedAt) < Self.recentSessionWindow
+            }
+
+        let snapshots = monitor.enabledProviders.compactMap(\.snapshot)
+        let quotas = snapshots.flatMap(\.quotas)
+
+        var activity = resolver.resolve(sessions: sessions, quotas: quotas, now: now)
+        if isSnoozed(at: now), !demandsAttentionThroughSnooze(activity) {
+            activity = nil
+        }
+
+        return NotchContent(
+            activity: activity,
+            sessions: Array(sessions.prefix(3)),
+            // The panel is about what is nearly gone, so lead with the most
+            // depleted rather than whichever provider happens to be first.
+            quotas: Array(quotas.sorted { $0.percentRemaining < $1.percentRemaining }.prefix(3)),
+            today: snapshots.compactMap(\.dailyUsageReport).first?.today
+        )
+    }
+
+    private func refreshQuotas() {
+        Task { await monitor.refreshAll() }
+    }
+
+    private func snooze() {
+        snoozedUntil = Date().addingTimeInterval(Self.snoozeDuration)
+        contentSync?.refreshNow()
+        scheduleWake(at: snoozedUntil)
+    }
+
+    private func isSnoozed(at now: Date) -> Bool {
+        guard let snoozedUntil else { return false }
+        if now >= snoozedUntil {
+            self.snoozedUntil = nil
+            return false
+        }
+        return true
+    }
+
+    /// A snooze quiets ambient status, not a session that is blocked on the
+    /// user — that is the one thing worth interrupting for.
+    private func demandsAttentionThroughSnooze(_ activity: NotchActivity?) -> Bool {
+        if case .awaitingInput = activity { return true }
+        return false
     }
 
     /// A finished session stops being worth showing on a clock, not on a state
     /// change — nothing will fire an observation to retract it, so schedule the
-    /// re-resolve ourselves.
-    private func scheduleExpiry(for activity: NotchActivity?) {
-        expiryTimer?.invalidate()
-        expiryTimer = nil
+    /// re-resolve ourselves. Same for the end of a snooze.
+    private func scheduleWake(for activity: NotchActivity?) {
+        guard case .finished(let session) = activity, let finishedAt = session.finishedAt else {
+            scheduleWake(at: snoozedUntil)
+            return
+        }
+        scheduleWake(
+            at: finishedAt.addingTimeInterval(NotchActivityResolver.defaultFinishedDisplayDuration)
+        )
+    }
 
-        guard case .finished(let session) = activity, let finishedAt = session.finishedAt else { return }
+    private func scheduleWake(at date: Date?) {
+        wakeTimer?.invalidate()
+        wakeTimer = nil
 
-        let remaining = NotchActivityResolver.defaultFinishedDisplayDuration
-            - Date().timeIntervalSince(finishedAt)
-        guard remaining > 0 else { return }
+        guard let date else { return }
+        let delay = date.timeIntervalSinceNow + 0.1
+        guard delay > 0 else { return }
 
-        expiryTimer = Timer.scheduledTimer(withTimeInterval: remaining + 0.1, repeats: false) { [weak self] _ in
+        wakeTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
             Task { @MainActor [weak self] in
-                self?.activitySync?.refreshNow()
+                self?.contentSync?.refreshNow()
             }
         }
     }

--- a/Sources/App/Notch/NotchWindowDriver.swift
+++ b/Sources/App/Notch/NotchWindowDriver.swift
@@ -89,6 +89,10 @@ final class NotchWindowDriver {
 
     /// Reads everything the notch depends on. Every `@Observable` property
     /// touched here is tracked, so any change re-resolves the content.
+    ///
+    /// Scoped to the provider selected in the popover. The notch is a second
+    /// view onto that selection, not a separate one: showing an average across
+    /// nineteen providers would report a number the user never chose to watch.
     private func currentContent() -> NotchContent {
         let now = Date()
 
@@ -100,10 +104,11 @@ final class NotchWindowDriver {
                 return now.timeIntervalSince(finishedAt) < Self.recentSessionWindow
             }
 
-        let snapshots = monitor.enabledProviders.compactMap(\.snapshot)
-        let quotas = snapshots.flatMap(\.quotas)
+        let selected = monitor.selectedProvider
+        let snapshot = selected?.snapshot
+        let quotas = snapshot?.quotas ?? []
+        let headline = snapshot?.lowestQuota
 
-        let headline = headlineQuota()
         var activity = resolver.resolve(
             sessions: sessions,
             quotas: quotas,
@@ -118,36 +123,20 @@ final class NotchWindowDriver {
             activity: activity,
             sessions: Array(sessions.prefix(3)),
             // The panel is about what is nearly gone, so lead with the most
-            // depleted rather than whichever provider happens to be first.
+            // depleted rather than whichever quota happens to be first.
             quotas: Array(quotas.sorted { $0.percentRemaining < $1.percentRemaining }.prefix(3)),
-            today: snapshots.compactMap(\.dailyUsageReport).first?.today,
+            today: snapshot?.dailyUsageReport?.today,
             headline: headline,
-            isRefreshing: isRefreshing(headline)
+            isRefreshing: selected?.isSyncing ?? false
         )
     }
 
-    /// The quota the notch rests on: whichever one the user already chose to
-    /// watch in the menu bar, so the two surfaces never disagree.
-    private func headlineQuota() -> UsageQuota? {
-        monitor.quota(
-            providerId: settings.menuBarPercentageProviderId,
-            quotaKey: settings.menuBarPercentageQuotaKey
-        ) ?? monitor.lowestQuota()
-    }
-
-    /// Whether the number currently on screen is being refetched.
-    ///
-    /// Deliberately narrower than `QuotaMonitor.isRefreshing`, which is true if
-    /// *any* provider is syncing — including disabled ones. Across nineteen
-    /// providers that is true often enough, and stays true if any one of them
-    /// hangs, that the notch would glow permanently and mean nothing.
-    private func isRefreshing(_ headline: UsageQuota?) -> Bool {
-        guard let headline else { return false }
-        return monitor.provider(for: headline.providerId)?.isSyncing ?? false
-    }
-
+    /// Refreshes only what the notch is showing. Refreshing all nineteen
+    /// providers to update one reading is work the user did not ask for, and
+    /// leaves the loader stopping while other providers are still fetching.
     private func refreshQuotas() {
-        Task { await monitor.refreshAll() }
+        let providerId = monitor.selectedProviderId
+        Task { await monitor.refresh(providerId: providerId) }
     }
 
     private func snooze() {

--- a/Sources/App/Notch/NotchWindowDriver.swift
+++ b/Sources/App/Notch/NotchWindowDriver.swift
@@ -103,7 +103,12 @@ final class NotchWindowDriver {
         let snapshots = monitor.enabledProviders.compactMap(\.snapshot)
         let quotas = snapshots.flatMap(\.quotas)
 
-        var activity = resolver.resolve(sessions: sessions, quotas: quotas, now: now)
+        var activity = resolver.resolve(
+            sessions: sessions,
+            quotas: quotas,
+            headlineQuota: headlineQuota(),
+            now: now
+        )
         if isSnoozed(at: now), !demandsAttentionThroughSnooze(activity) {
             activity = nil
         }
@@ -116,6 +121,15 @@ final class NotchWindowDriver {
             quotas: Array(quotas.sorted { $0.percentRemaining < $1.percentRemaining }.prefix(3)),
             today: snapshots.compactMap(\.dailyUsageReport).first?.today
         )
+    }
+
+    /// The quota the notch rests on: whichever one the user already chose to
+    /// watch in the menu bar, so the two surfaces never disagree.
+    private func headlineQuota() -> UsageQuota? {
+        monitor.quota(
+            providerId: settings.menuBarPercentageProviderId,
+            quotaKey: settings.menuBarPercentageQuotaKey
+        ) ?? monitor.lowestQuota()
     }
 
     private func refreshQuotas() {

--- a/Sources/App/Notch/NotchWindowDriver.swift
+++ b/Sources/App/Notch/NotchWindowDriver.swift
@@ -1,0 +1,103 @@
+import AppKit
+import Domain
+import Infrastructure
+
+/// Keeps the notch in sync with the app's state.
+///
+/// Mirrors `StatusItemLabelDriver`: an `ObservationRenderSync` reads every
+/// `@Observable` property the notch depends on and pushes the resolved activity
+/// into the window controller. SwiftUI is not involved — the notch lives in its
+/// own `NSPanel`, and `MenuBarExtra`'s hosting has a history of going quiet
+/// after sleep (issue #192).
+@MainActor
+final class NotchWindowDriver {
+    private let monitor: QuotaMonitor
+    private let sessionMonitor: SessionMonitor
+    private let settings: AppSettings
+    private let controller = NotchWindowController()
+    private let resolver = NotchActivityResolver()
+
+    private var activitySync: ObservationRenderSync<NotchActivity?>?
+    private var enabledSync: ObservationRenderSync<Bool>?
+
+    /// Retracts the "done" flash, which expires on a clock rather than on state.
+    private var expiryTimer: Timer?
+
+    init(monitor: QuotaMonitor, sessionMonitor: SessionMonitor, settings: AppSettings) {
+        self.monitor = monitor
+        self.sessionMonitor = sessionMonitor
+        self.settings = settings
+    }
+
+    /// Starts watching the setting, bringing the notch up and down with it.
+    func start() {
+        let sync = ObservationRenderSync<Bool>(
+            read: { [settings] in settings.notchEnabled },
+            render: { [weak self] enabled in
+                guard let self else { return }
+                if enabled {
+                    controller.start()
+                    startActivitySync()
+                } else {
+                    stopActivitySync()
+                    controller.stop()
+                }
+            }
+        )
+        enabledSync = sync
+        sync.start()
+    }
+
+    // MARK: - Private
+
+    private func startActivitySync() {
+        guard activitySync == nil else { return }
+
+        let sync = ObservationRenderSync<NotchActivity?>(
+            read: { [weak self] in self?.currentActivity() ?? nil },
+            render: { [weak self] activity in
+                self?.controller.update(activity: activity)
+                self?.scheduleExpiry(for: activity)
+            }
+        )
+        activitySync = sync
+        sync.start()
+    }
+
+    private func stopActivitySync() {
+        activitySync?.stop()
+        activitySync = nil
+        expiryTimer?.invalidate()
+        expiryTimer = nil
+    }
+
+    /// Reads everything the notch depends on. Every `@Observable` property
+    /// touched here is tracked, so any change re-resolves the activity.
+    private func currentActivity() -> NotchActivity? {
+        let sessions = [sessionMonitor.activeSession].compactMap { $0 }
+            + sessionMonitor.recentSessions
+        let quotas = monitor.enabledProviders.compactMap(\.snapshot).flatMap(\.quotas)
+
+        return resolver.resolve(sessions: sessions, quotas: quotas, now: Date())
+    }
+
+    /// A finished session stops being worth showing on a clock, not on a state
+    /// change — nothing will fire an observation to retract it, so schedule the
+    /// re-resolve ourselves.
+    private func scheduleExpiry(for activity: NotchActivity?) {
+        expiryTimer?.invalidate()
+        expiryTimer = nil
+
+        guard case .finished(let session) = activity, let finishedAt = session.finishedAt else { return }
+
+        let remaining = NotchActivityResolver.defaultFinishedDisplayDuration
+            - Date().timeIntervalSince(finishedAt)
+        guard remaining > 0 else { return }
+
+        expiryTimer = Timer.scheduledTimer(withTimeInterval: remaining + 0.1, repeats: false) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.activitySync?.refreshNow()
+            }
+        }
+    }
+}

--- a/Sources/App/Notch/NotchWindowDriver.swift
+++ b/Sources/App/Notch/NotchWindowDriver.swift
@@ -103,10 +103,11 @@ final class NotchWindowDriver {
         let snapshots = monitor.enabledProviders.compactMap(\.snapshot)
         let quotas = snapshots.flatMap(\.quotas)
 
+        let headline = headlineQuota()
         var activity = resolver.resolve(
             sessions: sessions,
             quotas: quotas,
-            headlineQuota: headlineQuota(),
+            headlineQuota: headline,
             now: now
         )
         if isSnoozed(at: now), !demandsAttentionThroughSnooze(activity) {
@@ -119,7 +120,9 @@ final class NotchWindowDriver {
             // The panel is about what is nearly gone, so lead with the most
             // depleted rather than whichever provider happens to be first.
             quotas: Array(quotas.sorted { $0.percentRemaining < $1.percentRemaining }.prefix(3)),
-            today: snapshots.compactMap(\.dailyUsageReport).first?.today
+            today: snapshots.compactMap(\.dailyUsageReport).first?.today,
+            headline: headline,
+            isRefreshing: monitor.isRefreshing
         )
     }
 

--- a/Sources/App/Settings/AppSettings.swift
+++ b/Sources/App/Settings/AppSettings.swift
@@ -107,6 +107,16 @@ public final class AppSettings {
         }
     }
 
+    // MARK: - Notch Settings
+
+    /// Whether Claude Code session and quota state is drawn into the notch
+    /// (default: false).
+    public var notchEnabled: Bool {
+        didSet {
+            repository.setNotchEnabled(notchEnabled)
+        }
+    }
+
     // MARK: - Overview Mode Settings
 
     /// Whether to show all enabled providers at once instead of one at a time
@@ -232,6 +242,7 @@ public final class AppSettings {
         self.burnRateWarningEnabled = repository.burnRateWarningEnabled()
         self.burnRateThreshold = repository.burnRateThreshold()
         self.showDailyUsageCards = repository.showDailyUsageCards()
+        self.notchEnabled = repository.notchEnabled()
         self.overviewModeEnabled = repository.overviewModeEnabled()
         self.backgroundSyncEnabled = repository.backgroundSyncEnabled()
         self.backgroundSyncInterval = repository.backgroundSyncInterval()

--- a/Sources/App/Views/MenuContentView.swift
+++ b/Sources/App/Views/MenuContentView.swift
@@ -28,6 +28,10 @@ struct MenuContentView: View {
     @State private var pillsContentWidth: CGFloat = 0
     @State private var pillsViewportWidth: CGFloat = 0
 
+    /// Measured height of the scrollable content. Zero until the first layout
+    /// pass reports it — see `PopoverContentHeight.height`.
+    @State private var metricsContentHeight: CGFloat = 0
+
     /// The currently selected provider ID (from monitor, which is @Observable)
     private var selectedProviderId: String {
         get { monitor.selectedProviderId }
@@ -89,8 +93,11 @@ struct MenuContentView: View {
                     }
                     .padding(.horizontal, 16)
                     .padding(.bottom, 16)
+                    .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { height in
+                        metricsContentHeight = height
+                    }
                 }
-                .frame(maxHeight: contentMaxHeight)
+                .frame(height: contentHeight)
                 // Recreate the scroll view when the shown content
                 // changes, so a newly selected provider starts at the
                 // top instead of inheriting the previous scroll offset.
@@ -166,13 +173,29 @@ struct MenuContentView: View {
         }
     }
 
-    /// Upper bound for the scrollable content region — see
-    /// `PopoverContentHeight` for the policy and its tests.
-    private var contentMaxHeight: CGFloat {
-        PopoverContentHeight.maxHeight(
-            visibleScreenHeight: NSScreen.main?.visibleFrame.height ?? 800,
+    /// Height for the scrollable content region — see `PopoverContentHeight`
+    /// for the policy and its tests. A `ScrollView` fills whatever frame it is
+    /// given, so this is a height rather than a maximum: without it, a single
+    /// card stretched the popover to the cap on a tall display.
+    private var contentHeight: CGFloat {
+        PopoverContentHeight.height(
+            contentHeight: metricsContentHeight,
+            visibleScreenHeight: popoverScreenHeight,
             overviewMode: settings.overviewModeEnabled
         )
+    }
+
+    /// Height of the screen the popover is on.
+    ///
+    /// `NSScreen.main` is the screen holding the *key window*, which on a
+    /// multi-display setup is often not the one the menu bar was clicked on.
+    /// The pointer is over the status item at that moment, so the screen under
+    /// it is the better answer.
+    private var popoverScreenHeight: CGFloat {
+        let pointerLocation = NSEvent.mouseLocation
+        let screen = NSScreen.screens.first { $0.frame.contains(pointerLocation) }
+            ?? NSScreen.main
+        return screen?.visibleFrame.height ?? 800
     }
 
     // MARK: - Background Orbs

--- a/Sources/App/Views/SessionPhaseColor.swift
+++ b/Sources/App/Views/SessionPhaseColor.swift
@@ -8,6 +8,7 @@ extension ClaudeSession.Phase {
         switch self {
         case .active: return .green
         case .subagentsWorking: return .blue
+        case .awaitingInput: return .yellow
         case .stopped: return .orange
         case .ended: return .gray
         }

--- a/Sources/App/Views/SettingsWindow/GeneralPane.swift
+++ b/Sources/App/Views/SettingsWindow/GeneralPane.swift
@@ -44,6 +44,15 @@ struct GeneralPane: View {
                 ) {
                     SettingsSwitch(isOn: $settings.showDailyUsageCards)
                 }
+
+                SettingsRowDivider()
+
+                SettingsRow(
+                    title: "Notch Live Activity",
+                    subtitle: "Show session and quota state in the notch. Appears only while there is something to report."
+                ) {
+                    SettingsSwitch(isOn: $settings.notchEnabled)
+                }
             }
 
             SettingsCard {

--- a/Sources/Domain/Notch/NotchActivity.swift
+++ b/Sources/Domain/Notch/NotchActivity.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// A single thing the notch can say.
+///
+/// The notch is one strip of glass with several independent sources competing
+/// for it — running sessions, permission prompts, quota thresholds. Modelling
+/// each as a case lets `NotchActivityResolver` pick a winner without any view
+/// knowing the rules.
+///
+/// Ordering is by how loudly the activity demands attention, so two activities
+/// of the same kind are order-equivalent without being equal.
+public enum NotchActivity: Sendable, Equatable {
+    /// Claude Code is working on a turn.
+    case working(ClaudeSession)
+
+    /// Claude Code has fanned subagents out.
+    case agentsWorking(ClaudeSession)
+
+    /// A provider is at or past the point where the user should know.
+    case quotaThreshold(UsageQuota)
+
+    /// A turn or session just finished. Transient — see
+    /// `NotchActivityResolver.finishedDisplayDuration`.
+    case finished(ClaudeSession)
+
+    /// Claude Code is blocked waiting on the user. Outranks everything, and
+    /// never expires on its own: only the user can clear it.
+    case awaitingInput(ClaudeSession)
+
+    /// The session behind this activity, for the activities that have one.
+    public var session: ClaudeSession? {
+        switch self {
+        case .working(let session),
+             .agentsWorking(let session),
+             .finished(let session),
+             .awaitingInput(let session):
+            session
+        case .quotaThreshold:
+            nil
+        }
+    }
+
+    /// The quota behind this activity, for the activities that have one.
+    public var quota: UsageQuota? {
+        switch self {
+        case .quotaThreshold(let quota): quota
+        default: nil
+        }
+    }
+
+    /// How loudly this activity demands attention (higher wins).
+    ///
+    /// The ordering encodes two product rules: a human being blocked beats
+    /// anything a machine is doing, and a "done" flash briefly interrupts
+    /// ambient state without ever masking a blocked session.
+    var severity: Int {
+        switch self {
+        case .working: 1
+        case .agentsWorking: 2
+        case .quotaThreshold: 3
+        case .finished: 4
+        case .awaitingInput: 5
+        }
+    }
+}
+
+extension NotchActivity: Comparable {
+    public static func < (lhs: NotchActivity, rhs: NotchActivity) -> Bool {
+        lhs.severity < rhs.severity
+    }
+}

--- a/Sources/Domain/Notch/NotchActivity.swift
+++ b/Sources/Domain/Notch/NotchActivity.swift
@@ -10,6 +10,13 @@ import Foundation
 /// Ordering is by how loudly the activity demands attention, so two activities
 /// of the same kind are order-equivalent without being equal.
 public enum NotchActivity: Sendable, Equatable {
+    /// Nothing is happening, so the notch does the job ClaudeBar exists for:
+    /// shows how much of the quota the user chose to watch is left.
+    ///
+    /// This is the resting state, not an absence of one. A notch that goes
+    /// blank between sessions has no reason to be on screen at all.
+    case quotaGlance(UsageQuota)
+
     /// Claude Code is working on a turn.
     case working(ClaudeSession)
 
@@ -35,7 +42,7 @@ public enum NotchActivity: Sendable, Equatable {
              .finished(let session),
              .awaitingInput(let session):
             session
-        case .quotaThreshold:
+        case .quotaThreshold, .quotaGlance:
             nil
         }
     }
@@ -43,7 +50,7 @@ public enum NotchActivity: Sendable, Equatable {
     /// The quota behind this activity, for the activities that have one.
     public var quota: UsageQuota? {
         switch self {
-        case .quotaThreshold(let quota): quota
+        case .quotaThreshold(let quota), .quotaGlance(let quota): quota
         default: nil
         }
     }
@@ -55,6 +62,7 @@ public enum NotchActivity: Sendable, Equatable {
     /// ambient state without ever masking a blocked session.
     var severity: Int {
         switch self {
+        case .quotaGlance: 0
         case .working: 1
         case .agentsWorking: 2
         case .quotaThreshold: 3

--- a/Sources/Domain/Notch/NotchActivityResolver.swift
+++ b/Sources/Domain/Notch/NotchActivityResolver.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Decides what — if anything — the notch shows right now.
+///
+/// Pure: monitor state in, one activity or nothing out. No AppKit, no clock of
+/// its own, no I/O. Every rule about what wins the notch lives here so the
+/// window and its views stay presentation-only, and so the rules are testable
+/// as plain state assertions.
+public struct NotchActivityResolver: Sendable {
+    /// How long a finished session keeps the notch before it retracts.
+    public static let defaultFinishedDisplayDuration: TimeInterval = 4
+
+    private let finishedDisplayDuration: TimeInterval
+
+    public init(finishedDisplayDuration: TimeInterval = NotchActivityResolver.defaultFinishedDisplayDuration) {
+        self.finishedDisplayDuration = finishedDisplayDuration
+    }
+
+    /// Resolves the single activity worth showing.
+    ///
+    /// - Parameters:
+    ///   - sessions: Live and recently finished sessions. Callers filter out
+    ///     ClaudeBar's own probe runs before this point.
+    ///   - quotas: Every provider quota currently known.
+    ///   - now: The reference time, so the "done" flash can expire deterministically.
+    /// - Returns: The winning activity, or nil when the notch should stay hidden.
+    public func resolve(
+        sessions: [ClaudeSession],
+        quotas: [UsageQuota],
+        now: Date
+    ) -> NotchActivity? {
+        var candidates = sessions.compactMap { activity(for: $0, now: now) }
+
+        if let quota = mostDepletedQuotaNeedingAttention(in: quotas) {
+            candidates.append(.quotaThreshold(quota))
+        }
+
+        guard let topSeverity = candidates.map(\.severity).max() else { return nil }
+
+        // Among equally severe activities the one that has been waiting longest
+        // wins — a session blocked ten minutes ago needs the user more than one
+        // blocked ten seconds ago.
+        return candidates
+            .filter { $0.severity == topSeverity }
+            .min { lhs, rhs in
+                guard let left = lhs.session, let right = rhs.session else { return false }
+                return left.startedAt < right.startedAt
+            }
+    }
+
+    // MARK: - Private
+
+    private func activity(for session: ClaudeSession, now: Date) -> NotchActivity? {
+        switch session.phase {
+        case .awaitingInput:
+            .awaitingInput(session)
+        case .subagentsWorking:
+            .agentsWorking(session)
+        case .active:
+            .working(session)
+        case .stopped, .ended:
+            finishedActivity(for: session, now: now)
+        }
+    }
+
+    private func finishedActivity(for session: ClaudeSession, now: Date) -> NotchActivity? {
+        guard let finishedAt = session.finishedAt,
+              now.timeIntervalSince(finishedAt) < finishedDisplayDuration
+        else { return nil }
+        return .finished(session)
+    }
+
+    /// Only `.critical` and `.depleted` quotas are worth taking over the notch.
+    /// `.warning` is real but not urgent, and a notch that lights up at half a
+    /// tank stops meaning anything.
+    private func mostDepletedQuotaNeedingAttention(in quotas: [UsageQuota]) -> UsageQuota? {
+        quotas
+            .filter { quota in
+                switch QuotaStatus.from(percentRemaining: quota.percentRemaining) {
+                case .critical, .depleted: true
+                case .healthy, .warning: false
+                }
+            }
+            .min { $0.percentRemaining < $1.percentRemaining }
+    }
+}

--- a/Sources/Domain/Notch/NotchActivityResolver.swift
+++ b/Sources/Domain/Notch/NotchActivityResolver.swift
@@ -22,17 +22,24 @@ public struct NotchActivityResolver: Sendable {
     ///   - sessions: Live and recently finished sessions. Callers filter out
     ///     ClaudeBar's own probe runs before this point.
     ///   - quotas: Every provider quota currently known.
+    ///   - headlineQuota: The quota the user chose to watch, shown whenever
+    ///     nothing louder is happening. Nil before the first probe returns.
     ///   - now: The reference time, so the "done" flash can expire deterministically.
     /// - Returns: The winning activity, or nil when the notch should stay hidden.
     public func resolve(
         sessions: [ClaudeSession],
         quotas: [UsageQuota],
+        headlineQuota: UsageQuota?,
         now: Date
     ) -> NotchActivity? {
         var candidates = sessions.compactMap { activity(for: $0, now: now) }
 
         if let quota = mostDepletedQuotaNeedingAttention(in: quotas) {
             candidates.append(.quotaThreshold(quota))
+        }
+
+        if let headlineQuota {
+            candidates.append(.quotaGlance(headlineQuota))
         }
 
         guard let topSeverity = candidates.map(\.severity).max() else { return nil }

--- a/Sources/Domain/Notch/NotchMetrics.swift
+++ b/Sources/Domain/Notch/NotchMetrics.swift
@@ -1,0 +1,95 @@
+import CoreGraphics
+import Foundation
+
+/// The size and nature of the notch region on one display.
+///
+/// macOS exposes no notch API. The measurement is inferred from the *auxiliary
+/// menu bar areas* either side of the cutout, and whether a display has a notch
+/// at all is inferred from its top safe-area inset. Both rules are subtle
+/// enough to be worth isolating from AppKit so they can be tested directly.
+public struct NotchMetrics: Sendable, Equatable {
+    /// Width of a virtual notch, and the fallback whenever the real one cannot
+    /// be measured. Close to the physical notch on a 14"/16" MacBook Pro.
+    public static let defaultWidth: CGFloat = 185
+
+    /// Fallback height for displays that report no menu bar — an auto-hidden
+    /// menu bar measures as zero.
+    public static let defaultHeight: CGFloat = 32
+
+    /// Drawn slightly wider than measured so the notch overlays the physical
+    /// cutout's edges instead of leaving a hairline seam beside them.
+    private static let seamOverlap: CGFloat = 4
+
+    /// Below this, a measurement is not a notch — it is a transient screen
+    /// configuration, and drawing it would collapse the notch to a sliver.
+    private static let plausibleMinimumWidth: CGFloat = 100
+
+    /// The notch at rest, before any activity widens it.
+    public let closedSize: CGSize
+
+    /// Whether this display has a real cutout. False means ClaudeBar draws a
+    /// virtual notch at top centre — roughly half of installs.
+    public let isPhysicalNotch: Bool
+
+    public init(closedSize: CGSize, isPhysicalNotch: Bool) {
+        self.closedSize = closedSize
+        self.isPhysicalNotch = isPhysicalNotch
+    }
+
+    /// Derives the metrics from one display's raw measurements.
+    ///
+    /// - Parameters:
+    ///   - screenWidth: The display's full width in points.
+    ///   - safeAreaTop: The top safe-area inset. Greater than zero means a notch.
+    ///   - auxiliaryTopLeftWidth: Usable menu bar width left of the cutout, if any.
+    ///   - auxiliaryTopRightWidth: Usable menu bar width right of the cutout, if any.
+    ///   - menuBarHeight: The menu bar's height, used for displays with no notch.
+    public static func measure(
+        screenWidth: CGFloat,
+        safeAreaTop: CGFloat,
+        auxiliaryTopLeftWidth: CGFloat?,
+        auxiliaryTopRightWidth: CGFloat?,
+        menuBarHeight: CGFloat
+    ) -> NotchMetrics {
+        let isPhysicalNotch = safeAreaTop > 0
+
+        return NotchMetrics(
+            closedSize: CGSize(
+                width: width(
+                    screenWidth: screenWidth,
+                    auxiliaryTopLeftWidth: auxiliaryTopLeftWidth,
+                    auxiliaryTopRightWidth: auxiliaryTopRightWidth
+                ),
+                height: height(
+                    isPhysicalNotch: isPhysicalNotch,
+                    safeAreaTop: safeAreaTop,
+                    menuBarHeight: menuBarHeight
+                )
+            ),
+            isPhysicalNotch: isPhysicalNotch
+        )
+    }
+
+    // MARK: - Private
+
+    private static func width(
+        screenWidth: CGFloat,
+        auxiliaryTopLeftWidth: CGFloat?,
+        auxiliaryTopRightWidth: CGFloat?
+    ) -> CGFloat {
+        guard let left = auxiliaryTopLeftWidth, let right = auxiliaryTopRightWidth else {
+            return defaultWidth
+        }
+        let measured = screenWidth - left - right + seamOverlap
+        return measured >= plausibleMinimumWidth ? measured : defaultWidth
+    }
+
+    private static func height(
+        isPhysicalNotch: Bool,
+        safeAreaTop: CGFloat,
+        menuBarHeight: CGFloat
+    ) -> CGFloat {
+        if isPhysicalNotch { return safeAreaTop }
+        return menuBarHeight > 0 ? menuBarHeight : defaultHeight
+    }
+}

--- a/Sources/Domain/Provider/PopoverContentHeight.swift
+++ b/Sources/Domain/Provider/PopoverContentHeight.swift
@@ -28,4 +28,29 @@ public enum PopoverContentHeight {
         let available = max(visibleScreenHeight - chrome, usableFloor)
         return overviewMode ? min(overviewCeiling, available) : available
     }
+
+    /// The height the scrollable region should actually take: its content's,
+    /// capped so the action bar cannot be pushed off screen.
+    ///
+    /// A `ScrollView` is greedy — offered a tall frame it fills it — so a cap
+    /// alone is not enough. On a portrait display the cap is over 2000pt, and
+    /// a provider with a single card stretched the popover to match it.
+    ///
+    /// - Parameters:
+    ///   - contentHeight: The measured height of the content. Zero or less
+    ///     means it has not been measured yet, on the first layout pass.
+    ///   - visibleScreenHeight: `NSScreen.visibleFrame.height` of the
+    ///     screen hosting the popover.
+    ///   - overviewMode: whether the popover lists all providers.
+    public static func height(
+        contentHeight: CGFloat,
+        visibleScreenHeight: CGFloat,
+        overviewMode: Bool
+    ) -> CGFloat {
+        let cap = maxHeight(visibleScreenHeight: visibleScreenHeight, overviewMode: overviewMode)
+        // Before the first measurement, prefer the cap: a scrollable popover
+        // is recoverable, one collapsed to nothing is not.
+        guard contentHeight > 0 else { return cap }
+        return min(contentHeight, cap)
+    }
 }

--- a/Sources/Domain/Session/ClaudeSession.swift
+++ b/Sources/Domain/Session/ClaudeSession.swift
@@ -11,6 +11,15 @@ public struct ClaudeSession: Sendable, Equatable, Identifiable {
     public private(set) var completedTaskCount: Int
     public private(set) var endedAt: Date?
 
+    /// When the current turn stopped, if it has. Cleared when work resumes.
+    /// Distinct from `endedAt`: a stopped session is still alive and will
+    /// revive on the next `UserPromptSubmit`.
+    public private(set) var stoppedAt: Date?
+
+    /// What Claude Code is blocked on, when the session is `.awaitingInput`
+    /// (e.g. "Claude needs your permission to use Bash"). Cleared when work resumes.
+    public private(set) var pendingPrompt: String?
+
     public init(
         id: String,
         cwd: String,
@@ -28,6 +37,8 @@ public struct ClaudeSession: Sendable, Equatable, Identifiable {
     public enum Phase: String, Sendable, Equatable {
         case active
         case subagentsWorking
+        /// Claude Code is blocked waiting on the user — typically a permission prompt.
+        case awaitingInput
         case stopped
         case ended
 
@@ -36,6 +47,7 @@ public struct ClaudeSession: Sendable, Equatable, Identifiable {
             switch self {
             case .active: return "Active"
             case .subagentsWorking: return "Agents Working"
+            case .awaitingInput: return "Needs You"
             case .stopped: return "Stopped"
             case .ended: return "Ended"
             }
@@ -68,6 +80,15 @@ public struct ClaudeSession: Sendable, Equatable, Identifiable {
         updatePhase()
     }
 
+    /// Records that Claude Code is blocked waiting on the user, carrying the
+    /// prompt it is blocked on. No-op once ended.
+    public mutating func awaitInput(_ prompt: String? = nil, at date: Date = Date()) {
+        guard phase != .ended else { return }
+        phase = .awaitingInput
+        pendingPrompt = prompt
+        stoppedAt = nil
+    }
+
     /// Records a task completion
     public mutating func taskCompleted() {
         guard phase != .ended else { return }
@@ -75,10 +96,12 @@ public struct ClaudeSession: Sendable, Equatable, Identifiable {
     }
 
     /// Marks the session as stopped (Claude Code stopped responding)
-    public mutating func stop() {
+    public mutating func stop(at date: Date = Date()) {
         guard phase != .ended else { return }
         phase = .stopped
         activeSubagentCount = 0
+        stoppedAt = date
+        pendingPrompt = nil
     }
 
     /// Marks the session as ended
@@ -86,6 +109,22 @@ public struct ClaudeSession: Sendable, Equatable, Identifiable {
         phase = .ended
         activeSubagentCount = 0
         endedAt = date
+    }
+
+    /// When this session last finished doing something — the end of the session
+    /// if it has ended, otherwise the end of the last turn. nil while working.
+    ///
+    /// The notch uses this to time the "done" flash; `endedAt` wins because a
+    /// session that ended is finished for good, whereas a stop is provisional.
+    public var finishedAt: Date? {
+        endedAt ?? stoppedAt
+    }
+
+    /// The repository the session is running in — the last path component of
+    /// `cwd`. This is how users refer to a session ("the claudebar one"), so it
+    /// belongs here rather than being re-derived by each view.
+    public var repoName: String {
+        ((cwd as NSString).standardizingPath as NSString).lastPathComponent
     }
 
     /// Whether this session is still active (not ended)
@@ -118,6 +157,8 @@ public struct ClaudeSession: Sendable, Equatable, Identifiable {
     // MARK: - Private
 
     private mutating func updatePhase() {
+        pendingPrompt = nil
+        stoppedAt = nil
         if activeSubagentCount > 0 {
             phase = .subagentsWorking
         } else {

--- a/Sources/Domain/Session/SessionEvent.swift
+++ b/Sources/Domain/Session/SessionEvent.swift
@@ -15,16 +15,23 @@ public struct SessionEvent: Sendable, Equatable, Codable {
     /// When this event was received
     public let receivedAt: Date
 
+    /// Free-text payload carried by the event, when the hook provides one.
+    /// `Notification` uses it for what Claude Code is blocked on
+    /// (e.g. "Claude needs your permission to use Bash").
+    public let message: String?
+
     public init(
         sessionId: String,
         eventName: EventName,
         cwd: String,
-        receivedAt: Date = Date()
+        receivedAt: Date = Date(),
+        message: String? = nil
     ) {
         self.sessionId = sessionId
         self.eventName = eventName
         self.cwd = cwd
         self.receivedAt = receivedAt
+        self.message = message
     }
 
     /// Whether this event originates from ClaudeBar's own background quota probe.
@@ -52,5 +59,8 @@ public struct SessionEvent: Sendable, Equatable, Codable {
         /// Used to revive a session out of `.stopped` so the indicator tracks
         /// real activity instead of sticking on the end-of-turn `Stop`.
         case userPromptSubmit = "UserPromptSubmit"
+        /// Fires when Claude Code needs the user — most importantly a
+        /// permission prompt. The session is blocked until it is answered.
+        case notification = "Notification"
     }
 }

--- a/Sources/Domain/Session/SessionMonitor.swift
+++ b/Sources/Domain/Session/SessionMonitor.swift
@@ -39,6 +39,8 @@ public final class SessionMonitor {
             handleStop(event)
         case .userPromptSubmit:
             handleUserPromptSubmit(event)
+        case .notification:
+            handleNotification(event)
         }
     }
 
@@ -86,6 +88,11 @@ public final class SessionMonitor {
     private func handleStop(_ event: SessionEvent) {
         guard activeSession?.id == event.sessionId else { return }
         activeSession?.stop()
+    }
+
+    private func handleNotification(_ event: SessionEvent) {
+        guard activeSession?.id == event.sessionId else { return }
+        activeSession?.awaitInput(event.message, at: event.receivedAt)
     }
 
     private func handleUserPromptSubmit(_ event: SessionEvent) {

--- a/Sources/Domain/Settings/AppSettingsRepository.swift
+++ b/Sources/Domain/Settings/AppSettingsRepository.swift
@@ -45,6 +45,12 @@ public protocol AppSettingsRepository: Sendable {
     func showDailyUsageCards() -> Bool
     func setShowDailyUsageCards(_ show: Bool)
 
+    // MARK: - Notch
+
+    /// Whether the notch live activity is shown (default: false).
+    func notchEnabled() -> Bool
+    func setNotchEnabled(_ enabled: Bool)
+
     // MARK: - Overview
 
     func overviewModeEnabled() -> Bool

--- a/Sources/Infrastructure/Notch/NSScreen+NotchMetrics.swift
+++ b/Sources/Infrastructure/Notch/NSScreen+NotchMetrics.swift
@@ -1,0 +1,27 @@
+import AppKit
+import Domain
+
+public extension NSScreen {
+    /// Measures this display's notch region.
+    ///
+    /// Every rule lives in `NotchMetrics.measure`; this is only the AppKit read.
+    /// `auxiliaryTopLeftArea` / `auxiliaryTopRightArea` are the usable menu bar
+    /// areas either side of the cutout — subtracting them from the full width is
+    /// the only way to learn how wide the notch is, since macOS exposes no API
+    /// for it.
+    var notchMetrics: NotchMetrics {
+        NotchMetrics.measure(
+            screenWidth: frame.width,
+            safeAreaTop: safeAreaInsets.top,
+            auxiliaryTopLeftWidth: auxiliaryTopLeftArea?.width,
+            auxiliaryTopRightWidth: auxiliaryTopRightArea?.width,
+            menuBarHeight: frame.maxY - visibleFrame.maxY
+        )
+    }
+
+    /// The display ClaudeBar draws its notch on: the one with a real cutout if
+    /// there is one, otherwise the main display.
+    static var preferredNotchScreen: NSScreen? {
+        screens.first { $0.safeAreaInsets.top > 0 } ?? main ?? screens.first
+    }
+}

--- a/Sources/Infrastructure/Storage/JSONSettingsRepository.swift
+++ b/Sources/Infrastructure/Storage/JSONSettingsRepository.swift
@@ -138,6 +138,14 @@ public final class JSONSettingsRepository:
         store.write(value: show, key: "app.showDailyUsageCards")
     }
 
+    public func notchEnabled() -> Bool {
+        store.read(key: "app.notchEnabled") ?? false
+    }
+
+    public func setNotchEnabled(_ enabled: Bool) {
+        store.write(value: enabled, key: "app.notchEnabled")
+    }
+
     public func overviewModeEnabled() -> Bool {
         store.read(key: "app.overviewModeEnabled") ?? false
     }

--- a/Tests/DomainTests/Notch/NotchActivityResolverTests.swift
+++ b/Tests/DomainTests/Notch/NotchActivityResolverTests.swift
@@ -1,0 +1,183 @@
+import Testing
+import Foundation
+@testable import Domain
+
+@Suite
+struct NotchActivityResolverTests {
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+    private let resolver = NotchActivityResolver(finishedDisplayDuration: 4)
+
+    private func running(_ id: String, startedAt: Date? = nil) -> ClaudeSession {
+        ClaudeSession(id: id, cwd: "/Users/me/github/\(id)", startedAt: startedAt ?? now.addingTimeInterval(-60))
+    }
+
+    private func quota(_ percentRemaining: Double, provider: String = "claude") -> UsageQuota {
+        UsageQuota(percentRemaining: percentRemaining, quotaType: .session, providerId: provider)
+    }
+
+    // MARK: - Nothing to say
+
+    @Test
+    func `no sessions and no quotas resolves to nothing`() {
+        #expect(resolver.resolve(sessions: [], quotas: [], now: now) == nil)
+    }
+
+    @Test
+    func `a healthy quota alone resolves to nothing`() {
+        #expect(resolver.resolve(sessions: [], quotas: [quota(80)], now: now) == nil)
+    }
+
+    @Test
+    func `a warning quota is not worth taking over the notch`() {
+        // 35% remaining is QuotaStatus.warning — visible in the popover, not in the notch.
+        #expect(resolver.resolve(sessions: [], quotas: [quota(35)], now: now) == nil)
+    }
+
+    // MARK: - Session phases
+
+    @Test
+    func `an active session resolves to working`() {
+        let result = resolver.resolve(sessions: [running("claudebar")], quotas: [], now: now)
+
+        #expect(result == .working(running("claudebar")))
+    }
+
+    @Test
+    func `a session with subagents resolves to agents working`() {
+        var session = running("claudebar")
+        session.subagentStarted()
+
+        let result = resolver.resolve(sessions: [session], quotas: [], now: now)
+
+        #expect(result?.session?.activeSubagentCount == 1)
+        #expect(result == .agentsWorking(session))
+    }
+
+    @Test
+    func `a blocked session resolves to awaiting input`() {
+        var session = running("claudebar")
+        session.awaitInput("Bash · rm -rf build/", at: now)
+
+        let result = resolver.resolve(sessions: [session], quotas: [], now: now)
+
+        #expect(result == .awaitingInput(session))
+        #expect(result?.session?.pendingPrompt == "Bash · rm -rf build/")
+    }
+
+    // MARK: - Priority
+
+    @Test
+    func `a blocked session outranks any number of working sessions`() {
+        var blocked = running("claudebar", startedAt: now.addingTimeInterval(-10))
+        blocked.awaitInput("Write · Package.swift", at: now)
+
+        var busy = running("asc")
+        busy.subagentStarted()
+        busy.subagentStarted()
+
+        let result = resolver.resolve(sessions: [busy, running("billfold"), blocked], quotas: [], now: now)
+
+        #expect(result?.session?.id == "claudebar")
+    }
+
+    @Test
+    func `a critical quota outranks a working session`() {
+        let result = resolver.resolve(sessions: [running("claudebar")], quotas: [quota(5)], now: now)
+
+        #expect(result == .quotaThreshold(quota(5)))
+    }
+
+    @Test
+    func `a blocked session outranks a critical quota`() {
+        var blocked = running("claudebar")
+        blocked.awaitInput("Bash · git push", at: now)
+
+        let result = resolver.resolve(sessions: [blocked], quotas: [quota(0)], now: now)
+
+        #expect(result == .awaitingInput(blocked))
+    }
+
+    @Test
+    func `the most severe quota wins when several are past the threshold`() {
+        let result = resolver.resolve(
+            sessions: [],
+            quotas: [quota(18, provider: "copilot"), quota(3, provider: "claude"), quota(60, provider: "codex")],
+            now: now
+        )
+
+        #expect(result == .quotaThreshold(quota(3, provider: "claude")))
+    }
+
+    @Test
+    func `among blocked sessions the one waiting longest wins`() {
+        var early = running("claudebar", startedAt: now.addingTimeInterval(-600))
+        early.awaitInput("Bash · make", at: now)
+        var late = running("asc", startedAt: now.addingTimeInterval(-30))
+        late.awaitInput("Bash · ls", at: now)
+
+        let result = resolver.resolve(sessions: [late, early], quotas: [], now: now)
+
+        #expect(result?.session?.id == "claudebar")
+    }
+
+    // MARK: - The finished flash
+
+    @Test
+    func `a session that just stopped resolves to finished`() {
+        var session = running("claudebar")
+        session.stop(at: now.addingTimeInterval(-1))
+
+        let result = resolver.resolve(sessions: [session], quotas: [], now: now)
+
+        #expect(result == .finished(session))
+    }
+
+    @Test
+    func `an ended session resolves to finished inside the display window`() {
+        var session = running("claudebar")
+        session.end(at: now.addingTimeInterval(-3))
+
+        #expect(resolver.resolve(sessions: [session], quotas: [], now: now) == .finished(session))
+    }
+
+    @Test
+    func `finished expires once the display window has passed`() {
+        var session = running("claudebar")
+        session.end(at: now.addingTimeInterval(-5))
+
+        #expect(resolver.resolve(sessions: [session], quotas: [], now: now) == nil)
+    }
+
+    @Test
+    func `an expired finished session yields to the next activity`() {
+        var done = running("claudebar")
+        done.end(at: now.addingTimeInterval(-30))
+        let stillGoing = running("asc")
+
+        let result = resolver.resolve(sessions: [done, stillGoing], quotas: [], now: now)
+
+        #expect(result == .working(stillGoing))
+    }
+
+    @Test
+    func `finished briefly outranks a session that is still working`() {
+        var done = running("claudebar")
+        done.end(at: now.addingTimeInterval(-1))
+
+        let result = resolver.resolve(sessions: [done, running("asc")], quotas: [], now: now)
+
+        #expect(result?.session?.id == "claudebar")
+    }
+
+    @Test
+    func `a blocked session is never masked by a finished flash`() {
+        var done = running("asc")
+        done.end(at: now)
+        var blocked = running("claudebar")
+        blocked.awaitInput("Bash · rm", at: now)
+
+        let result = resolver.resolve(sessions: [done, blocked], quotas: [], now: now)
+
+        #expect(result?.session?.id == "claudebar")
+    }
+}

--- a/Tests/DomainTests/Notch/NotchActivityResolverTests.swift
+++ b/Tests/DomainTests/Notch/NotchActivityResolverTests.swift
@@ -19,25 +19,25 @@ struct NotchActivityResolverTests {
 
     @Test
     func `no sessions and no quotas resolves to nothing`() {
-        #expect(resolver.resolve(sessions: [], quotas: [], now: now) == nil)
+        #expect(resolver.resolve(sessions: [], quotas: [], headlineQuota: nil, now: now) == nil)
     }
 
     @Test
-    func `a healthy quota alone resolves to nothing`() {
-        #expect(resolver.resolve(sessions: [], quotas: [quota(80)], now: now) == nil)
+    func `a healthy quota that is not the headline resolves to nothing`() {
+        #expect(resolver.resolve(sessions: [], quotas: [quota(80)], headlineQuota: nil, now: now) == nil)
     }
 
     @Test
-    func `a warning quota is not worth taking over the notch`() {
+    func `a warning quota does not take over the notch`() {
         // 35% remaining is QuotaStatus.warning — visible in the popover, not in the notch.
-        #expect(resolver.resolve(sessions: [], quotas: [quota(35)], now: now) == nil)
+        #expect(resolver.resolve(sessions: [], quotas: [quota(35)], headlineQuota: nil, now: now) == nil)
     }
 
     // MARK: - Session phases
 
     @Test
     func `an active session resolves to working`() {
-        let result = resolver.resolve(sessions: [running("claudebar")], quotas: [], now: now)
+        let result = resolver.resolve(sessions: [running("claudebar")], quotas: [], headlineQuota: nil, now: now)
 
         #expect(result == .working(running("claudebar")))
     }
@@ -47,7 +47,7 @@ struct NotchActivityResolverTests {
         var session = running("claudebar")
         session.subagentStarted()
 
-        let result = resolver.resolve(sessions: [session], quotas: [], now: now)
+        let result = resolver.resolve(sessions: [session], quotas: [], headlineQuota: nil, now: now)
 
         #expect(result?.session?.activeSubagentCount == 1)
         #expect(result == .agentsWorking(session))
@@ -58,7 +58,7 @@ struct NotchActivityResolverTests {
         var session = running("claudebar")
         session.awaitInput("Bash · rm -rf build/", at: now)
 
-        let result = resolver.resolve(sessions: [session], quotas: [], now: now)
+        let result = resolver.resolve(sessions: [session], quotas: [], headlineQuota: nil, now: now)
 
         #expect(result == .awaitingInput(session))
         #expect(result?.session?.pendingPrompt == "Bash · rm -rf build/")
@@ -75,14 +75,14 @@ struct NotchActivityResolverTests {
         busy.subagentStarted()
         busy.subagentStarted()
 
-        let result = resolver.resolve(sessions: [busy, running("billfold"), blocked], quotas: [], now: now)
+        let result = resolver.resolve(sessions: [busy, running("billfold"), blocked], quotas: [], headlineQuota: nil, now: now)
 
         #expect(result?.session?.id == "claudebar")
     }
 
     @Test
     func `a critical quota outranks a working session`() {
-        let result = resolver.resolve(sessions: [running("claudebar")], quotas: [quota(5)], now: now)
+        let result = resolver.resolve(sessions: [running("claudebar")], quotas: [quota(5)], headlineQuota: nil, now: now)
 
         #expect(result == .quotaThreshold(quota(5)))
     }
@@ -92,7 +92,7 @@ struct NotchActivityResolverTests {
         var blocked = running("claudebar")
         blocked.awaitInput("Bash · git push", at: now)
 
-        let result = resolver.resolve(sessions: [blocked], quotas: [quota(0)], now: now)
+        let result = resolver.resolve(sessions: [blocked], quotas: [quota(0)], headlineQuota: nil, now: now)
 
         #expect(result == .awaitingInput(blocked))
     }
@@ -102,6 +102,7 @@ struct NotchActivityResolverTests {
         let result = resolver.resolve(
             sessions: [],
             quotas: [quota(18, provider: "copilot"), quota(3, provider: "claude"), quota(60, provider: "codex")],
+            headlineQuota: nil,
             now: now
         )
 
@@ -115,9 +116,71 @@ struct NotchActivityResolverTests {
         var late = running("asc", startedAt: now.addingTimeInterval(-30))
         late.awaitInput("Bash · ls", at: now)
 
-        let result = resolver.resolve(sessions: [late, early], quotas: [], now: now)
+        let result = resolver.resolve(sessions: [late, early], quotas: [], headlineQuota: nil, now: now)
 
         #expect(result?.session?.id == "claudebar")
+    }
+
+    // MARK: - The idle glance
+
+    @Test
+    func `the headline quota is shown at a glance when nothing is happening`() {
+        // ClaudeBar is a quota monitor. With no session running, how much is
+        // left is still the thing the user came for.
+        let headline = quota(86)
+
+        let result = resolver.resolve(sessions: [], quotas: [headline], headlineQuota: headline, now: now)
+
+        #expect(result == .quotaGlance(headline))
+    }
+
+    @Test
+    func `the glance shows the chosen quota even when another one is lower`() {
+        let headline = quota(86, provider: "claude")
+        let lower = quota(55, provider: "codex")
+
+        let result = resolver.resolve(
+            sessions: [],
+            quotas: [lower, headline],
+            headlineQuota: headline,
+            now: now
+        )
+
+        #expect(result == .quotaGlance(headline))
+    }
+
+    @Test
+    func `a working session takes the notch back from the glance`() {
+        let headline = quota(86)
+
+        let result = resolver.resolve(
+            sessions: [running("claudebar")],
+            quotas: [headline],
+            headlineQuota: headline,
+            now: now
+        )
+
+        #expect(result == .working(running("claudebar")))
+    }
+
+    @Test
+    func `a quota past the threshold outranks the glance`() {
+        let headline = quota(86, provider: "claude")
+        let critical = quota(4, provider: "codex")
+
+        let result = resolver.resolve(
+            sessions: [],
+            quotas: [headline, critical],
+            headlineQuota: headline,
+            now: now
+        )
+
+        #expect(result == .quotaThreshold(critical))
+    }
+
+    @Test
+    func `there is nothing to glance at before the first probe returns`() {
+        #expect(resolver.resolve(sessions: [], quotas: [], headlineQuota: nil, now: now) == nil)
     }
 
     // MARK: - The finished flash
@@ -127,7 +190,7 @@ struct NotchActivityResolverTests {
         var session = running("claudebar")
         session.stop(at: now.addingTimeInterval(-1))
 
-        let result = resolver.resolve(sessions: [session], quotas: [], now: now)
+        let result = resolver.resolve(sessions: [session], quotas: [], headlineQuota: nil, now: now)
 
         #expect(result == .finished(session))
     }
@@ -137,7 +200,7 @@ struct NotchActivityResolverTests {
         var session = running("claudebar")
         session.end(at: now.addingTimeInterval(-3))
 
-        #expect(resolver.resolve(sessions: [session], quotas: [], now: now) == .finished(session))
+        #expect(resolver.resolve(sessions: [session], quotas: [], headlineQuota: nil, now: now) == .finished(session))
     }
 
     @Test
@@ -145,7 +208,7 @@ struct NotchActivityResolverTests {
         var session = running("claudebar")
         session.end(at: now.addingTimeInterval(-5))
 
-        #expect(resolver.resolve(sessions: [session], quotas: [], now: now) == nil)
+        #expect(resolver.resolve(sessions: [session], quotas: [], headlineQuota: nil, now: now) == nil)
     }
 
     @Test
@@ -154,7 +217,7 @@ struct NotchActivityResolverTests {
         done.end(at: now.addingTimeInterval(-30))
         let stillGoing = running("asc")
 
-        let result = resolver.resolve(sessions: [done, stillGoing], quotas: [], now: now)
+        let result = resolver.resolve(sessions: [done, stillGoing], quotas: [], headlineQuota: nil, now: now)
 
         #expect(result == .working(stillGoing))
     }
@@ -164,7 +227,7 @@ struct NotchActivityResolverTests {
         var done = running("claudebar")
         done.end(at: now.addingTimeInterval(-1))
 
-        let result = resolver.resolve(sessions: [done, running("asc")], quotas: [], now: now)
+        let result = resolver.resolve(sessions: [done, running("asc")], quotas: [], headlineQuota: nil, now: now)
 
         #expect(result?.session?.id == "claudebar")
     }
@@ -176,7 +239,7 @@ struct NotchActivityResolverTests {
         var blocked = running("claudebar")
         blocked.awaitInput("Bash · rm", at: now)
 
-        let result = resolver.resolve(sessions: [done, blocked], quotas: [], now: now)
+        let result = resolver.resolve(sessions: [done, blocked], quotas: [], headlineQuota: nil, now: now)
 
         #expect(result?.session?.id == "claudebar")
     }

--- a/Tests/DomainTests/Notch/NotchActivityTests.swift
+++ b/Tests/DomainTests/Notch/NotchActivityTests.swift
@@ -45,11 +45,23 @@ struct NotchActivityTests {
     }
 
     @Test
+    func `the idle glance ranks below everything else`() {
+        let glance = NotchActivity.quotaGlance(quota(86))
+
+        #expect(glance < .working(session()))
+        #expect(glance < .agentsWorking(session()))
+        #expect(glance < .quotaThreshold(quota(2)))
+        #expect(glance < .finished(session()))
+        #expect(glance < .awaitingInput(session()))
+    }
+
+    @Test
     func `session accessor exposes the session for session-backed activities`() {
         #expect(NotchActivity.working(session("a")).session?.id == "a")
         #expect(NotchActivity.agentsWorking(session("b")).session?.id == "b")
         #expect(NotchActivity.awaitingInput(session("c")).session?.id == "c")
         #expect(NotchActivity.finished(session("d")).session?.id == "d")
         #expect(NotchActivity.quotaThreshold(quota(2)).session == nil)
+        #expect(NotchActivity.quotaGlance(quota(86)).session == nil)
     }
 }

--- a/Tests/DomainTests/Notch/NotchActivityTests.swift
+++ b/Tests/DomainTests/Notch/NotchActivityTests.swift
@@ -1,0 +1,55 @@
+import Testing
+import Foundation
+@testable import Domain
+
+@Suite
+struct NotchActivityTests {
+    private func session(_ id: String = "s1") -> ClaudeSession {
+        ClaudeSession(id: id, cwd: "/Users/me/github/claudebar")
+    }
+
+    private func quota(_ percentRemaining: Double) -> UsageQuota {
+        UsageQuota(percentRemaining: percentRemaining, quotaType: .session, providerId: "claude")
+    }
+
+    @Test
+    func `awaiting input outranks every other activity`() {
+        let blocked = NotchActivity.awaitingInput(session())
+
+        #expect(blocked > .finished(session()))
+        #expect(blocked > .quotaThreshold(quota(2)))
+        #expect(blocked > .agentsWorking(session()))
+        #expect(blocked > .working(session()))
+    }
+
+    @Test
+    func `finished outranks quota and work but not blocked`() {
+        let finished = NotchActivity.finished(session())
+
+        #expect(finished > .quotaThreshold(quota(2)))
+        #expect(finished > .agentsWorking(session()))
+        #expect(finished < .awaitingInput(session()))
+    }
+
+    @Test
+    func `quota threshold outranks working sessions`() {
+        let quotaActivity = NotchActivity.quotaThreshold(quota(2))
+
+        #expect(quotaActivity > .agentsWorking(session()))
+        #expect(quotaActivity > .working(session()))
+    }
+
+    @Test
+    func `agents working outranks plain working`() {
+        #expect(NotchActivity.agentsWorking(session()) > .working(session()))
+    }
+
+    @Test
+    func `session accessor exposes the session for session-backed activities`() {
+        #expect(NotchActivity.working(session("a")).session?.id == "a")
+        #expect(NotchActivity.agentsWorking(session("b")).session?.id == "b")
+        #expect(NotchActivity.awaitingInput(session("c")).session?.id == "c")
+        #expect(NotchActivity.finished(session("d")).session?.id == "d")
+        #expect(NotchActivity.quotaThreshold(quota(2)).session == nil)
+    }
+}

--- a/Tests/DomainTests/Notch/NotchMetricsTests.swift
+++ b/Tests/DomainTests/Notch/NotchMetricsTests.swift
@@ -1,0 +1,110 @@
+import Testing
+import Foundation
+@testable import Domain
+
+@Suite
+struct NotchMetricsTests {
+    // A 14" MacBook Pro at its default scaled resolution: 1512pt wide, a 32pt
+    // menu bar, and ~663.5pt of usable menu bar either side of the notch.
+    private let builtInDisplayWidth: CGFloat = 1512
+    private let builtInAuxiliaryWidth: CGFloat = 663.5
+
+    @Test
+    func `a notched display measures the notch from the auxiliary areas either side`() {
+        let metrics = NotchMetrics.measure(
+            screenWidth: builtInDisplayWidth,
+            safeAreaTop: 32,
+            auxiliaryTopLeftWidth: builtInAuxiliaryWidth,
+            auxiliaryTopRightWidth: builtInAuxiliaryWidth,
+            menuBarHeight: 32
+        )
+
+        // 1512 - 663.5 - 663.5 = 185, plus the 4pt overlap that hides the seam.
+        #expect(metrics.closedSize.width == 189)
+        #expect(metrics.isPhysicalNotch)
+    }
+
+    @Test
+    func `a notched display takes its height from the safe area inset`() {
+        let metrics = NotchMetrics.measure(
+            screenWidth: builtInDisplayWidth,
+            safeAreaTop: 38,
+            auxiliaryTopLeftWidth: builtInAuxiliaryWidth,
+            auxiliaryTopRightWidth: builtInAuxiliaryWidth,
+            menuBarHeight: 24
+        )
+
+        #expect(metrics.closedSize.height == 38)
+    }
+
+    @Test
+    func `a display without a notch gets a virtual pill of the default width`() {
+        let metrics = NotchMetrics.measure(
+            screenWidth: 2560,
+            safeAreaTop: 0,
+            auxiliaryTopLeftWidth: nil,
+            auxiliaryTopRightWidth: nil,
+            menuBarHeight: 24
+        )
+
+        #expect(metrics.closedSize.width == NotchMetrics.defaultWidth)
+        #expect(metrics.isPhysicalNotch == false)
+    }
+
+    @Test
+    func `a display without a notch takes its height from the menu bar`() {
+        let metrics = NotchMetrics.measure(
+            screenWidth: 2560,
+            safeAreaTop: 0,
+            auxiliaryTopLeftWidth: nil,
+            auxiliaryTopRightWidth: nil,
+            menuBarHeight: 24
+        )
+
+        #expect(metrics.closedSize.height == 24)
+    }
+
+    @Test
+    func `an auto-hidden menu bar falls back to the default height`() {
+        // visibleFrame reaches the top of the screen when the menu bar hides,
+        // which measures as a zero-height menu bar.
+        let metrics = NotchMetrics.measure(
+            screenWidth: 2560,
+            safeAreaTop: 0,
+            auxiliaryTopLeftWidth: nil,
+            auxiliaryTopRightWidth: nil,
+            menuBarHeight: 0
+        )
+
+        #expect(metrics.closedSize.height == NotchMetrics.defaultHeight)
+    }
+
+    @Test
+    func `a notched display missing its auxiliary areas falls back to the default width`() {
+        let metrics = NotchMetrics.measure(
+            screenWidth: builtInDisplayWidth,
+            safeAreaTop: 32,
+            auxiliaryTopLeftWidth: nil,
+            auxiliaryTopRightWidth: builtInAuxiliaryWidth,
+            menuBarHeight: 32
+        )
+
+        #expect(metrics.closedSize.width == NotchMetrics.defaultWidth)
+        #expect(metrics.closedSize.height == 32)
+    }
+
+    @Test
+    func `an implausibly narrow measurement falls back rather than collapsing the notch`() {
+        // Guards against a transient screen configuration reporting auxiliary
+        // areas that consume the whole width.
+        let metrics = NotchMetrics.measure(
+            screenWidth: builtInDisplayWidth,
+            safeAreaTop: 32,
+            auxiliaryTopLeftWidth: 756,
+            auxiliaryTopRightWidth: 756,
+            menuBarHeight: 32
+        )
+
+        #expect(metrics.closedSize.width == NotchMetrics.defaultWidth)
+    }
+}

--- a/Tests/DomainTests/Provider/PopoverContentHeightTests.swift
+++ b/Tests/DomainTests/Provider/PopoverContentHeightTests.swift
@@ -48,6 +48,64 @@ struct PopoverContentHeightTests {
         #expect(cap == 735 - PopoverContentHeight.chrome)
     }
 
+    // MARK: - Fitting the Content
+
+    @Test
+    func `content shorter than the cap keeps its own height`() {
+        // A provider with one card must not stretch to fill the cap.
+        let height = PopoverContentHeight.height(
+            contentHeight: 180,
+            visibleScreenHeight: 982,
+            overviewMode: false
+        )
+        #expect(height == 180)
+    }
+
+    @Test
+    func `content taller than the cap is clamped to it`() {
+        let height = PopoverContentHeight.height(
+            contentHeight: 5000,
+            visibleScreenHeight: 982,
+            overviewMode: false
+        )
+        #expect(height == PopoverContentHeight.maxHeight(visibleScreenHeight: 982, overviewMode: false))
+    }
+
+    @Test
+    func `a tall display does not stretch a short popover`() {
+        // A 2560pt portrait display leaves a ~2300pt cap. Before the content
+        // height was taken into account, one small card ballooned to fill it.
+        let height = PopoverContentHeight.height(
+            contentHeight: 220,
+            visibleScreenHeight: 2530,
+            overviewMode: false
+        )
+        #expect(height == 220)
+    }
+
+    @Test(arguments: [0.0, -40.0])
+    func `an unmeasured content height falls back to the cap`(contentHeight: Double) {
+        // First layout pass, before the geometry reader has reported. Falling
+        // back to the cap keeps the popover scrollable rather than collapsing
+        // it to nothing.
+        let height = PopoverContentHeight.height(
+            contentHeight: contentHeight,
+            visibleScreenHeight: 982,
+            overviewMode: false
+        )
+        #expect(height == PopoverContentHeight.maxHeight(visibleScreenHeight: 982, overviewMode: false))
+    }
+
+    @Test
+    func `overview still respects its ceiling when content is taller`() {
+        let height = PopoverContentHeight.height(
+            contentHeight: 5000,
+            visibleScreenHeight: 982,
+            overviewMode: true
+        )
+        #expect(height == 500)
+    }
+
     // MARK: - Degenerate Displays
 
     @Test

--- a/Tests/DomainTests/Session/ClaudeSessionTests.swift
+++ b/Tests/DomainTests/Session/ClaudeSessionTests.swift
@@ -230,10 +230,116 @@ struct ClaudeSessionTests {
         #expect(session.phase == .ended)
     }
 
+
+    // MARK: - Awaiting input
+
+    @Test
+    func `awaitInput moves the session to awaitingInput and records the prompt`() {
+        var session = ClaudeSession(id: "test", cwd: "/tmp")
+
+        session.awaitInput("Bash · rm -rf build/")
+
+        #expect(session.phase == .awaitingInput)
+        #expect(session.pendingPrompt == "Bash · rm -rf build/")
+    }
+
+    @Test
+    func `awaitInput is ignored after ended`() {
+        var session = ClaudeSession(id: "test", cwd: "/tmp")
+        session.end()
+
+        session.awaitInput("Bash · ls")
+
+        #expect(session.phase == .ended)
+        #expect(session.pendingPrompt == nil)
+    }
+
+    @Test
+    func `resume clears the pending prompt`() {
+        var session = ClaudeSession(id: "test", cwd: "/tmp")
+        session.awaitInput("Bash · ls")
+
+        session.resume()
+
+        #expect(session.phase == .active)
+        #expect(session.pendingPrompt == nil)
+    }
+
+    @Test
+    func `subagent start clears the pending prompt`() {
+        var session = ClaudeSession(id: "test", cwd: "/tmp")
+        session.awaitInput("Bash · ls")
+
+        session.subagentStarted()
+
+        #expect(session.phase == .subagentsWorking)
+        #expect(session.pendingPrompt == nil)
+    }
+
+    // MARK: - Finishing
+
+    @Test
+    func `stop records when the session stopped`() {
+        let when = Date(timeIntervalSince1970: 1_700_000_000)
+        var session = ClaudeSession(id: "test", cwd: "/tmp")
+
+        session.stop(at: when)
+
+        #expect(session.stoppedAt == when)
+        #expect(session.finishedAt == when)
+    }
+
+    @Test
+    func `finishedAt is nil while the session is running`() {
+        let session = ClaudeSession(id: "test", cwd: "/tmp")
+
+        #expect(session.finishedAt == nil)
+    }
+
+    @Test
+    func `finishedAt prefers endedAt over stoppedAt`() {
+        let stopped = Date(timeIntervalSince1970: 1_700_000_000)
+        let ended = stopped.addingTimeInterval(30)
+        var session = ClaudeSession(id: "test", cwd: "/tmp")
+        session.stop(at: stopped)
+
+        session.end(at: ended)
+
+        #expect(session.finishedAt == ended)
+    }
+
+    @Test
+    func `resuming a stopped session clears the stop timestamp`() {
+        var session = ClaudeSession(id: "test", cwd: "/tmp")
+        session.stop()
+
+        session.resume()
+
+        #expect(session.stoppedAt == nil)
+        #expect(session.finishedAt == nil)
+    }
+
+    // MARK: - Identity
+
+    @Test
+    func `repoName is the last path component of the working directory`() {
+        let session = ClaudeSession(id: "test", cwd: "/Users/me/github/tddworks/claudebar")
+
+        #expect(session.repoName == "claudebar")
+    }
+
+    @Test
+    func `repoName tolerates a trailing slash`() {
+        let session = ClaudeSession(id: "test", cwd: "/Users/me/github/claudebar/")
+
+        #expect(session.repoName == "claudebar")
+    }
+
     @Test
     func `phase label returns correct strings`() {
         #expect(ClaudeSession.Phase.active.label == "Active")
         #expect(ClaudeSession.Phase.subagentsWorking.label == "Agents Working")
+        #expect(ClaudeSession.Phase.awaitingInput.label == "Needs You")
         #expect(ClaudeSession.Phase.stopped.label == "Stopped")
         #expect(ClaudeSession.Phase.ended.label == "Ended")
     }

--- a/Tests/DomainTests/Session/SessionEventTests.swift
+++ b/Tests/DomainTests/Session/SessionEventTests.swift
@@ -111,5 +111,26 @@ struct SessionEventTests {
         #expect(SessionEvent.EventName.subagentStop.rawValue == "SubagentStop")
         #expect(SessionEvent.EventName.stop.rawValue == "Stop")
         #expect(SessionEvent.EventName.userPromptSubmit.rawValue == "UserPromptSubmit")
+        #expect(SessionEvent.EventName.notification.rawValue == "Notification")
+    }
+
+    @Test
+    func `message defaults to nil`() {
+        let event = SessionEvent(sessionId: "s", eventName: .sessionStart, cwd: "/tmp")
+
+        #expect(event.message == nil)
+    }
+
+    @Test
+    func `a notification event carries the prompt Claude Code is blocked on`() {
+        let event = SessionEvent(
+            sessionId: "s",
+            eventName: .notification,
+            cwd: "/tmp",
+            message: "Claude needs your permission to use Bash"
+        )
+
+        #expect(event.eventName == .notification)
+        #expect(event.message == "Claude needs your permission to use Bash")
     }
 }

--- a/Tests/DomainTests/Session/SessionMonitorTests.swift
+++ b/Tests/DomainTests/Session/SessionMonitorTests.swift
@@ -9,9 +9,16 @@ struct SessionMonitorTests {
         sessionId: String = "test-session",
         eventName: SessionEvent.EventName,
         cwd: String = "/tmp/project",
-        receivedAt: Date = Date()
+        receivedAt: Date = Date(),
+        message: String? = nil
     ) -> SessionEvent {
-        SessionEvent(sessionId: sessionId, eventName: eventName, cwd: cwd, receivedAt: receivedAt)
+        SessionEvent(
+            sessionId: sessionId,
+            eventName: eventName,
+            cwd: cwd,
+            receivedAt: receivedAt,
+            message: message
+        )
     }
 
     // MARK: - Session Lifecycle
@@ -260,5 +267,41 @@ struct SessionMonitorTests {
         #expect(monitor.activeSession == nil)
         #expect(monitor.recentSessions.count == 1)
         #expect(monitor.recentSessions.first?.completedTaskCount == 2)
+    }
+
+    // MARK: - Permission Prompts
+
+    @Test
+    func `Notification moves the active session to awaitingInput`() {
+        let monitor = SessionMonitor()
+        monitor.processEvent(makeEvent(eventName: .sessionStart))
+
+        monitor.processEvent(makeEvent(eventName: .notification, message: "Claude needs your permission to use Bash"))
+
+        #expect(monitor.activeSession?.phase == .awaitingInput)
+        #expect(monitor.activeSession?.pendingPrompt == "Claude needs your permission to use Bash")
+    }
+
+    @Test
+    func `Notification is ignored when it belongs to another session`() {
+        let monitor = SessionMonitor()
+        monitor.processEvent(makeEvent(eventName: .sessionStart))
+
+        monitor.processEvent(makeEvent(sessionId: "other", eventName: .notification, message: "blocked"))
+
+        #expect(monitor.activeSession?.phase == .active)
+        #expect(monitor.activeSession?.pendingPrompt == nil)
+    }
+
+    @Test
+    func `UserPromptSubmit releases a session waiting on input`() {
+        let monitor = SessionMonitor()
+        monitor.processEvent(makeEvent(eventName: .sessionStart))
+        monitor.processEvent(makeEvent(eventName: .notification, message: "blocked"))
+
+        monitor.processEvent(makeEvent(eventName: .userPromptSubmit))
+
+        #expect(monitor.activeSession?.phase == .active)
+        #expect(monitor.activeSession?.pendingPrompt == nil)
     }
 }

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -12,11 +12,16 @@ let packageSettings = PackageSettings(
     // Metal shaders into both Sources and Resources for staticFramework SPM bundles.
     productTypes: [
         "SwiftTerm": .framework,
+        // Same Metal-shader duplication as SwiftTerm: GlowEffectKit bundles
+        // GlowEffect.metal under Sources/, which Tuist copies into both Sources
+        // and Resources for a staticFramework SPM bundle (tuist/tuist#9111).
+        "GlowEffectKit": .framework,
     ],
     targetSettings: [
         "IssueReporting": ["SWIFT_PACKAGE_NAME": "xctest-dynamic-overlay"],
         "IssueReportingPackageSupport": ["SWIFT_PACKAGE_NAME": "xctest-dynamic-overlay"],
         "SwiftTerm": ["EXCLUDED_SOURCE_FILE_NAMES": "Shaders.metal"],
+        "GlowEffectKit": ["EXCLUDED_SOURCE_FILE_NAMES": "GlowEffect.metal"],
     ]
 )
 #endif
@@ -41,5 +46,11 @@ let package = Package(
         // Foundation.Process — Subprocess has no pseudo-terminal support as of
         // 1.0.0 (swiftlang/swift-subprocess#227 is post-1.0).
         .package(url: "https://github.com/swiftlang/swift-subprocess.git", from: "1.0.0"),
+        // Metal-shader glow, used to make a refresh visible on the notch.
+        .package(url: "https://github.com/didisouzacosta/GlowEffectKit", from: "1.1.0"),
+        // Dot-matrix loaders. Custom licence: commercial use is granted, but
+        // republishing the components as a reusable library is not — fine for
+        // consuming it here, so long as the source is never vendored.
+        .package(url: "https://github.com/mana-am/matrix-swift", from: "0.2.0"),
     ]
 )

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -12,16 +12,11 @@ let packageSettings = PackageSettings(
     // Metal shaders into both Sources and Resources for staticFramework SPM bundles.
     productTypes: [
         "SwiftTerm": .framework,
-        // Same Metal-shader duplication as SwiftTerm: GlowEffectKit bundles
-        // GlowEffect.metal under Sources/, which Tuist copies into both Sources
-        // and Resources for a staticFramework SPM bundle (tuist/tuist#9111).
-        "GlowEffectKit": .framework,
     ],
     targetSettings: [
         "IssueReporting": ["SWIFT_PACKAGE_NAME": "xctest-dynamic-overlay"],
         "IssueReportingPackageSupport": ["SWIFT_PACKAGE_NAME": "xctest-dynamic-overlay"],
         "SwiftTerm": ["EXCLUDED_SOURCE_FILE_NAMES": "Shaders.metal"],
-        "GlowEffectKit": ["EXCLUDED_SOURCE_FILE_NAMES": "GlowEffect.metal"],
     ]
 )
 #endif
@@ -46,8 +41,6 @@ let package = Package(
         // Foundation.Process — Subprocess has no pseudo-terminal support as of
         // 1.0.0 (swiftlang/swift-subprocess#227 is post-1.0).
         .package(url: "https://github.com/swiftlang/swift-subprocess.git", from: "1.0.0"),
-        // Metal-shader glow, used to make a refresh visible on the notch.
-        .package(url: "https://github.com/didisouzacosta/GlowEffectKit", from: "1.1.0"),
         // Dot-matrix loaders. Custom licence: commercial use is granted, but
         // republishing the components as a reusable library is not — fine for
         // consuming it here, so long as the source is never vendored.

--- a/docs/features/notch-live-activity.md
+++ b/docs/features/notch-live-activity.md
@@ -1,0 +1,298 @@
+# Notch Live Activity
+
+ClaudeBar renders session and quota state into the MacBook notch — a Dynamic Island for Claude Code, built on the hook stream and `QuotaMonitor` that already exist.
+
+**Mockup:** [`docs/mockups/notch-live-activity.html`](../mockups/notch-live-activity.html)
+
+---
+
+## The problem
+
+ClaudeBar already knows everything worth knowing about a running session. `SessionMonitor` consumes a live hook stream (`SessionStart`, `UserPromptSubmit`, `SubagentStart/Stop`, `TaskCompleted`, `Stop`, `SessionEnd`) and maintains a rich `ClaudeSession` with `phase`, `activeSubagentCount`, `completedTaskCount`, and elapsed time. `QuotaMonitor` holds every provider's remaining quota and reset window.
+
+All of it is delivered through two surfaces that are wrong for ambient state:
+
+| Surface | Failure mode |
+|---|---|
+| **16 px status item** | Fits one number. Sits in a menu bar that macOS 15 crowds and truncates. You have to already be looking at it. |
+| **User notifications** | Transient by construction. Focus modes swallow them. `QuotaAlerter` firing at 95% is exactly the message that must not be dismissible-by-default. |
+| **Popover** | Requires a click on a target you have to aim for. |
+
+The gap this leaves is specific and daily: **you start Claude in a repo, switch to a browser, and lose all signal about whether it is working, blocked, or finished.** The most expensive case is *blocked* — Claude waiting on a permission prompt while you read Slack, burning wall-clock on a session that needs one keystroke.
+
+`Sources/App/LiveActivity/LiveActivityManager.swift` is already a no-op placeholder documenting this exact intent:
+
+> ActivityKit types are currently marked as explicitly unavailable on macOS — even in macOS 26. When Apple adds macOS support for Live Activities, this manager can be activated to show session status as a system-level Live Activity.
+
+The notch is that surface, available today. It is the only region of the screen that is always visible, never occluded by a window, and already the user's focal point.
+
+## Behavior
+
+Eight states, seven of which read from data ClaudeBar already has. The notch is **collapsed and invisible** by default and only claims space when it has something to say.
+
+| State | Fires on | Reads | Dismissal |
+|---|---|---|---|
+| **Idle** | no active session | `SessionMonitor.activeSession == nil` | — |
+| **Working** | `UserPromptSubmit` | `Phase.active`, elapsed | persists while active |
+| **Agents working** | `SubagentStart` | `activeSubagentCount` | persists while active |
+| **Needs you** | `Notification` hook *(new)* | permission prompt payload | on resolution — **never times out** |
+| **Done** | `Stop` / `SessionEnd` | `completedTaskCount`, duration | auto-retracts after 4 s |
+| **Quota threshold** | `QuotaAlerter` 80% / 95% | `QuotaMonitor` | until window resets |
+| **Multiple sessions** | concurrent `SessionStart` | sessions keyed by `cwd` | persists |
+| **Expanded** | hover / click | same data as the popover | mouse exit |
+
+Two design rules fall out of the state table:
+
+- **Severity wins.** With three sessions running, the collapsed pill shows the worst state across all of them — a blocked session outranks two working ones. The status item cannot express this; the notch can.
+- **Attention states do not expire.** `Done` is a four-second flash. `Needs you` and `Quota threshold` stay on screen until the underlying condition clears. This is the property notifications cannot give us.
+
+### The one new hook
+
+`Needs you` is the highest-value state and the only session state needing new plumbing. Claude Code fires a `Notification` hook when it requests permission. Wiring it is two edits:
+
+```swift
+// Sources/Infrastructure/Hooks/HookInstaller.swift:22
+static let hookEvents = [
+    "SessionStart", "SessionEnd", "TaskCompleted",
+    "SubagentStart", "SubagentStop", "Stop", "UserPromptSubmit",
+    "Notification",                                    // ← new
+]
+
+// Sources/Domain/Session/SessionEvent.swift
+case notification = "Notification"                     // ← new
+```
+
+`ClaudeSession` gains a `.awaitingInput` phase, and `SessionEvent.isClaudeBarProbe` already filters ClaudeBar's own `<AppSupport>/ClaudeBar/Probe` runs so background quota probing does not light the notch.
+
+---
+
+## Prior art
+
+Two open-source implementations were read end to end before designing this.
+
+### boring.notch — [TheBoredTeam/boring.notch](https://github.com/TheBoredTeam/boring.notch)
+
+A full menu bar/HUD replacement: media controls, calendar, battery, file shelf, AirDrop, webcam.
+
+**What it gets right**
+
+*Notch geometry.* `getClosedNotchSize()` in `sizing/matters.swift` is the definitive measurement, and it is not obvious:
+
+```swift
+if let topLeftNotchpadding  = screen.auxiliaryTopLeftArea?.width,
+   let topRightNotchpadding = screen.auxiliaryTopRightArea?.width {
+    notchWidth = screen.frame.width - topLeftNotchpadding - topRightNotchpadding + 4
+}
+
+if screen.safeAreaInsets.top > 0 {          // display HAS a notch
+    notchHeight = screen.safeAreaInsets.top
+} else {                                     // external / non-notch display
+    notchHeight = screen.frame.maxY - screen.visibleFrame.maxY   // match menu bar
+}
+```
+
+The width comes from the *auxiliary areas either side* of the notch, not from any notch API — there isn't one. The `safeAreaInsets.top > 0` test is the canonical has-a-notch check, and the non-notch branch falling back to menu bar height is what makes a virtual notch on an external display look right.
+
+*Fixed window, animated content.* `windowSize` is a constant `640 × 210` canvas, positioned top-centre and never resized. The notch shape is drawn and animated *inside* it. Resizing an `NSWindow` per frame is visibly janky; this sidesteps it entirely.
+
+*`NotchShape`.* A SwiftUI `Shape` with inverted top corners built from quad curves, with `animatableData` over `(topCornerRadius, bottomCornerRadius)` so the corners round out as the notch expands. Descended from MrKai77/DynamicNotchKit. Worth adopting nearly verbatim.
+
+*`sharingType = .none`* to hide the notch from screen recordings — public API, one line, genuinely thoughtful.
+
+**What we will not copy**
+
+Private API, extensively:
+
+```swift
+// managers/NotchSpaceManager.swift
+notchSpace = CGSSpace(level: 2147483647)   // @_silgen_name into CGSSpaceCreate
+
+// components/Notch/BoringNotchSkyLightWindow.swift
+dlopen("/System/Library/PrivateFrameworks/SkyLight.framework/…")
+```
+
+`CGSSpace` puts the window in its own max-level space so it floats above fullscreen apps; SkyLight lets it draw on the lock screen. Both are undocumented, both break across macOS releases, and both are disqualifying for a Mac App Store build.
+
+### DynamicNotch — [jackson-storm/DynamicNotch](https://github.com/jackson-storm/DynamicNotch)
+
+Newer, better factored, and the more useful reference for *architecture* rather than geometry.
+
+**The content model is the takeaway.** Rather than one view switching on a mode enum, content sources are protocol-conforming values competing by priority:
+
+```swift
+protocol NotchContentProtocol {
+    var id: String { get }
+    var stackID: String { get }
+    var priority: Int { get }
+    var isExpandable: Bool { get }
+    var expandsOnTap: Bool { get }
+
+    func size(baseWidth: CGFloat, baseHeight: CGFloat) -> CGSize
+    func expandedSize(baseWidth: CGFloat, baseHeight: CGFloat) -> CGSize
+    func cornerRadius(baseRadius: CGFloat) -> (top: CGFloat, bottom: CGFloat)
+
+    @MainActor @ViewBuilder func makeView() -> AnyView
+    @MainActor @ViewBuilder func makeExpandedView() -> AnyView
+}
+
+enum NotchState {
+    case showLiveActivity(NotchContentProtocol)
+    case showTemporaryNotification(NotchContentProtocol, duration: TimeInterval)
+    case hideLiveActivity(id: String)
+    case dismissLiveActivity(id: String)
+    case hide
+}
+```
+
+`NotchModel` then resolves which content wins and derives the window size and corner radii from it. `NotchContentRegistry` is a flat catalogue of descriptors with priorities — `nowPlaying`, `download.active`, `focus.on`, `screen.recording`, `airdrop`.
+
+**This maps exactly onto ClaudeBar's problem.** Session activity, quota alerts and permission prompts are three independent sources competing for one strip of glass, and the `showLiveActivity` / `showTemporaryNotification(duration:)` split *is* the "attention states persist, Done flashes for four seconds" rule from the state table above. That distinction is Apple's Dynamic Island semantics, and both were arrived at independently.
+
+*Panel setup* is clean and reusable:
+
+```swift
+window.styleMask       = [.borderless, .nonactivatingPanel]
+window.level           = .mainMenu + 3
+window.collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle, .fullScreenAuxiliary]
+window.isFloatingPanel = true
+window.isOpaque        = false
+window.backgroundColor = .clear
+window.hasShadow       = false
+window.animationBehavior = .none
+window.acceptsMouseMovedEvents = true
+```
+
+Both projects converged on `.mainMenu + 3` and that exact `collectionBehavior` set. Treat it as the community-settled answer.
+
+**Where it differs, and why we side with boring.notch:** `OverlayPanelWindow` overrides `canBecomeKey`/`canBecomeMain`/`isKeyWindow` to `true`, so the notch takes keyboard focus — which then requires `GlobalClickMonitor` and a 151-line `AppDelegate+OutsideClick` to dismiss it again. boring.notch returns `false` for both and never steals focus. ClaudeBar's notch has no text entry, so `false` is right: **the notch must never pull focus from the terminal the user is working in.**
+
+DynamicNotch also uses SkyLight and `CGShieldingWindowLevel()` for lock-screen presence. Same exclusion as above.
+
+### Comparison
+
+| | boring.notch | DynamicNotch | **ClaudeBar** |
+|---|---|---|---|
+| Window | `NSPanel` `.mainMenu + 3` | `NSPanel` `.mainMenu + 3` | same |
+| Canvas | fixed 640 × 210 | fixed 1000 × 1000 | fixed, ~640 × 280 |
+| Takes key focus | no | **yes** | **no** |
+| Notch shape | custom `Shape`, animatable radii | custom, animatable radii | adopt boring.notch's |
+| Content model | mode enum on one view | **priority protocol + registry** | adopt DynamicNotch's |
+| Private API | `CGSSpace` + SkyLight + `dlopen` | SkyLight + `CGShieldingWindowLevel` | **none** |
+| Above fullscreen | yes (private) | yes (private) | `.fullScreenAuxiliary` only |
+| Lock screen | yes (private) | yes (private) | no |
+| MAS-shippable | no | no | **yes** |
+| Scope | system HUD replacement | system HUD replacement | **one domain, existing state** |
+
+**The synthesis:** boring.notch's geometry and shape, DynamicNotch's content model, and no private API at all.
+
+### The private-API decision
+
+Declining `CGSSpace` and SkyLight costs two capabilities: the notch will not draw over a fullscreen app on another Space, and will not appear on the lock screen.
+
+That is the right trade for this app, for three reasons that do not apply to either reference project:
+
+1. **`Sources/App/entitlements.mas.plist` exists.** ClaudeBar ships to the Mac App Store. `dlopen` into a PrivateFramework is a review rejection.
+2. **Sparkle auto-updates raise the cost of breakage.** A private-API change in a macOS point release becomes a support burden across every installed copy.
+3. **The use case does not need it.** ClaudeBar's user is in a terminal and an editor, not a fullscreen game. `.fullScreenAuxiliary` covers auxiliary presentation over the *current* fullscreen space, which is the case that actually occurs.
+
+Both reference apps are HUD replacements whose entire premise requires always-on-top-of-everything. ClaudeBar's notch is a second view onto a menu bar app's existing state. Different premise, different budget for risk.
+
+---
+
+## Architecture
+
+The notch is a **view**, not a new source of truth. `QuotaMonitor` and `SessionMonitor` remain authoritative, per the single-source-of-truth rule in `CLAUDE.md`.
+
+```
+Sources/Domain/Notch/
+├── NotchActivity.swift            # what could be shown; pure value type
+├── NotchActivityResolver.swift    # priority resolution — pure, fully TDD-able
+└── NotchPresentation.swift        # .hidden / .collapsed / .expanded
+
+Sources/Infrastructure/Notch/
+└── NotchScreenGeometry.swift      # NSScreen measurement (auxiliaryTopLeftArea, safeAreaInsets)
+
+Sources/App/Notch/
+├── NotchWindow.swift              # NSPanel subclass; canBecomeKey = false
+├── NotchWindowController.swift    # lifecycle, screen changes, positioning
+├── NotchShape.swift               # animatable inverted corners
+├── NotchRootView.swift            # collapsed lanes + expanded panel
+└── Activities/
+    ├── SessionActivityView.swift
+    ├── AttentionActivityView.swift
+    └── QuotaActivityView.swift
+```
+
+### The testable core
+
+`NotchActivityResolver` is where the interesting logic lives and it touches no AppKit — a pure function from monitor state to presentation, which is exactly the Chicago-school state-based shape this codebase tests with:
+
+```swift
+public struct NotchActivityResolver {
+    public func resolve(
+        sessions: [ClaudeSession],
+        quotas: [ProviderQuota],
+        now: Date
+    ) -> NotchActivity?
+}
+```
+
+Rules under test, no mocks required:
+
+- a blocked session outranks any number of working sessions
+- a 95% quota alert outranks a working session, but not a blocked one
+- `Done` expires at `now > completedAt + 4s` and yields to the next activity
+- an ended session with no successor resolves to `nil` → notch hidden
+- ClaudeBar's own probe session never produces an activity
+
+### Screen handling
+
+`NotchScreenGeometry` isolates the AppKit measurement so the resolver stays pure:
+
+```swift
+struct NotchMetrics {
+    let closedSize: CGSize
+    let isPhysicalNotch: Bool     // screen.safeAreaInsets.top > 0
+}
+```
+
+On a display with no notch, the closed height falls back to menu bar height (`screen.frame.maxY - screen.visibleFrame.maxY`) and ClaudeBar draws a virtual notch at top centre — roughly half of installs are on external displays or non-notch Macs, so this is a primary path, not a fallback.
+
+`NSApplication.didChangeScreenParametersNotification` drives re-measurement and repositioning.
+
+### Theming
+
+Both reference apps force `NSAppearance(named: .darkAqua)`. ClaudeBar splits it:
+
+- **the notch region itself is always black** — it is simulating physical glass; a light-themed notch is incoherent
+- **the expanded panel themes normally** through `AppThemeProvider`, using `cardGradient` / `glassBorder` / `statusColor(for:)` like every other surface
+
+`ClaudeSession.Phase.color` (`Sources/App/Views/SessionPhaseColor.swift`) is already the single source of truth for phase colour across `StatusBarIcon` and `SessionIndicatorView`; the notch becomes a third consumer, and `.awaitingInput` is added there once.
+
+---
+
+## Delivery
+
+**Phase 1 — the surface.** `NotchWindow`, `NotchShape`, geometry, positioning, multi-display, hover expand. Renders the existing session state only. Proves the hard parts: click-through, no focus stealing, correct measurement on notch and non-notch displays.
+
+**Phase 2 — attention.** `Notification` hook, `.awaitingInput` phase, `NotchActivityResolver` with priority rules, quota threshold state. This is where the feature stops being a demo.
+
+**Phase 3 — multi-session and expanded panel.** Session list keyed by `cwd`, quota bars, actions.
+
+Ships behind `app.notchEnabled` in `settings.json`, default off, with the notch's presence gated on the same `hook.enabled` that already drives `SessionMonitor`.
+
+## Considered and rejected
+
+**Drop a folder on the notch to start a session there.** Both reference apps have a file shelf, so it is the obvious thing to copy. It was cut:
+
+- **Wrong category.** Every other state answers *"what is Claude doing?"*. This one answers *"start Claude"* — an invocation shortcut on an ambient status surface. Mixing the two makes the surface mean less, and a notch that sometimes means "status" and sometimes means "drop zone" is a notch you have to think about.
+- **Cost is disproportionate.** It needs a per-screen drag monitor over a screen rect (boring.notch runs a `DragDetector` per display), plus `reRegisterDragDestination`'s staggered re-registration to survive space transitions — real, load-bearing complexity for a shortcut.
+- **The payload is worse than the plumbing.** Acting on the drop means launching a *specific* terminal with a scripted `cd … && claude`. That is terminal-specific AppleScript, and effectively impossible under the MAS sandbox — so it would be a non-MAS-only feature bolted to an otherwise clean surface.
+- **Users already have faster paths.** `cd` and `claude`, or dragging the folder onto a Terminal tab.
+
+## Open questions
+
+- **Click-through when collapsed.** The window must not consume clicks aimed at menu bar items near screen centre. `ignoresMouseEvents` toggled by an `NSTrackingArea` sized to the current content — needs verification against menu bar item overflow on macOS 15+.
+- **Focusing a session's terminal** from the expanded panel needs Accessibility permission, which a sandboxed MAS build cannot have. Keep it an optional non-MAS affordance, not load-bearing.
+- **Menu bar auto-hide.** Whether the notch persists when the menu bar hides. Proposal: yes while an activity is live, otherwise no.
+- **Interaction with the status item.** Whether the notch replaces the menu bar item or supplements it. Proposal: supplements — the status item remains the click target for the full popover.

--- a/docs/mockups/notch-live-activity.html
+++ b/docs/mockups/notch-live-activity.html
@@ -1,0 +1,565 @@
+<title>ClaudeBar Notch</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans+Condensed:wght@500;600&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap">
+
+<style>
+/* ClaudeBar Notch — deliberately single-theme.
+   The subject is a black display cutout on a dark desktop; a light variant
+   would misrepresent it. Every colour is painted explicitly. */
+:root{
+  --void:#000000;
+  --desk-deep:#120C24;
+  --desk-mid:#241340;
+  --desk-glow:#3A1C5C;
+  --chrome:#0C0814;
+  --chrome-2:#15101F;
+  --rule:rgba(255,255,255,.09);
+  --rule-2:rgba(255,255,255,.16);
+  --ink:#EDE9F6;
+  --ink-2:#A79BC2;
+  --ink-3:#6D6386;
+  --live:#34D399;
+  --agents:#60A5FA;
+  --attention:#FBBF24;
+  --critical:#F87171;
+  --accent:#C084FC;
+  --sans:"IBM Plex Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;
+  --cond:"IBM Plex Sans Condensed","IBM Plex Sans",-apple-system,sans-serif;
+  --mono:"IBM Plex Mono",ui-monospace,SFMono-Regular,Menlo,monospace;
+  --sf:-apple-system,BlinkMacSystemFont,"SF Pro Text","Helvetica Neue",sans-serif;
+  --ease:cubic-bezier(.32,.72,0,1);
+}
+
+*{box-sizing:border-box}
+body{
+  margin:0;
+  background:var(--chrome);
+  color:var(--ink);
+  font-family:var(--sans);
+  font-size:15px;
+  line-height:1.55;
+  -webkit-font-smoothing:antialiased;
+}
+
+.stage{max-width:1120px;margin:0 auto;padding:56px 28px 88px;display:flex;flex-direction:column;gap:40px}
+
+/* ---------- masthead ---------- */
+.masthead{display:flex;flex-direction:column;gap:14px;max-width:62ch}
+.eyebrow{
+  font-family:var(--cond);font-size:12px;font-weight:600;letter-spacing:.16em;
+  text-transform:uppercase;color:var(--accent);display:flex;align-items:center;gap:10px;
+}
+.eyebrow::after{content:"";flex:1;height:1px;background:linear-gradient(90deg,var(--rule-2),transparent)}
+h1{
+  margin:0;font-size:clamp(30px,4.4vw,46px);line-height:1.06;font-weight:600;
+  letter-spacing:-.025em;text-wrap:balance;
+}
+h1 em{font-style:normal;color:var(--accent)}
+.lede{margin:0;color:var(--ink-2);font-size:16.5px;max-width:60ch}
+
+/* ---------- the display ---------- */
+.display{
+  position:relative;border-radius:20px;overflow:hidden;
+  background:radial-gradient(120% 130% at 50% -10%,var(--desk-glow) 0%,var(--desk-mid) 42%,var(--desk-deep) 100%);
+  border:1px solid var(--rule-2);
+  box-shadow:0 40px 90px -30px rgba(0,0,0,.9), inset 0 1px 0 rgba(255,255,255,.06);
+  min-height:430px;
+  isolation:isolate;
+}
+.wallpaper{position:absolute;inset:0;pointer-events:none;opacity:.55}
+.wallpaper svg{width:100%;height:100%;display:block}
+
+/* menu bar — black, as it is on a notched Mac */
+.menubar{
+  position:relative;z-index:3;height:32px;background:var(--void);
+  display:flex;align-items:center;justify-content:space-between;
+  padding:0 14px;font-family:var(--sf);font-size:12.5px;color:rgba(255,255,255,.82);
+}
+.menubar .apps{display:flex;gap:17px;align-items:center}
+.menubar .apps b{font-weight:600}
+.menubar .status{display:flex;gap:14px;align-items:center;font-variant-numeric:tabular-nums}
+.menubar .status .cb{
+  display:inline-flex;align-items:center;gap:4px;padding:1px 6px;border-radius:5px;
+  background:rgba(192,132,252,.18);color:#DDC8FF;font-size:11px;font-weight:600;
+}
+.dot-mini{width:6px;height:6px;border-radius:50%;background:var(--live)}
+
+/* ---------- notch ---------- */
+.notch-mount{
+  position:absolute;top:0;left:50%;transform:translateX(-50%);z-index:4;
+  display:flex;justify-content:center;
+}
+.notch{
+  --w:200px; --h:32px; --fillet:11px; --accent-c:var(--ink-3);
+  position:relative;width:var(--w);height:var(--h);
+  background:var(--void);
+  border-radius:0 0 var(--radius,14px) var(--radius,14px);
+  transition:width .52s var(--ease),height .52s var(--ease),border-radius .52s var(--ease);
+  display:flex;flex-direction:column;
+  overflow:hidden;
+}
+/* concave fillets, mirroring NotchShape's animatable topCornerRadius */
+.notch::before,.notch::after{
+  content:"";position:absolute;top:0;width:var(--fillet);height:var(--fillet);
+  transition:width .52s var(--ease),height .52s var(--ease);
+  pointer-events:none;
+}
+.notch::before{left:calc(-1 * var(--fillet));background:radial-gradient(circle at 0 100%,transparent 0 var(--fillet),var(--void) var(--fillet))}
+.notch::after{right:calc(-1 * var(--fillet));background:radial-gradient(circle at 100% 100%,transparent 0 var(--fillet),var(--void) var(--fillet))}
+
+/* soft coloured bloom for attention states */
+.notch-glow{
+  position:absolute;top:0;left:50%;transform:translateX(-50%);
+  width:var(--gw,260px);height:var(--gh,60px);z-index:3;pointer-events:none;
+  background:radial-gradient(ellipse at 50% 0%,var(--glow,transparent) 0%,transparent 70%);
+  opacity:0;transition:opacity .4s ease;
+}
+.notch-glow.on{opacity:.85}
+
+/* collapsed lanes: content flanking the pill, Dynamic-Island style */
+.lanes{
+  flex:0 0 auto;height:var(--h);display:flex;align-items:center;justify-content:space-between;
+  padding:0 13px;gap:12px;font-family:var(--sf);
+  opacity:1;transition:opacity .3s ease;
+}
+.notch[data-open="1"] .lanes{height:34px;flex:0 0 34px;padding:0 16px}
+.lane{display:flex;align-items:center;gap:7px;min-width:0}
+.lane-r{justify-content:flex-end}
+.lane .label{font-size:11.5px;font-weight:600;color:rgba(255,255,255,.92);white-space:nowrap}
+.lane .meta{font-size:11px;font-weight:500;color:rgba(255,255,255,.62);white-space:nowrap;font-variant-numeric:tabular-nums}
+.lane .mono{font-family:var(--mono);font-size:10.5px;letter-spacing:-.01em}
+
+.pulse{width:8px;height:8px;border-radius:50%;background:var(--accent-c);position:relative;flex:none}
+.pulse::after{content:"";position:absolute;inset:-4px;border-radius:50%;background:var(--accent-c);opacity:.28;animation:breathe 1.9s var(--ease) infinite}
+@keyframes breathe{0%,100%{transform:scale(.7);opacity:.32}50%{transform:scale(1.15);opacity:.08}}
+
+.orbit{display:flex;gap:3px;flex:none}
+.orbit i{width:5px;height:5px;border-radius:50%;background:var(--agents);animation:bob 1.1s var(--ease) infinite}
+.orbit i:nth-child(2){animation-delay:.15s}
+.orbit i:nth-child(3){animation-delay:.3s}
+@keyframes bob{0%,100%{transform:translateY(1.5px);opacity:.45}50%{transform:translateY(-1.5px);opacity:1}}
+
+.glyph{width:15px;height:15px;flex:none;display:grid;place-items:center;color:var(--accent-c);font-size:12px}
+.chip-live{
+  font-family:var(--sf);font-size:9.5px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;
+  padding:1.5px 5px;border-radius:4px;background:color-mix(in srgb,var(--accent-c) 22%,transparent);
+  color:var(--accent-c);flex:none;
+}
+
+/* mini quota bar inside the collapsed notch */
+.minibar{width:52px;height:4px;border-radius:2px;background:rgba(255,255,255,.16);overflow:hidden;flex:none}
+.minibar i{display:block;height:100%;border-radius:2px;background:var(--accent-c);transition:width .5s var(--ease)}
+
+/* ---------- expanded panel ---------- */
+.panel{
+  flex:1;min-height:0;padding:4px 18px 18px;font-family:var(--sf);
+  opacity:0;transform:translateY(-6px);pointer-events:none;
+  transition:opacity .26s ease .06s,transform .34s var(--ease) .06s;
+  display:flex;flex-direction:column;gap:12px;
+}
+.notch[data-open="1"] .panel{opacity:1;transform:none;pointer-events:auto}
+
+.p-head{display:flex;align-items:center;justify-content:space-between;gap:12px}
+.p-title{display:flex;align-items:center;gap:9px}
+.p-title .name{font-size:13px;font-weight:600;color:#fff}
+.p-title .phase{
+  font-size:9.5px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;
+  padding:2px 6px;border-radius:5px;
+}
+.p-head .elapsed{font-family:var(--mono);font-size:11px;color:rgba(255,255,255,.55);font-variant-numeric:tabular-nums}
+
+.sessions{display:flex;flex-direction:column;gap:1px;background:rgba(255,255,255,.07);border-radius:9px;overflow:hidden}
+.srow{
+  display:grid;grid-template-columns:14px 1fr auto auto;align-items:center;gap:10px;
+  padding:7px 11px;background:#0A0710;
+}
+.srow:hover{background:#120C1C}
+.srow .rdot{width:7px;height:7px;border-radius:50%}
+.srow .repo{font-family:var(--mono);font-size:11px;color:rgba(255,255,255,.9);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.srow .st{font-size:10.5px;color:rgba(255,255,255,.5);white-space:nowrap}
+.srow .tm{font-family:var(--mono);font-size:10.5px;color:rgba(255,255,255,.38);font-variant-numeric:tabular-nums}
+
+.quotas{display:grid;grid-template-columns:repeat(3,1fr);gap:9px}
+.q{background:rgba(255,255,255,.055);border:1px solid rgba(255,255,255,.07);border-radius:9px;padding:8px 10px;display:flex;flex-direction:column;gap:6px}
+.q .qt{display:flex;align-items:baseline;justify-content:space-between;gap:6px}
+.q .qn{font-size:10.5px;font-weight:600;color:rgba(255,255,255,.72)}
+.q .qv{font-family:var(--mono);font-size:12px;font-weight:600;font-variant-numeric:tabular-nums}
+.q .track{height:4px;border-radius:2px;background:rgba(255,255,255,.14);overflow:hidden}
+.q .track i{display:block;height:100%;border-radius:2px}
+.q .qr{font-size:9.5px;color:rgba(255,255,255,.4);font-variant-numeric:tabular-nums}
+
+.p-foot{display:flex;gap:7px;align-items:center}
+.act{
+  font-family:var(--sf);font-size:10.5px;font-weight:600;color:rgba(255,255,255,.78);
+  background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.1);
+  padding:4.5px 10px;border-radius:7px;cursor:default;
+}
+.act.primary{background:rgba(192,132,252,.22);border-color:rgba(192,132,252,.4);color:#E6D2FF}
+.act.danger{background:rgba(248,113,113,.18);border-color:rgba(248,113,113,.35);color:#FFD5D5}
+
+/* prompt block for the attention state */
+.prompt{
+  background:rgba(251,191,36,.1);border:1px solid rgba(251,191,36,.3);border-radius:9px;
+  padding:9px 11px;display:flex;flex-direction:column;gap:5px;
+}
+.prompt .pq{font-size:11.5px;color:#FFE9B8;font-weight:500}
+.prompt .pc{font-family:var(--mono);font-size:11px;color:#FFF3D6;background:rgba(0,0,0,.42);padding:5px 8px;border-radius:6px;overflow-x:auto;white-space:nowrap}
+
+/* faux terminal peeking below, to give the notch context */
+.desk-window{
+  position:absolute;left:50%;transform:translateX(-50%);top:118px;width:min(620px,84%);
+  background:rgba(10,7,16,.82);border:1px solid rgba(255,255,255,.1);border-radius:12px;
+  padding:11px 14px 14px;font-family:var(--mono);font-size:11.5px;line-height:1.75;
+  color:rgba(255,255,255,.45);z-index:1;
+  box-shadow:0 24px 60px -20px rgba(0,0,0,.8);
+}
+.desk-window .tb{display:flex;gap:6px;margin-bottom:9px}
+.desk-window .tb i{width:9px;height:9px;border-radius:50%;background:rgba(255,255,255,.16)}
+.desk-window .p{color:var(--accent);opacity:.75}
+.desk-window .dim{color:rgba(255,255,255,.26)}
+.caret{display:inline-block;width:7px;height:13px;background:rgba(255,255,255,.35);vertical-align:-2px;animation:blink 1.15s steps(1) infinite}
+@keyframes blink{0%,49%{opacity:1}50%,100%{opacity:0}}
+
+/* ---------- scenario rail ---------- */
+.rail-wrap{display:flex;flex-direction:column;gap:14px}
+.rail-label{font-family:var(--cond);font-size:11.5px;font-weight:600;letter-spacing:.15em;text-transform:uppercase;color:var(--ink-3)}
+.rail{display:flex;flex-wrap:wrap;gap:8px;padding:0;margin:0;list-style:none}
+.rail button{
+  font-family:var(--sans);font-size:13px;font-weight:500;color:var(--ink-2);
+  background:var(--chrome-2);border:1px solid var(--rule);border-radius:9px;
+  padding:8px 13px;cursor:pointer;display:flex;align-items:center;gap:8px;
+  transition:border-color .18s ease,color .18s ease,background .18s ease,transform .18s var(--ease);
+}
+.rail button:hover{border-color:var(--rule-2);color:var(--ink);transform:translateY(-1px)}
+.rail button:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+.rail button[aria-pressed="true"]{background:#1D1430;border-color:var(--accent);color:#fff}
+.rail button .sw{width:7px;height:7px;border-radius:50%;background:currentColor;opacity:.8;flex:none}
+
+/* ---------- readout ---------- */
+.readout{
+  display:grid;grid-template-columns:repeat(auto-fit,minmax(210px,1fr));gap:0;
+  background:var(--chrome-2);border:1px solid var(--rule);border-radius:14px;overflow:hidden;
+}
+.cell{padding:18px 20px;border-right:1px solid var(--rule);display:flex;flex-direction:column;gap:7px;min-width:0}
+.cell:last-child{border-right:none}
+.cell h3{
+  margin:0;font-family:var(--cond);font-size:11px;font-weight:600;letter-spacing:.14em;
+  text-transform:uppercase;color:var(--ink-3);
+}
+.cell p{margin:0;font-size:13.5px;color:var(--ink);line-height:1.5}
+.cell code{
+  font-family:var(--mono);font-size:12px;color:var(--accent);
+  background:rgba(192,132,252,.1);padding:1px 5px;border-radius:4px;white-space:nowrap;
+}
+.cell .stack{display:flex;flex-direction:column;gap:5px;align-items:flex-start}
+.cell .new{
+  font-family:var(--cond);font-size:10px;font-weight:600;letter-spacing:.1em;text-transform:uppercase;
+  color:#FFD79A;background:rgba(251,191,36,.14);border:1px solid rgba(251,191,36,.3);
+  padding:2px 7px;border-radius:20px;
+}
+
+.foot{color:var(--ink-3);font-size:13px;max-width:66ch}
+.foot a{color:var(--accent)}
+
+@media (max-width:720px){
+  .stage{padding:36px 16px 60px}
+  .quotas{grid-template-columns:1fr}
+  .desk-window{display:none}
+  .cell{border-right:none;border-bottom:1px solid var(--rule)}
+}
+@media (prefers-reduced-motion:reduce){
+  *,*::before,*::after{animation-duration:.001ms!important;transition-duration:.001ms!important}
+}
+</style>
+
+<div class="stage">
+
+  <header class="masthead">
+    <div class="eyebrow">ClaudeBar · Prototype</div>
+    <h1>The notch, wired to <em>Claude Code</em></h1>
+    <p class="lede">ClaudeBar already knows when a session starts, when subagents fan out, when a turn ends, and how much quota is left. All of it lives behind a 16&nbsp;px menu bar icon. This moves it to the one piece of screen you are already looking at.</p>
+  </header>
+
+  <div class="display">
+    <div class="wallpaper" aria-hidden="true">
+      <svg viewBox="0 0 1000 430" preserveAspectRatio="xMidYMid slice">
+        <defs>
+          <linearGradient id="w1" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0" stop-color="#7C3AED" stop-opacity=".5"/>
+            <stop offset="1" stop-color="#1E1B4B" stop-opacity="0"/>
+          </linearGradient>
+          <linearGradient id="w2" x1="0" y1="1" x2="1" y2="0">
+            <stop offset="0" stop-color="#DB2777" stop-opacity=".32"/>
+            <stop offset="1" stop-color="#4C1D95" stop-opacity="0"/>
+          </linearGradient>
+        </defs>
+        <path d="M0 250 C 220 130 360 330 560 210 S 860 120 1000 200 L1000 430 L0 430Z" fill="url(#w1)"/>
+        <path d="M0 330 C 260 240 420 400 640 300 S 900 250 1000 300 L1000 430 L0 430Z" fill="url(#w2)"/>
+      </svg>
+    </div>
+
+    <div class="desk-window" aria-hidden="true">
+      <div class="tb"><i></i><i></i><i></i></div>
+      <div><span class="p">~/github/tddworks/claudebar</span> <span class="dim">on</span> main</div>
+      <div>$ claude</div>
+      <div class="dim">› refactor the quota alerter to debounce…<span class="caret"></span></div>
+    </div>
+
+    <div class="notch-glow" id="glow"></div>
+
+    <div class="menubar">
+      <div class="apps"><b>Terminal</b><span>Shell</span><span>Edit</span><span>View</span><span>Window</span></div>
+      <div class="status">
+        <span class="cb"><span class="dot-mini" id="mbdot"></span> 68%</span>
+        <span>􀙇</span><span>􀉬</span><span>Wed 14:26</span>
+      </div>
+    </div>
+
+    <div class="notch-mount">
+      <div class="notch" id="notch" data-open="0">
+        <div class="lanes">
+          <div class="lane lane-l" id="laneL"></div>
+          <div class="lane lane-r" id="laneR"></div>
+        </div>
+        <div class="panel" id="panel"></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="rail-wrap">
+    <div class="rail-label">Scenarios — click to play the transition</div>
+    <ul class="rail" id="rail"></ul>
+  </div>
+
+  <section class="readout" id="readout"></section>
+
+  <p class="foot">Everything above except the badged state reads from state ClaudeBar already tracks — <code style="font-family:var(--mono);font-size:12px;color:var(--accent)">SessionMonitor</code> for the hook stream, <code style="font-family:var(--mono);font-size:12px;color:var(--accent)">QuotaMonitor</code> for provider quotas. The notch is a second view onto them, not a second source of truth.</p>
+
+</div>
+
+<script>
+const S = {
+  idle: {
+    chip:"Idle", sw:"#6D6386",
+    w:200, h:32, r:14, fillet:11, accent:"var(--ink-3)", glow:null, open:0,
+    left:"", right:"",
+    read:{
+      state:"Nothing running",
+      trigger:"No active session",
+      source:"<code>SessionMonitor.activeSession == nil</code>",
+      does:"The notch stays the notch. ClaudeBar draws nothing until it has something to say."
+    }
+  },
+
+  working: {
+    chip:"Claude is working", sw:"#34D399",
+    w:352, h:40, r:16, fillet:12, accent:"var(--live)", glow:null, open:0,
+    left:'<span class="pulse"></span><span class="label">claudebar</span>',
+    right:'<span class="meta mono">1:34</span>',
+    read:{
+      state:"Working",
+      trigger:"<code>UserPromptSubmit</code>",
+      source:"<code>ClaudeSession.Phase.active</code>",
+      does:"You alt-tabbed away. The pill tells you it is still going without switching windows."
+    }
+  },
+
+  agents: {
+    chip:"Subagents fanned out", sw:"#60A5FA",
+    w:382, h:40, r:16, fillet:12, accent:"var(--agents)", glow:null, open:0,
+    left:'<span class="orbit"><i></i><i></i><i></i></span><span class="label">claudebar</span>',
+    right:'<span class="meta">3 agents</span><span class="meta mono">2:08</span>',
+    read:{
+      state:"Agents working",
+      trigger:"<code>SubagentStart</code> ×3",
+      source:"<code>activeSubagentCount</code>",
+      does:"Parallel work is visible as parallel work. Three dots, three agents."
+    }
+  },
+
+  attention: {
+    chip:"Waiting on you", sw:"#FBBF24", badge:true,
+    w:430, h:44, r:17, fillet:13, accent:"var(--attention)", glow:"rgba(251,191,36,.35)", open:0,
+    left:'<span class="glyph">􀇾</span><span class="label">Needs you</span>',
+    right:'<span class="meta mono">Bash · rm&nbsp;-rf&nbsp;build/</span>',
+    read:{
+      state:"Blocked on a permission prompt",
+      trigger:"<code>Notification</code> hook",
+      source:"New — one string in <code>HookInstaller.hookEvents</code>",
+      does:"The real dead time is not Claude working, it is Claude waiting. This state does not time out."
+    }
+  },
+
+  done: {
+    chip:"Turn finished", sw:"#34D399",
+    w:346, h:40, r:16, fillet:12, accent:"var(--live)", glow:"rgba(52,211,153,.28)", open:0,
+    left:'<span class="glyph">􀆅</span><span class="label">claudebar</span>',
+    right:'<span class="meta">7 tasks</span><span class="meta mono">4:12</span>',
+    read:{
+      state:"Done",
+      trigger:"<code>Stop</code> / <code>SessionEnd</code>",
+      source:"<code>completedTaskCount</code>",
+      does:"Flashes for four seconds, then retracts on its own. A notification you cannot miss and never have to dismiss."
+    }
+  },
+
+  quota: {
+    chip:"Quota threshold", sw:"#F87171",
+    w:404, h:44, r:17, fillet:13, accent:"var(--critical)", glow:"rgba(248,113,113,.32)", open:0,
+    left:'<span class="chip-live">Claude 5h</span><span class="label">95%</span>',
+    right:'<span class="minibar"><i style="width:95%"></i></span><span class="meta mono">42m</span>',
+    read:{
+      state:"Approaching the cap",
+      trigger:"<code>QuotaAlerter</code> crossing 95%",
+      source:"<code>QuotaMonitor</code>",
+      does:"Today this is a banner that Focus mode eats. Here it is on screen until the window resets."
+    }
+  },
+
+  multi: {
+    chip:"Three repos at once", sw:"#A79BC2",
+    w:400, h:40, r:16, fillet:12, accent:"var(--agents)", glow:null, open:0,
+    left:'<span class="orbit"><i></i><i style="background:#34D399"></i><i style="background:#FBBF24"></i></span><span class="label">3 sessions</span>',
+    right:'<span class="meta">1 needs you</span>',
+    read:{
+      state:"Multiple sessions",
+      trigger:"Concurrent <code>SessionStart</code>",
+      source:"<code>SessionMonitor</code> keyed by cwd",
+      does:"The menu bar can only show one number. The notch shows the worst state across all of them."
+    }
+  },
+
+  expanded: {
+    chip:"Hover to expand", sw:"#C084FC",
+    w:624, h:264, r:22, fillet:16, accent:"var(--accent)", glow:null, open:1,
+    left:'<span class="pulse"></span><span class="label">3 sessions</span>',
+    right:'<span class="meta mono">14:26</span>',
+    panel:`
+      <div class="p-head">
+        <div class="p-title">
+          <span class="name">Claude Code</span>
+          <span class="phase" style="background:rgba(251,191,36,.18);color:#FFD79A">1 needs you</span>
+        </div>
+        <span class="elapsed">Today · 4h 51m · $12.40</span>
+      </div>
+
+      <div class="sessions">
+        <div class="srow">
+          <span class="rdot" style="background:#FBBF24"></span>
+          <span class="repo">~/github/tddworks/claudebar</span>
+          <span class="st">Permission · Bash</span>
+          <span class="tm">2:08</span>
+        </div>
+        <div class="srow">
+          <span class="rdot" style="background:#60A5FA"></span>
+          <span class="repo">~/github/tddworks/asc</span>
+          <span class="st">3 agents working</span>
+          <span class="tm">11:42</span>
+        </div>
+        <div class="srow">
+          <span class="rdot" style="background:#34D399"></span>
+          <span class="repo">~/work/billfold-api</span>
+          <span class="st">Active · 12 tasks</span>
+          <span class="tm">38:05</span>
+        </div>
+      </div>
+
+      <div class="quotas">
+        <div class="q">
+          <div class="qt"><span class="qn">Claude 5h</span><span class="qv" style="color:#F87171">95%</span></div>
+          <div class="track"><i style="width:95%;background:#F87171"></i></div>
+          <div class="qr">resets in 42m</div>
+        </div>
+        <div class="q">
+          <div class="qt"><span class="qn">Claude weekly</span><span class="qv" style="color:#FBBF24">61%</span></div>
+          <div class="track"><i style="width:61%;background:#FBBF24"></i></div>
+          <div class="qr">resets Sun</div>
+        </div>
+        <div class="q">
+          <div class="qt"><span class="qn">Copilot</span><span class="qv" style="color:#34D399">18%</span></div>
+          <div class="track"><i style="width:18%;background:#34D399"></i></div>
+          <div class="qr">resets in 9d</div>
+        </div>
+      </div>
+
+      <div class="p-foot">
+        <span class="act primary">Focus claudebar</span>
+        <span class="act">Open ClaudeBar</span>
+        <span class="act">Snooze alerts</span>
+      </div>`,
+    read:{
+      state:"Expanded",
+      trigger:"Hover, or click the collapsed pill",
+      source:"Same data as the popover",
+      does:"A 200 px target at the top of the screen you can hit without aiming, instead of a 16 px status item."
+    }
+  }
+};
+
+const order = ["idle","working","agents","attention","done","quota","multi","expanded"];
+const notch = document.getElementById("notch");
+const laneL = document.getElementById("laneL");
+const laneR = document.getElementById("laneR");
+const panel = document.getElementById("panel");
+const glow  = document.getElementById("glow");
+const rail  = document.getElementById("rail");
+const readout = document.getElementById("readout");
+const mbdot = document.getElementById("mbdot");
+
+order.forEach(k => {
+  const s = S[k];
+  const li = document.createElement("li");
+  const b = document.createElement("button");
+  b.type = "button";
+  b.setAttribute("aria-pressed", k === "idle" ? "true" : "false");
+  b.dataset.key = k;
+  b.innerHTML = '<span class="sw" style="background:' + s.sw + '"></span>' + s.chip;
+  b.addEventListener("click", () => apply(k));
+  li.appendChild(b);
+  rail.appendChild(li);
+});
+
+function apply(key){
+  const s = S[key];
+
+  notch.style.setProperty("--w", s.w + "px");
+  notch.style.setProperty("--h", s.h + "px");
+  notch.style.setProperty("--radius", s.r + "px");
+  notch.style.setProperty("--fillet", s.fillet + "px");
+  notch.style.setProperty("--accent-c", s.accent);
+  notch.dataset.open = s.open;
+
+  laneL.innerHTML = s.left || "";
+  laneR.innerHTML = s.right || "";
+  panel.innerHTML = s.panel || "";
+
+  if (s.glow){
+    glow.style.setProperty("--glow", s.glow);
+    glow.style.setProperty("--gw", (s.w + 140) + "px");
+    glow.style.setProperty("--gh", (s.h + 46) + "px");
+    glow.classList.add("on");
+  } else {
+    glow.classList.remove("on");
+  }
+
+  mbdot.style.background = key === "idle" ? "#6D6386" : s.accent;
+
+  readout.innerHTML =
+    cell("State", "<p>" + s.read.state + "</p>") +
+    cell("Fires on", "<p>" + s.read.trigger + "</p>") +
+    cell("Source of truth", "<div class=\"stack\"><p>" + s.read.source + "</p>" +
+      (s.badge ? '<span class="new">Needs new plumbing</span>' : "") + "</div>") +
+    cell("Why it earns the space", "<p>" + s.read.does + "</p>");
+
+  document.querySelectorAll("#rail button").forEach(b => {
+    b.setAttribute("aria-pressed", String(b.dataset.key === key));
+  });
+}
+
+function cell(h, body){
+  return '<div class="cell"><h3>' + h + "</h3>" + body + "</div>";
+}
+
+apply("idle");
+</script>

--- a/docs/mockups/notch-live-activity.html
+++ b/docs/mockups/notch-live-activity.html
@@ -153,32 +153,6 @@ h1 em{font-style:normal;color:var(--accent)}
 
 /* ---------- refreshing ---------- */
 
-/* Light off the bottom contour only. The top edge is against the bezel,
-   so nothing there is ever worth lighting. */
-.notch.underglow::after,
-.notch.underglow::before{filter:none}
-.notch.underglow{
-  animation:travellingGlow 1.9s linear infinite;
-}
-/* GlowEffectKit strokes the path with an angular multi-hue gradient and sweeps
-   the origin around it, blurred wide. Several offset shadows stand in for that
-   here: a soft bloom whose bright point travels along the underside. */
-@keyframes travellingGlow{
-  0%{box-shadow:
-      -22px 8px 26px -10px rgba(236,72,153,.85),
-       -4px 10px 30px -8px  rgba(168,85,247,.55),
-       18px 8px 26px -12px  rgba(59,130,246,.35)}
-  50%{box-shadow:
-      -18px 8px 26px -12px rgba(59,130,246,.35),
-        0px 11px 34px -8px rgba(168,85,247,.85),
-       18px 8px 26px -10px rgba(236,72,153,.55)}
-  100%{box-shadow:
-      -18px 8px 26px -12px rgba(45,212,191,.35),
-        4px 10px 30px -8px rgba(59,130,246,.55),
-       22px 8px 26px -10px rgba(168,85,247,.85)}
-}
-
-
 /* the dot-matrix loader standing in for Matrix's DotmSquare3 */
 .dotgrid{display:grid;grid-template-columns:repeat(3,3px);gap:2px;flex:none}
 .dotgrid i{width:3px;height:3px;border-radius:1px;background:var(--accent-c);opacity:.25;animation:dotpulse 1.1s steps(1) infinite}
@@ -474,7 +448,7 @@ const S = {
 
 
   refreshing: {
-    chip:"Refreshing", sw:"#C084FC", fx:"underglow",
+    chip:"Refreshing", sw:"#C084FC",
     w:404, h:44, r:17, fillet:13, accent:"var(--accent)", glow:null, open:0,
     left:'<span class="chip-live">Claude 5h</span><span class="label">84%</span>',
     right:'<span class="dotgrid"><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i></span><span class="meta mono">2:49</span>',
@@ -482,7 +456,7 @@ const S = {
       state:"Refetching the headline quota",
       trigger:"The provider behind the number on screen is syncing",
       source:"<code>provider.isSyncing</code>, not <code>QuotaMonitor.isRefreshing</code>",
-      does:"Light comes off the underside, along the only contour anyone can see. The top edge runs against the bezel, so outlining it reads as a box drawn around the notch rather than the notch itself glowing."
+      does:"The bar is replaced by a dot-matrix loader in place, so the reading is visibly being refetched rather than silently swapped. No glow: an animated outline needs a clock that does not run in a panel which never takes focus."
     }
   },
 
@@ -586,7 +560,6 @@ function apply(key){
   notch.style.setProperty("--accent-c", s.accent);
   notch.dataset.open = s.open;
   notch.classList.remove("underglow");
-  if (s.fx) notch.classList.add(s.fx);
 
   laneL.innerHTML = s.left || "";
   laneR.innerHTML = s.right || "";

--- a/docs/mockups/notch-live-activity.html
+++ b/docs/mockups/notch-live-activity.html
@@ -151,6 +151,48 @@ h1 em{font-style:normal;color:var(--accent)}
 .minibar{width:52px;height:4px;border-radius:2px;background:rgba(255,255,255,.16);overflow:hidden;flex:none}
 .minibar i{display:block;height:100%;border-radius:2px;background:var(--accent-c);transition:width .5s var(--ease)}
 
+/* ---------- refreshing ---------- */
+
+/* Light off the bottom contour only. The top edge is against the bezel,
+   so nothing there is ever worth lighting. */
+.notch.underglow::after,
+.notch.underglow::before{filter:none}
+.notch.underglow{
+  animation:travellingGlow 1.9s linear infinite;
+}
+/* GlowEffectKit strokes the path with an angular multi-hue gradient and sweeps
+   the origin around it, blurred wide. Several offset shadows stand in for that
+   here: a soft bloom whose bright point travels along the underside. */
+@keyframes travellingGlow{
+  0%{box-shadow:
+      -22px 8px 26px -10px rgba(236,72,153,.85),
+       -4px 10px 30px -8px  rgba(168,85,247,.55),
+       18px 8px 26px -12px  rgba(59,130,246,.35)}
+  50%{box-shadow:
+      -18px 8px 26px -12px rgba(59,130,246,.35),
+        0px 11px 34px -8px rgba(168,85,247,.85),
+       18px 8px 26px -10px rgba(236,72,153,.55)}
+  100%{box-shadow:
+      -18px 8px 26px -12px rgba(45,212,191,.35),
+        4px 10px 30px -8px rgba(59,130,246,.55),
+       22px 8px 26px -10px rgba(168,85,247,.85)}
+}
+
+
+/* the dot-matrix loader standing in for Matrix's DotmSquare3 */
+.dotgrid{display:grid;grid-template-columns:repeat(3,3px);gap:2px;flex:none}
+.dotgrid i{width:3px;height:3px;border-radius:1px;background:var(--accent-c);opacity:.25;animation:dotpulse 1.1s steps(1) infinite}
+.dotgrid i:nth-child(1){animation-delay:0s}
+.dotgrid i:nth-child(2){animation-delay:.12s}
+.dotgrid i:nth-child(3){animation-delay:.24s}
+.dotgrid i:nth-child(6){animation-delay:.36s}
+.dotgrid i:nth-child(9){animation-delay:.48s}
+.dotgrid i:nth-child(8){animation-delay:.60s}
+.dotgrid i:nth-child(7){animation-delay:.72s}
+.dotgrid i:nth-child(4){animation-delay:.84s}
+.dotgrid i:nth-child(5){animation-delay:.96s}
+@keyframes dotpulse{0%,30%{opacity:1}31%,100%{opacity:.22}}
+
 /* ---------- expanded panel ---------- */
 .panel{
   flex:1;min-height:0;padding:4px 18px 18px;font-family:var(--sf);
@@ -430,6 +472,20 @@ const S = {
     }
   },
 
+
+  refreshing: {
+    chip:"Refreshing", sw:"#C084FC", fx:"underglow",
+    w:404, h:44, r:17, fillet:13, accent:"var(--accent)", glow:null, open:0,
+    left:'<span class="chip-live">Claude 5h</span><span class="label">84%</span>',
+    right:'<span class="dotgrid"><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i></span><span class="meta mono">2:49</span>',
+    read:{
+      state:"Refetching the headline quota",
+      trigger:"The provider behind the number on screen is syncing",
+      source:"<code>provider.isSyncing</code>, not <code>QuotaMonitor.isRefreshing</code>",
+      does:"Light comes off the underside, along the only contour anyone can see. The top edge runs against the bezel, so outlining it reads as a box drawn around the notch rather than the notch itself glowing."
+    }
+  },
+
   expanded: {
     chip:"Hover to expand", sw:"#C084FC",
     w:624, h:264, r:22, fillet:16, accent:"var(--accent)", glow:null, open:1,
@@ -497,7 +553,7 @@ const S = {
   }
 };
 
-const order = ["idle","working","agents","attention","done","quota","multi","expanded"];
+const order = ["idle","working","agents","attention","done","quota","multi","refreshing","expanded"];
 const notch = document.getElementById("notch");
 const laneL = document.getElementById("laneL");
 const laneR = document.getElementById("laneR");
@@ -529,6 +585,8 @@ function apply(key){
   notch.style.setProperty("--fillet", s.fillet + "px");
   notch.style.setProperty("--accent-c", s.accent);
   notch.dataset.open = s.open;
+  notch.classList.remove("underglow");
+  if (s.fx) notch.classList.add(s.fx);
 
   laneL.innerHTML = s.left || "";
   laneR.innerHTML = s.right || "";


### PR DESCRIPTION
Renders ClaudeBar's existing state into the MacBook notch — a Dynamic Island for Claude Code, built on the hook stream and `QuotaMonitor` that already exist.

**Off by default**, behind a new **General → Notch Live Activity** toggle (`app.notchEnabled`).

- Feature doc: `docs/features/notch-live-activity.md`
- Interactive mockup: `docs/mockups/notch-live-activity.html`

## Why

ClaudeBar already knows everything worth knowing — `SessionMonitor` consumes a live hook stream, `QuotaMonitor` holds every provider's remaining quota. All of it is delivered through a 16px status item that fits one number, and notifications that Focus modes swallow. `Sources/App/LiveActivity/LiveActivityManager.swift` has been a no-op placeholder documenting this exact intent, waiting on ActivityKit support macOS still doesn't have.

The gap is specific and daily: you start Claude in a repo, switch to a browser, and lose all signal about whether it's working, blocked, or finished. The most expensive case is *blocked* — Claude waiting on a permission prompt while you read Slack.

## What it shows

Eight states, seven reading from data that already exists. The notch is collapsed and invisible by default and only claims space when it has something to say.

| State | Fires on | Reads |
|---|---|---|
| Quota glance | resting state | selected provider's most depleted quota |
| Working | `UserPromptSubmit` | `Phase.active` |
| Agents working | `SubagentStart` | `activeSubagentCount` |
| **Needs you** | `Notification` hook *(new)* | permission prompt payload |
| Done | `Stop` / `SessionEnd` | `completedTaskCount`, auto-retracts after 4s |
| Quota threshold | `.critical` / `.depleted` | `QuotaStatus` |
| Multiple sessions | concurrent starts | sessions keyed by `cwd` |
| Expanded | hover | session list, quota cards, actions |

Two rules fall out: **severity wins** (a blocked session outranks any number of working ones), and **attention states don't expire** — `Done` is a four-second flash, but `Needs you` stays until you clear it. That's the property notifications can't give us.

The idle state isn't empty. ClaudeBar is a quota monitor, so the resting state is the gauge — the notch shows how much is left on the provider selected in the popover, and everything else takes the notch over and hands it back.

### The one new hook

`Needs you` is the highest-value state and the only one needing new plumbing. Claude Code fires a `Notification` hook on permission prompts — one string in `HookInstaller.hookEvents`, one case in `SessionEvent.EventName`, one `.awaitingInput` phase.

## Architecture

The notch is a **view**, not a new source of truth.

```
Sources/Domain/Notch/          NotchActivity, NotchActivityResolver, NotchMetrics
Sources/Infrastructure/Notch/  NSScreen+NotchMetrics
Sources/App/Notch/             NotchWindow, NotchWindowController, NotchWindowDriver,
                               NotchShape, NotchRootView, NotchPanelView
```

`NotchActivityResolver` is pure — sessions + quotas + `now` in, one activity out. Every rule about what wins the notch lives there, so the window stays presentation-only and the rules are plain state assertions. `NotchMetrics` holds the geometry rules for the same reason: macOS exposes no notch API, so the width is inferred by subtracting the auxiliary menu bar areas either side of the cutout, and whether a display has one at all from its top safe-area inset. Displays without a notch — roughly half of installs — get a virtual pill sized to the menu bar.

## Prior art

Both open-source implementations were read end to end before designing this (details in the feature doc).

| | boring.notch | DynamicNotch | **this** |
|---|---|---|---|
| Window | `NSPanel` `.mainMenu + 3` | same | same |
| Canvas | fixed, animates content | fixed, animates content | same |
| Takes key focus | no | **yes** | **no** |
| Content model | mode enum | **priority protocol** | adopted |
| Private API | `CGSSpace` + SkyLight + `dlopen` | SkyLight + `CGShieldingWindowLevel` | **none** |
| MAS-shippable | no | no | **yes** |

Geometry and `NotchShape` from boring.notch, the priority content model from DynamicNotch, no private API at all. That costs above-fullscreen and lock-screen presence — the right trade here, since `entitlements.mas.plist` exists, Sparkle makes breakage expensive across every install, and this app's user is in a terminal rather than a fullscreen game.

## Two things worth reviewing closely

**Click-through.** Returning nil from `hitTest` does *not* pass a click through — the window still swallows it. The window ignores the mouse entirely and only accepts it while the pointer is over the notch, tracked by a global `.mouseMoved` monitor that needs no Accessibility permission. That callback runs on every pointer movement anywhere on screen, so it writes nothing unless the answer changed: `@Observable` has no equality check, and assigning the same value would invalidate the notch's view tree continuously.

**Refresh scoping.** `QuotaMonitor.isRefreshing` is `providers.all.contains { $0.isSyncing }` — `all`, including disabled ones — so across nineteen providers it stays true if any one hangs. The notch asks a narrower question: is the selected provider syncing? Its Refresh button likewise refetches that provider alone.

## Consequence to weigh

Scoping to the selected provider means a quota past its threshold on an *unselected* provider no longer takes over the notch. The menu bar and notifications still cover that. Easy to make threshold detection global while the glance stays scoped, if reviewers prefer.

## Also included

- `fix(popover)` (#273) is merged in for testing; it stands alone off `main`.
- One new dependency: `mana-am/matrix-swift` for the subagent and refresh loaders. **Custom licence** — commercial use granted, republishing the components as a library is not. Consumed via SPM, never vendored. Worth a conscious yes for an open-source project.
- GlowEffectKit was tried and removed: its sweep rides `TimelineView(.animation)`, which doesn't advance in a panel that never becomes key.

## Tests

767 domain, 1196 infrastructure, 71 acceptance — all green. The domain layer was built test-first; the window layer is verified by running the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional Notch Live Activity showing Claude sessions, agent activity, permission requests, completed work, and quota status.
  * Hover to expand the notch for session details, quota progress, refresh, and snooze controls.
  * Added a General setting to enable or disable the feature.
  * Permission prompts now appear as “Needs you” activity with their associated message.
* **Bug Fixes**
  * Improved popover sizing and screen selection for more reliable layouts across displays.
* **Documentation**
  * Added feature documentation and an interactive design mockup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->