### PR TITLE
fix(notch): start after launch, and revert the popover height change

### DIFF
--- a/Sources/App/ClaudeBarApp.swift
+++ b/Sources/App/ClaudeBarApp.swift
@@ -163,7 +163,7 @@ struct ClaudeBarApp: App {
             sessionMonitor: sessionMonitor,
             settings: AppSettings.shared
         )
-        notchDriver.start()
+        notchDriver.startWhenLaunched()
 
         // Load user extensions from ~/.claudebar/extensions/
         let extensionRegistry = ExtensionRegistry(

--- a/Sources/App/Notch/NotchWindowDriver.swift
+++ b/Sources/App/Notch/NotchWindowDriver.swift
@@ -19,6 +19,7 @@ final class NotchWindowDriver {
 
     private var contentSync: ObservationRenderSync<NotchContent>?
     private var enabledSync: ObservationRenderSync<Bool>?
+    private var launchObserver: NSObjectProtocol?
 
     /// Re-resolves the content at a moment nothing else will: the end of the
     /// "done" flash, or the end of a snooze.
@@ -39,6 +40,36 @@ final class NotchWindowDriver {
         self.monitor = monitor
         self.sessionMonitor = sessionMonitor
         self.settings = settings
+    }
+
+    /// Defers `start()` until the app has finished launching.
+    ///
+    /// `ClaudeBarApp` builds this driver in `App.init()`, and starting there
+    /// would create an `NSWindow` and its `NSHostingView` before SwiftUI has
+    /// built a single scene. Doing so left `MenuBarExtra`'s popover sized to
+    /// roughly twice its content — 400x671 around 300pt of cards — for the
+    /// life of the process, and switching the notch off afterwards did not
+    /// undo it, because the damage was done at construction.
+    func startWhenLaunched() {
+        if NSApp?.isRunning == true {
+            start()
+            return
+        }
+
+        launchObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didFinishLaunchingNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                if let observer = self.launchObserver {
+                    NotificationCenter.default.removeObserver(observer)
+                    self.launchObserver = nil
+                }
+                self.start()
+            }
+        }
     }
 
     /// Starts watching the setting, bringing the notch up and down with it.

--- a/Sources/App/Views/MenuContentView.swift
+++ b/Sources/App/Views/MenuContentView.swift
@@ -28,10 +28,6 @@ struct MenuContentView: View {
     @State private var pillsContentWidth: CGFloat = 0
     @State private var pillsViewportWidth: CGFloat = 0
 
-    /// Measured height of the scrollable content. Zero until the first layout
-    /// pass reports it — see `PopoverContentHeight.height`.
-    @State private var metricsContentHeight: CGFloat = 0
-
     /// The currently selected provider ID (from monitor, which is @Observable)
     private var selectedProviderId: String {
         get { monitor.selectedProviderId }
@@ -93,11 +89,8 @@ struct MenuContentView: View {
                     }
                     .padding(.horizontal, 16)
                     .padding(.bottom, 16)
-                    .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { height in
-                        metricsContentHeight = height
-                    }
                 }
-                .frame(height: contentHeight)
+                .frame(maxHeight: contentMaxHeight)
                 // Recreate the scroll view when the shown content
                 // changes, so a newly selected provider starts at the
                 // top instead of inheriting the previous scroll offset.
@@ -173,29 +166,13 @@ struct MenuContentView: View {
         }
     }
 
