### PR TITLE
fix(ui): stop quota card text rendering mirrored after a refresh (#272)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Quota cards no longer draw their text mirrored. After a refresh, the fields whose value had just changed could come back upside down — a different set each time. The rolling digit animation on card headline numbers, which renders them through a separate morphing text layer, is gone; the numbers now update in place. Card rows also get ids that stay unique when a provider reports two cards of the same quota type, so no row can borrow another's drawing. (#272)
+
 ---
 
 ## [0.4.86] - 2026-09-01

--- a/Sources/App/Views/CostStatCard.swift
+++ b/Sources/App/Views/CostStatCard.swift
@@ -87,7 +87,6 @@ struct CostStatCard: View {
                 Text(costUsage.formattedCost)
                     .font(.system(size: 28, weight: .heavy, design: theme.fontDesign))
                     .foregroundStyle(theme.textPrimary)
-                    .contentTransition(.numericText())
 
                 if let budget = effectiveBudget {
                     Text("of \(formatBudget(budget))")

--- a/Sources/App/Views/DailyUsageCardView.swift
+++ b/Sources/App/Views/DailyUsageCardView.swift
@@ -35,7 +35,6 @@ struct DailyUsageCardView: View {
                 Text(primaryValue)
                     .font(.system(size: 24, weight: .bold, design: theme.fontDesign))
                     .foregroundStyle(theme.textPrimary)
-                    .contentTransition(.numericText())
 
                 Spacer()
 

--- a/Sources/App/Views/ExtensionMetricCardView.swift
+++ b/Sources/App/Views/ExtensionMetricCardView.swift
@@ -36,7 +36,6 @@ struct ExtensionMetricCardView: View {
                 Text(metric.value)
                     .font(.system(size: 24, weight: .bold, design: theme.fontDesign))
                     .foregroundStyle(theme.textPrimary)
-                    .contentTransition(.numericText())
                     .lineLimit(1)
                     .minimumScaleFactor(0.6)
 

--- a/Sources/App/Views/MenuContentView.swift
+++ b/Sources/App/Views/MenuContentView.swift
@@ -1059,15 +1059,32 @@ struct TwoColumnCardGrid<Item, ID: Hashable, Cell: View>: View {
         self.cell = cell
     }
 
-    /// Rows are keyed by their leading item so a stable card list keeps
-    /// stable row identity across refreshes (no re-run of card appear
-    /// animations); when the list itself changes, affected rows rebuild.
-    private var rows: [(id: ID, leading: Item, trailing: Item?)] {
+    /// A row's identity: its position plus the ids of the cards it holds.
+    ///
+    /// Keying a row on its leading card's id alone (the original form) is not
+    /// unique: providers can report two cards of the same `QuotaType` — one
+    /// `.session` per account, say — and two rows then claim the same `ForEach`
+    /// id. Duplicate ids leave SwiftUI free to recycle one row's backing layer
+    /// for another's content, which is one way cards end up drawing garbled
+    /// (see #272). The position keeps ids unique whatever the cards contain,
+    /// and the card ids keep a row's identity tied to what it actually shows.
+    private struct RowID: Hashable {
+        let index: Int
+        let leading: ID
+        let trailing: ID?
+    }
+
+    private var rows: [(id: RowID, leading: Item, trailing: Item?)] {
         stride(from: 0, to: items.count, by: 2).map { start in
-            (
-                id: items[start][keyPath: id],
+            let trailing = start + 1 < items.count ? items[start + 1] : nil
+            return (
+                id: RowID(
+                    index: start,
+                    leading: items[start][keyPath: id],
+                    trailing: trailing?[keyPath: id]
+                ),
                 leading: items[start],
-                trailing: start + 1 < items.count ? items[start + 1] : nil
+                trailing: trailing
             )
         }
     }
@@ -1166,7 +1183,14 @@ struct WrappedStatCard: View {
                 }
             }
 
-            // Large value display with label (end-aligned)
+            // Large value display with label (end-aligned).
+            //
+            // The headline number deliberately carries no
+            // `.contentTransition(.numericText())`: that modifier hands the
+            // digits to a separate morphing text layer, and those layers are
+            // what users see come back mirrored after a refresh (#272) — the
+            // flipped fields are the ones whose value just changed. A number
+            // that reads correctly is worth more than a rolling animation.
             HStack(alignment: .firstTextBaseline) {
                 if let dollarUsed = quota.formattedDollarUsed,
                    let dollarCap = quota.formattedDollarCap {
@@ -1174,7 +1198,6 @@ struct WrappedStatCard: View {
                         Text(dollarUsed)
                             .font(.system(size: 20, weight: .heavy, design: theme.fontDesign))
                             .foregroundStyle(theme.textPrimary)
-                            .contentTransition(.numericText())
 
                         Text("of \(dollarCap)")
                             .font(.system(size: 9, weight: .semibold, design: theme.fontDesign))
@@ -1187,13 +1210,11 @@ struct WrappedStatCard: View {
                     Text(dollarText)
                         .font(.system(size: 18, weight: .bold, design: theme.fontDesign))
                         .foregroundStyle(theme.textPrimary)
-                        .contentTransition(.numericText())
                 } else {
                     HStack(alignment: .firstTextBaseline, spacing: 1) {
                         Text("\(Int(quota.displayPercent(mode: effectiveDisplayMode)))")
                             .font(.system(size: 26, weight: .bold, design: theme.fontDesign))
                             .foregroundStyle(effectiveDisplayMode == .pace ? paceColor : theme.textPrimary)
-                            .contentTransition(.numericText())
 
                         Text("%")
                             .font(.system(size: 13, weight: .medium, design: theme.fontDesign))
@@ -1622,7 +1643,6 @@ struct BedrockUsageCard: View {
                     Text(usage.formattedTotalCost)
                         .font(.system(size: 36, weight: .bold, design: theme.fontDesign))
                         .foregroundStyle(theme.textPrimary)
-                        .contentTransition(.numericText())
                 }
 
                 Spacer()


### PR DESCRIPTION
Fixes #272.

## The report

Two users see popover cards draw text **mirrored in place** — not wrong values, upside-down glyphs. In the reporter's screenshot the WEEKLY card's `73`, `Remaining` and `Resets in 1d 18h…` are flipped while its header and badge are upright; on the FABLE card it's the header, badge and number that flip and the reset line that survives. Bars and pace ticks never flip — only text. The second reporter (`@gimpster`) adds the key detail: **which fields flip changes on every refresh**.

## What this changes

**1. Drop `.contentTransition(.numericText())` from the popover cards.**

That modifier hands the digits to a separate morphing text layer, and it runs precisely when a value changes — which matches the cleanest report, where only the number that had just moved was mirrored and everything around it was fine. The headline numbers now update in place. Removed from `WrappedStatCard`, `BedrockUsageCard`, `CostStatCard`, `DailyUsageCardView` and `ExtensionMetricCardView` so the popover is consistent.

**2. Give `TwoColumnCardGrid` rows unique ids.**

Rows were keyed on the leading card's id alone, and card ids are not unique across a grid: a provider reporting one `.session` per account gives two rows the same `ForEach` id. Duplicate ids let SwiftUI recycle one row's backing layer for another row's content — a documented way to get cards drawing each other's garbage. Rows now carry their position alongside both card ids.

## Honesty about confidence

The glitch is intermittent and I could not reproduce it locally, so this removes the two mechanisms that can produce it rather than fixing a reproduced failure. If it survives, the next suspect is the card's hover `.scaleEffect(1.015)`, which also rasterizes the text subtree into a transform layer.

I'd value a check from either reporter before this is trusted as closed — especially the macOS version each is on.

## Verification

- `tuist build ClaudeBar` — succeeds
- `tuist test` — all suites pass (App-layer views have no test target in this project, so nothing here is unit-covered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149vU8Afz5caQqZJHe6QENe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mirrored or incorrect quota card rendering after refreshing usage data.
  * Prevented cards from displaying another card’s drawing when multiple cards share the same quota type.
  * Updated numeric values directly instead of using the rolling digit animation, improving display stability across usage and cost cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->