### PR TITLE
fix(claude): stop costing out a subscription the CLI could not see (#271)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Claude no longer reports a $0.00 cost card instead of quota on a subscription the CLI could not see. A Max plan billed through Apple renders `/usage` as the API-billing cost panel, and ClaudeBar answered it with `/cost` — which succeeds, so the app never tried the usage API that can still read the real quota. `~/.claude.json` knows the account is a subscription (`billingType`), and that now vetoes the `/cost` route: genuine pay-as-you-go accounts still get their cost card, subscriptions fall through to the API probe. (#271)
+- A failed Keychain read no longer passes for "no credentials". On macOS `claude login` writes only the Keychain, so a denied read surfaced as "Authentication required. Please log in." to someone already logged in, with nothing in the log to say why. The `security` exit status and its error are now logged, along with which places were searched. (#271)
+
 ---
 
 ## [0.4.86] - 2026-09-01

--- a/Sources/Domain/Provider/AccountInfo.swift
+++ b/Sources/Domain/Provider/AccountInfo.swift
@@ -20,14 +20,33 @@ public struct AccountInfo: Sendable, Equatable {
     public let organization: String?
     public let loginMethod: String?
 
+    /// How the account pays, verbatim from the provider's own config
+    /// (Claude's `~/.claude.json` reports `apple_subscription`,
+    /// `stripe_subscription`, and so on). Nil when the source does not say.
+    public let billingType: String?
+
     public init(
         email: String? = nil,
         organization: String? = nil,
-        loginMethod: String? = nil
+        loginMethod: String? = nil,
+        billingType: String? = nil
     ) {
         self.email = email
         self.organization = organization
         self.loginMethod = loginMethod
+        self.billingType = billingType
+    }
+
+    /// Whether the account pays through a subscription rather than per-token
+    /// API billing.
+    ///
+    /// Worth knowing because a CLI can misreport it: a Max plan billed through
+    /// Apple renders the API-billing cost panel when the CLI cannot read its
+    /// subscription credentials, and only the config file still knows better
+    /// (#271). The suffix match covers every `*_subscription` form Anthropic
+    /// uses without pinning this to the two seen so far.
+    public var isSubscriptionBilled: Bool {
+        billingType?.hasSuffix("_subscription") == true
     }
 
     /// The best available name for display: email first, then organization.

--- a/Sources/Infrastructure/Claude/ClaudeAPIUsageProbe.swift
+++ b/Sources/Infrastructure/Claude/ClaudeAPIUsageProbe.swift
@@ -193,7 +193,12 @@ public struct ClaudeAPIUsageProbe: UsageProbe, @unchecked Sendable {
         // 仅在从文件加载时更新缓存，避免滑动续期导致 TTL 永不过期
         let fromCache = cache.get()
         guard var credentials = fromCache ?? credentialLoader.loadCredentials() else {
-            AppLog.probes.error("Claude API: No credentials found")
+            // Name both places we looked. On macOS `claude login` writes only
+            // the Keychain, so "no credentials" almost always means the
+            // Keychain read failed — and `loadFromKeychain` logs why (#271).
+            AppLog.probes.error(
+                "Claude API: no credentials in \(credentialLoader.credentialsFilePath) or the 'Claude Code-credentials' Keychain item"
+            )
             throw ProbeError.authenticationRequired
         }
         if fromCache == nil {

--- a/Sources/Infrastructure/Claude/ClaudeAccountInfoResolver.swift
+++ b/Sources/Infrastructure/Claude/ClaudeAccountInfoResolver.swift
@@ -28,12 +28,19 @@ public final class ClaudeAccountInfoResolver: AccountInfoResolving, Sendable {
 
         let email = oauthAccount["emailAddress"] as? String
         let displayName = oauthAccount["displayName"] as? String
+        // `billingType` tells a subscription (`apple_subscription`,
+        // `stripe_subscription`) from a pay-as-you-go API account, which is how
+        // the probe knows an API-billing `/usage` panel is the CLI misreading a
+        // subscription rather than the truth (#271). It stands on its own: an
+        // account with no cached name still has a billing type worth reporting.
+        let billingType = oauthAccount["billingType"] as? String
 
-        guard email != nil || displayName != nil else { return nil }
+        guard email != nil || displayName != nil || billingType != nil else { return nil }
 
         return AccountInfo(
             email: email,
-            organization: displayName
+            organization: displayName,
+            billingType: billingType
         )
     }
 }

--- a/Sources/Infrastructure/Claude/ClaudeCredentialLoader.swift
+++ b/Sources/Infrastructure/Claude/ClaudeCredentialLoader.swift
@@ -275,25 +275,48 @@ public struct ClaudeCredentialLoader: Sendable {
         process.arguments = ["find-generic-password", "-s", keychainService, "-w"]
 
         let pipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = pipe
-        process.standardError = Pipe()
+        process.standardError = errorPipe
 
         do {
             try process.run()
             // Drain before waiting: `waitUntilExit()` first would deadlock if the
             // child ever filled the pipe buffer, since nothing is reading it.
             let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
             process.waitUntilExit()
-            guard process.terminationStatus == 0 else { return nil }
+
+            // On macOS the Keychain is the only place `claude login` leaves
+            // credentials — there is no `~/.claude/.credentials.json` to fall
+            // back to. A silent nil here surfaces as "Authentication required.
+            // Please log in." to someone who is already logged in, with nothing
+            // in the log to say the read was denied rather than empty (#271).
+            guard process.terminationStatus == 0 else {
+                let stderr = String(data: errorData, encoding: .utf8)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                AppLog.credentials.error(
+                    "Keychain read of '\(keychainService)' failed: security exited \(process.terminationStatus)"
+                    + (stderr.isEmpty ? "" : " — \(stderr)")
+                )
+                return nil
+            }
 
             guard let jsonString = String(data: data, encoding: .utf8)?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
-                  !jsonString.isEmpty else { return nil }
+                  !jsonString.isEmpty else {
+                AppLog.credentials.error("Keychain item '\(keychainService)' held an empty password")
+                return nil
+            }
 
             guard let jsonData = Self.decodeKeychainPayload(jsonString),
                   let json = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
                   let oauthDict = json["claudeAiOauth"] as? [String: Any],
                   let rawAccessToken = oauthDict["accessToken"] as? String else {
+                // Shape only — never the payload, which is the token itself.
+                AppLog.credentials.error(
+                    "Keychain item '\(keychainService)' did not hold a readable claudeAiOauth access token"
+                )
                 return nil
             }
 

--- a/Sources/Infrastructure/Claude/ClaudeUsageProbe.swift
+++ b/Sources/Infrastructure/Claude/ClaudeUsageProbe.swift
@@ -20,6 +20,13 @@ public final class ClaudeUsageProbe: UsageProbe, @unchecked Sendable {
     /// `user:inference` scope and cannot access quota data via `/usage`.
     static let envExclusions = ["CLAUDE_CODE_OAUTH_TOKEN"]
 
+    /// Reported when `claude /usage` shows the API-billing cost panel for an
+    /// account the config file says is a subscription. Surfaced only if the
+    /// usage API cannot answer either, so it names both ways out (#271).
+    public static let subscriptionMisreadAsApiBilling =
+        "The Claude CLI did not see this account's subscription — its usage screen showed API billing only. "
+        + "Run `claude login` again, or switch Claude to API mode in Settings."
+
     /// Resolves account info from `~/.claude.json`
     private let accountInfoResolver: any AccountInfoResolving
 
@@ -320,6 +327,19 @@ public final class ClaudeUsageProbe: UsageProbe, @unchecked Sendable {
             // carry it beside real quota bars, which is why this sits behind the
             // "no percentages anywhere" guard.
             if isApiUsageBillingPanel(clean) {
+                // ...but `~/.claude.json` still knows the account pays by
+                // subscription, and a subscription has quota the CLI simply
+                // could not see. Answering with /cost would report $0.00 and no
+                // quota bars — and because that path *succeeds*, it would stop
+                // ClaudeProvider from falling back to the usage API, which can
+                // still read the real numbers. Fail instead so that runs (#271).
+                if let accountInfo, accountInfo.isSubscriptionBilled {
+                    AppLog.probes.error(
+                        "Claude /usage rendered the API billing cost panel for a \(accountInfo.billingType ?? "subscription") account — not falling back to /cost"
+                    )
+                    throw ProbeError.executionFailed(Self.subscriptionMisreadAsApiBilling)
+                }
+
                 AppLog.probes.info("Claude /usage rendered the API billing cost panel, falling back to /cost")
                 throw ProbeError.subscriptionRequired
             }

--- a/Tests/DomainTests/Provider/AccountInfoTests.swift
+++ b/Tests/DomainTests/Provider/AccountInfoTests.swift
@@ -81,4 +81,42 @@ struct AccountInfoTests {
 
         #expect(a == b)
     }
+    // MARK: - Billing Type (#271)
+
+    @Test
+    func `recognizes an Apple-billed subscription`() {
+        let info = AccountInfo(email: "user@example.com", billingType: "apple_subscription")
+
+        #expect(info.isSubscriptionBilled)
+    }
+
+    @Test
+    func `recognizes a Stripe-billed subscription`() {
+        let info = AccountInfo(email: "user@example.com", billingType: "stripe_subscription")
+
+        #expect(info.isSubscriptionBilled)
+    }
+
+    @Test
+    func `does not claim a subscription for a pay-as-you-go account`() {
+        let info = AccountInfo(email: "user@example.com", billingType: "api")
+
+        #expect(!info.isSubscriptionBilled)
+    }
+
+    @Test
+    func `does not claim a subscription when the billing type is unknown`() {
+        let info = AccountInfo(email: "user@example.com")
+
+        #expect(!info.isSubscriptionBilled)
+    }
+
+    @Test
+    func `billing type alone does not make the account displayable`() {
+        // `isEmpty` drives the account chip in the UI: a billing type is not a
+        // name, so an account that carries nothing else still reads as empty.
+        let info = AccountInfo(billingType: "apple_subscription")
+
+        #expect(info.isEmpty)
+    }
 }

--- a/Tests/InfrastructureTests/Claude/ClaudeAccountInfoResolverTests.swift
+++ b/Tests/InfrastructureTests/Claude/ClaudeAccountInfoResolverTests.swift
@@ -105,6 +105,59 @@ struct ClaudeAccountInfoResolverTests {
         #expect(result == nil)
     }
 
+    @Test
+    func `resolves the account's billing type`() {
+        let resolver = makeResolverWithConfig("""
+        {
+            "oauthAccount": {
+                "emailAddress": "user@example.com",
+                "billingType": "apple_subscription"
+            }
+        }
+        """)
+
+        let result = resolver.resolve()
+
+        #expect(result?.billingType == "apple_subscription")
+        #expect(result?.isSubscriptionBilled == true)
+    }
+
+    @Test
+    func `resolves a billing type even when the account has no name`() {
+        // The billing type decides whether a `/usage` cost panel means "this is
+        // an API account" or "the CLI could not see the subscription" (#271),
+        // so it is worth resolving on its own.
+        let resolver = makeResolverWithConfig("""
+        {
+            "oauthAccount": {
+                "accountUuid": "abc-123",
+                "billingType": "stripe_subscription"
+            }
+        }
+        """)
+
+        let result = resolver.resolve()
+
+        #expect(result?.isSubscriptionBilled == true)
+        #expect(result?.isEmpty == true)
+    }
+
+    @Test
+    func `leaves the billing type nil when the account does not carry one`() {
+        let resolver = makeResolverWithConfig("""
+        {
+            "oauthAccount": {
+                "emailAddress": "user@example.com"
+            }
+        }
+        """)
+
+        let result = resolver.resolve()
+
+        #expect(result?.billingType == nil)
+        #expect(result?.isSubscriptionBilled == false)
+    }
+
     // MARK: - Helpers
 
     private func makeResolverWithConfig(_ json: String) -> ClaudeAccountInfoResolver {

--- a/Tests/InfrastructureTests/Claude/ClaudeUsageProbeParsingTests.swift
+++ b/Tests/InfrastructureTests/Claude/ClaudeUsageProbeParsingTests.swift
@@ -1132,6 +1132,33 @@ struct ClaudeUsageProbeParsingTests {
     }
 
     @Test
+    func `API billing cost panel on a subscription account refuses the cost fallback`() {
+        // A Max plan billed through Apple still renders the API-billing cost
+        // panel when the CLI cannot see the subscription (#271). Answering with
+        // `/cost` would report $0.00 and no quota, and — because it succeeds —
+        // would stop ClaudeProvider from trying the usage API, which can still
+        // read the real quota. Fail instead, so that fallback runs.
+        let resolver = MockAccountInfoResolving()
+        given(resolver).resolve().willReturn(
+            AccountInfo(email: "user@example.com", billingType: "apple_subscription")
+        )
+
+        #expect(throws: ProbeError.executionFailed(ClaudeUsageProbe.subscriptionMisreadAsApiBilling)) {
+            try ClaudeUsageProbe.parse(Self.apiBillingCostPanelOutput, accountInfoResolver: resolver)
+        }
+    }
+
+    @Test
+    func `API billing cost panel on a pay-as-you-go account still routes to cost`() {
+        let resolver = MockAccountInfoResolving()
+        given(resolver).resolve().willReturn(AccountInfo(email: "user@example.com", billingType: "api"))
+
+        #expect(throws: ProbeError.subscriptionRequired) {
+            try ClaudeUsageProbe.parse(Self.apiBillingCostPanelOutput, accountInfoResolver: resolver)
+        }
+    }
+
+    @Test
     func `subscription output that mentions API usage billing alongside quotas still parses`() throws {
         // Extra Usage credits put "API Usage Billing" in a subscription header —
         // the quota bars are what decide, not the header.

--- a/Tests/InfrastructureTests/Claude/ClaudeUsageProbeTests.swift
+++ b/Tests/InfrastructureTests/Claude/ClaudeUsageProbeTests.swift
@@ -329,7 +329,12 @@ struct ClaudeUsageProbeTests {
             autoResponses: .any
         ).willReturn(CLIResult(output: costOutput, exitCode: 0))
 
-        let probe = ClaudeUsageProbe(cliExecutor: mockExecutor)
+        // A genuine pay-as-you-go account: nothing in the config claims a
+        // subscription, so the cost panel is the truth and /cost answers it.
+        let resolver = MockAccountInfoResolving()
+        given(resolver).resolve().willReturn(AccountInfo(email: "user@example.com", billingType: "api"))
+
+        let probe = ClaudeUsageProbe(cliExecutor: mockExecutor, accountInfoResolver: resolver)
 
         // When
         let snapshot = try await probe.probe()
@@ -337,6 +342,46 @@ struct ClaudeUsageProbeTests {
         // Then
         #expect(snapshot.costUsage?.totalCost == Decimal(string: "1.25"))
         #expect(snapshot.accountTier == .claudeApi)
+    }
+
+    @Test
+    func `probe fails instead of costing out a subscription the CLI could not see`() async throws {
+        // Given — issue #271: a Max plan billed through Apple renders the same
+        // cost panel, but the config still says it is a subscription. /cost
+        // would answer $0.00 with no quota, and its success would keep
+        // ClaudeProvider from trying the usage API, which can still read the
+        // real numbers. So the probe fails and lets that fallback run.
+        let mockExecutor = MockCLIExecutor()
+
+        let usageOutput = """
+        Opus 5 (1M context) · API Usage Billing
+
+          Session
+            Total cost:            $0.0000
+            Total duration (API):  0s
+            Usage:                 0 input, 0 output, 0 cache read, 0 cache write
+        """
+
+        given(mockExecutor).execute(
+            binary: .any,
+            args: .any,
+            input: .any,
+            timeout: .any,
+            workingDirectory: .any,
+            autoResponses: .any
+        ).willReturn(CLIResult(output: usageOutput, exitCode: 0))
+
+        let resolver = MockAccountInfoResolving()
+        given(resolver).resolve().willReturn(
+            AccountInfo(email: "user@example.com", billingType: "apple_subscription")
+        )
+
+        let probe = ClaudeUsageProbe(cliExecutor: mockExecutor, accountInfoResolver: resolver)
+
+        // When / Then
+        await #expect(throws: ProbeError.executionFailed(ClaudeUsageProbe.subscriptionMisreadAsApiBilling)) {
+            try await probe.probe()
+        }
     }
 
     // MARK: - Account Info from ClaudeAccountInfoResolver


### PR DESCRIPTION
Fixes #271.

## What was still broken after 0.4.86

0.4.86 stopped the `Could not find session usage` error by falling back to `/cost` when `/usage` settles on the API-billing cost panel (`ClaudeUsageProbe.swift:315`). That is the right answer for a pay-as-you-go account and the wrong one for the reporter: their Max plan, billed through Apple, gets a $0.00 cost card instead of quota bars.

Worse, the fallback *hides* the fix that already exists. `ClaudeProvider.refresh()` falls back CLI → API probe whenever the CLI probe **throws**, and the API probe reads real subscription quota from `/api/oauth/usage`. Because the internal `/cost` path **succeeds**, that fallback never runs.

## The signal nobody was reading

`~/.claude.json` → `oauthAccount.billingType` says how the account pays (`apple_subscription`, `stripe_subscription`, …). I confirmed the field on a live config; `ClaudeAccountInfoResolver` was parsing only `emailAddress` and `displayName`. It now resolves `billingType` too — including for an account with no cached name, since the billing type stands on its own.

When the cost panel appears **and** the config says subscription, the probe now fails with an actionable message instead of costing out, so the API fallback runs. Genuine API accounts are unaffected and still get their cost card.

## Second half: the Keychain read

The reporter's other symptom — API mode saying `Authentication required. Please log in.` — is expected to be unreachable, because ClaudeBar has read the Keychain since #255. I verified the storage shape on macOS 26: no `~/.claude/.credentials.json` at all, credentials live in the login keychain as `Claude Code-credentials`.

So why it failed for them was undiagnosable: `loadFromKeychain` returned `nil` on any non-zero `security` exit **without logging the status or stderr**. It now logs both, distinguishes an empty/unreadable payload, and the API probe names the places it searched. No fix for the read itself — there is nothing yet to fix, only something to see.

## Tests

Chicago-school, state-based, written first:

- `AccountInfoTests` — `isSubscriptionBilled` for `apple_subscription` / `stripe_subscription` / `api` / unknown, and that a billing type alone does not make an account displayable.
- `ClaudeAccountInfoResolverTests` — `billingType` resolved, resolved without a name, nil when absent.
- `ClaudeUsageProbeParsingTests` — the cost panel throws `executionFailed` for a subscription and still throws `subscriptionRequired` for an API account.
- `ClaudeUsageProbeTests` — full `probe()` fails for a subscription instead of costing out; the existing `/cost` fallback test now injects a resolver instead of reading the developer's real `~/.claude.json` (it was passing by accident of environment).

`tuist test` passes; `tuist build ClaudeBar` succeeds.

## For the reporter

Worth asking them to check `~/Library/Logs/ClaudeBar/ClaudeBar.log` after this build for the new `Keychain read of 'Claude Code-credentials' failed: security exited N` line — that is the missing evidence for why API mode was unauthenticated on their machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149vU8Afz5caQqZJHe6QENe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Subscription accounts incorrectly displayed API billing cost cards instead of quota information in usage views. They now continue to the appropriate quota lookup.
  - Pay-as-you-go accounts retain the existing cost display behavior.
  - Improved authentication troubleshooting when credentials are stored in macOS Keychain, including clearer logging for failed or unreadable credential access.
  - Accounts with limited profile details can now still be recognized when billing information is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->