-    /// Height for the scrollable content region — see `PopoverContentHeight`
-    /// for the policy and its tests. A `ScrollView` fills whatever frame it is
-    /// given, so this is a height rather than a maximum: without it, a single
-    /// card stretched the popover to the cap on a tall display.
-    private var contentHeight: CGFloat {
-        PopoverContentHeight.height(
-            contentHeight: metricsContentHeight,
-            visibleScreenHeight: popoverScreenHeight,
+    /// Upper bound for the scrollable content region — see
+    /// `PopoverContentHeight` for the policy and its tests.
+    private var contentMaxHeight: CGFloat {
+        PopoverContentHeight.maxHeight(
+            visibleScreenHeight: NSScreen.main?.visibleFrame.height ?? 800,
             overviewMode: settings.overviewModeEnabled
         )
-    }
-
-    /// Height of the screen the popover is on.
-    ///
-    /// `NSScreen.main` is the screen holding the *key window*, which on a
-    /// multi-display setup is often not the one the menu bar was clicked on.
-    /// The pointer is over the status item at that moment, so the screen under
-    /// it is the better answer.
-    private var popoverScreenHeight: CGFloat {
-        let pointerLocation = NSEvent.mouseLocation
-        let screen = NSScreen.screens.first { $0.frame.contains(pointerLocation) }
-            ?? NSScreen.main
-        return screen?.visibleFrame.height ?? 800
     }
 
     // MARK: - Background Orbs

--- a/Sources/Domain/Provider/PopoverContentHeight.swift
+++ b/Sources/Domain/Provider/PopoverContentHeight.swift
@@ -28,29 +28,4 @@ public enum PopoverContentHeight {
         let available = max(visibleScreenHeight - chrome, usableFloor)
         return overviewMode ? min(overviewCeiling, available) : available
     }
-
-    /// The height the scrollable region should actually take: its content's,
-    /// capped so the action bar cannot be pushed off screen.
-    ///
-    /// A `ScrollView` is greedy — offered a tall frame it fills it — so a cap
-    /// alone is not enough. On a portrait display the cap is over 2000pt, and
-    /// a provider with a single card stretched the popover to match it.
-    ///
-    /// - Parameters:
-    ///   - contentHeight: The measured height of the content. Zero or less
-    ///     means it has not been measured yet, on the first layout pass.
-    ///   - visibleScreenHeight: `NSScreen.visibleFrame.height` of the
-    ///     screen hosting the popover.
-    ///   - overviewMode: whether the popover lists all providers.
-    public static func height(
-        contentHeight: CGFloat,
-        visibleScreenHeight: CGFloat,
-        overviewMode: Bool
-    ) -> CGFloat {
-        let cap = maxHeight(visibleScreenHeight: visibleScreenHeight, overviewMode: overviewMode)
-        // Before the first measurement, prefer the cap: a scrollable popover
-        // is recoverable, one collapsed to nothing is not.
-        guard contentHeight > 0 else { return cap }
-        return min(contentHeight, cap)
-    }
 }

--- a/Tests/DomainTests/Provider/PopoverContentHeightTests.swift
+++ b/Tests/DomainTests/Provider/PopoverContentHeightTests.swift
@@ -48,64 +48,6 @@ struct PopoverContentHeightTests {
         #expect(cap == 735 - PopoverContentHeight.chrome)
     }
 
-    // MARK: - Fitting the Content
-
-    @Test
-    func `content shorter than the cap keeps its own height`() {
-        // A provider with one card must not stretch to fill the cap.
-        let height = PopoverContentHeight.height(
-            contentHeight: 180,
-            visibleScreenHeight: 982,
-            overviewMode: false
-        )
-        #expect(height == 180)
-    }
-
-    @Test
-    func `content taller than the cap is clamped to it`() {
-        let height = PopoverContentHeight.height(
-            contentHeight: 5000,
-            visibleScreenHeight: 982,
-            overviewMode: false
-        )
-        #expect(height == PopoverContentHeight.maxHeight(visibleScreenHeight: 982, overviewMode: false))
-    }
-
-    @Test
-    func `a tall display does not stretch a short popover`() {
-        // A 2560pt portrait display leaves a ~2300pt cap. Before the content
-        // height was taken into account, one small card ballooned to fill it.
-        let height = PopoverContentHeight.height(
-            contentHeight: 220,
-            visibleScreenHeight: 2530,
-            overviewMode: false
-        )
-        #expect(height == 220)
-    }
-
-    @Test(arguments: [0.0, -40.0])
-    func `an unmeasured content height falls back to the cap`(contentHeight: Double) {
-        // First layout pass, before the geometry reader has reported. Falling
-        // back to the cap keeps the popover scrollable rather than collapsing
-        // it to nothing.
-        let height = PopoverContentHeight.height(
-            contentHeight: contentHeight,
-            visibleScreenHeight: 982,
-            overviewMode: false
-        )
-        #expect(height == PopoverContentHeight.maxHeight(visibleScreenHeight: 982, overviewMode: false))
-    }
-
-    @Test
-    func `overview still respects its ceiling when content is taller`() {
-        let height = PopoverContentHeight.height(
-            contentHeight: 5000,
-            visibleScreenHeight: 982,
-            overviewMode: true
-        )
-        #expect(height == 500)
-    }
-
     // MARK: - Degenerate Displays
 
     @Test


### PR DESCRIPTION
Fixes the popover opening at roughly twice its content height. Two commits: the real fix, and a revert of an earlier attempt that was aimed at the wrong cause.

## Root cause

`ClaudeBarApp` builds the notch driver in `App.init()`, and the driver's enabled-sync renders immediately — so with **Notch Live Activity on**, an `NSWindow` and its `NSHostingView` were created **inside `App.init()`**, before SwiftUI had built a single scene. `MenuBarExtra` then sized its popover window to about twice its content for the life of the process.

The symptom pointed straight at it once measured:

| Build | Popover |
|---|---|
| v0.4.85 (no notch) | **400 × 284** — tight to content |
| notch enabled at startup | **400 × 671** — content centred in the slack |
| notch **disabled** at startup | 400 × 284 |
| notch enabled, then switched off at runtime | still 400 × 671 |

Switching the notch off afterwards never helped, because the damage was done once at construction. That asymmetry is what identified it.

The driver now waits for `NSApplication.didFinishLaunchingNotification` before creating anything.

## The revert

The first commit reverts #273, which changed the popover's content region from `.frame(maxHeight:)` to a measured `.frame(height:)`.

That change was made on a false premise. I assumed a `ScrollView` was ballooning to fill a tall-display cap. It was not: `NSScreen.main` is the portrait display on this setup, so the cap was 2270 in every build and never binding. The original `maxHeight` code hugs content correctly, as v0.4.85 demonstrates. #273 replaced a maximum with a fixed height whose unmeasured fallback *is* the cap, which made things worse rather than better.

Its six `PopoverContentHeight.height` tests go with it, since the function does.

## Verification

Measured with `CGWindowListCopyWindowInfo` rather than inferred from screenshots — the numbers in the table above are from the running processes, identified by binary path so the release and dev builds could not be confused.

Full suite green: 762 domain, 1196 infrastructure, 71 acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu popover sizing by allowing content to expand up to the available screen height.
  * Updated screen-height handling to use the visible display area for more consistent sizing across screen configurations.
  * Improved notch window startup timing for more reliable initial display behavior.

* **Tests**
  * Updated coverage for popover maximum-height behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->