### PR TITLE
feat(settings): add multi-account support to JSONSettingsRepository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `JSONSettingsRepository` now conforms to `MultiAccountSettingsRepository`, persisting per-provider accounts under `providers.{id}.accounts` and the active account under `providers.{id}.activeAccountId`. Nothing changes for existing installs: a provider with no `accounts` key reads back an empty list, which is the single-account path, so no migration runs. Removing the active account clears the active pointer rather than leaving it dangling at an account that is gone. (#164)
+
 ---
 
 ## [0.4.88] - 2026-09-02

--- a/Sources/Infrastructure/Storage/JSONSettingsRepository.swift
+++ b/Sources/Infrastructure/Storage/JSONSettingsRepository.swift
@@ -603,3 +603,79 @@ extension JSONSettingsRepository: DeepSeekSettingsRepository {
         getDeepSeekApiKey() != nil
     }
 }
+
+// MARK: - MultiAccountSettingsRepository
+
+extension JSONSettingsRepository: MultiAccountSettingsRepository {
+
+    public func accounts(forProvider id: String) -> [ProviderAccountConfig] {
+        guard let raw: [Any] = store.read(key: Self.accountsKey(id)) else { return [] }
+        return raw.compactMap(Self.decodeAccount)
+    }
+
+    public func addAccount(_ config: ProviderAccountConfig, forProvider id: String) {
+        var configs = accounts(forProvider: id)
+        if let index = configs.firstIndex(where: { $0.accountId == config.accountId }) {
+            configs[index] = config
+        } else {
+            configs.append(config)
+        }
+        writeAccounts(configs, forProvider: id)
+    }
+
+    public func removeAccount(accountId: String, forProvider id: String) {
+        let remaining = accounts(forProvider: id).filter { $0.accountId != accountId }
+        writeAccounts(remaining, forProvider: id)
+
+        // The active pointer must not outlive the account it points at.
+        if activeAccountId(forProvider: id) == accountId {
+            setActiveAccountId(nil, forProvider: id)
+        }
+    }
+
+    public func updateAccount(_ config: ProviderAccountConfig, forProvider id: String) {
+        var configs = accounts(forProvider: id)
+        guard let index = configs.firstIndex(where: { $0.accountId == config.accountId }) else { return }
+        configs[index] = config
+        writeAccounts(configs, forProvider: id)
+    }
+
+    public func activeAccountId(forProvider id: String) -> String? {
+        store.read(key: Self.activeAccountKey(id))
+    }
+
+    public func setActiveAccountId(_ accountId: String?, forProvider id: String) {
+        store.write(value: accountId, key: Self.activeAccountKey(id))
+    }
+
+    // MARK: Storage helpers
+
+    private static func accountsKey(_ id: String) -> String { "providers.\(id).accounts" }
+    private static func activeAccountKey(_ id: String) -> String { "providers.\(id).activeAccountId" }
+
+    private func writeAccounts(_ configs: [ProviderAccountConfig], forProvider id: String) {
+        // Persist an empty list as a removal so the file stays free of empty arrays,
+        // which keeps `accounts(forProvider:)` on its single-account path.
+        let value = configs.isEmpty ? nil : configs.compactMap(Self.encodeAccount)
+        store.write(value: value, key: Self.accountsKey(id))
+    }
+
+    /// `JSONSettingsStore` persists via `JSONSerialization`, so configs travel as
+    /// plain dictionaries rather than as `Codable` values.
+    private static func encodeAccount(_ config: ProviderAccountConfig) -> [String: Any]? {
+        guard let data = try? JSONEncoder().encode(config),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return object
+    }
+
+    private static func decodeAccount(_ raw: Any) -> ProviderAccountConfig? {
+        guard let object = raw as? [String: Any],
+              let data = try? JSONSerialization.data(withJSONObject: object),
+              let config = try? JSONDecoder().decode(ProviderAccountConfig.self, from: data) else {
+            return nil
+        }
+        return config
+    }
+}

--- a/Tests/InfrastructureTests/Settings/JSONSettingsRepositoryMultiAccountTests.swift
+++ b/Tests/InfrastructureTests/Settings/JSONSettingsRepositoryMultiAccountTests.swift
@@ -1,0 +1,334 @@
+import Testing
+import Foundation
+@testable import Infrastructure
+@testable import Domain
+
+/// Tests for multi-account provider settings in JSONSettingsRepository.
+@Suite("JSONSettingsRepository Multi-Account Tests")
+struct JSONSettingsRepositoryMultiAccountTests {
+
+    private func makeRepository() -> (JSONSettingsRepository, URL) {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claudebar-test-\(UUID().uuidString)")
+        let fileURL = tempDir.appendingPathComponent("settings.json")
+        let store = JSONSettingsStore(fileURL: fileURL)
+        let repo = JSONSettingsRepository(store: store)
+        return (repo, tempDir)
+    }
+
+    private func makeStore() -> (JSONSettingsStore, JSONSettingsRepository, URL) {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claudebar-test-\(UUID().uuidString)")
+        let fileURL = tempDir.appendingPathComponent("settings.json")
+        let store = JSONSettingsStore(fileURL: fileURL)
+        return (store, JSONSettingsRepository(store: store), tempDir)
+    }
+
+    private func cleanup(_ dir: URL) {
+        try? FileManager.default.removeItem(at: dir)
+    }
+
+    private func account(
+        _ accountId: String,
+        label: String? = nil,
+        email: String? = nil,
+        organization: String? = nil,
+        probeConfig: [String: String] = [:]
+    ) -> ProviderAccountConfig {
+        ProviderAccountConfig(
+            accountId: accountId,
+            label: label ?? accountId.capitalized,
+            email: email,
+            organization: organization,
+            probeConfig: probeConfig
+        )
+    }
+
+    // MARK: - Backward Compatibility
+
+    @Test
+    func `accounts is empty for a provider that was never configured`() {
+        let (repo, dir) = makeRepository()
+        defer { cleanup(dir) }
+
+        #expect(repo.accounts(forProvider: "claude").isEmpty)
+    }
+
+    @Test
+    func `activeAccountId is nil for a provider that was never configured`() {
+        let (repo, dir) = makeRepository()
+        defer { cleanup(dir) }
+
+        #expect(repo.activeAccountId(forProvider: "claude") == nil)
+    }
+
+    @Test
+    func `existing single-account settings survive account writes`() {
+        let (repo, dir) = makeRepository()
+        defer { cleanup(dir) }
+
+        repo.setEnabled(false, forProvider: "claude")
+        repo.addAccount(account("personal"), forProvider: "claude")
+
+        #expect(repo.isEnabled(forProvider: "claude") == false)
+    }
+
+    // MARK: - Adding
+
+    @Test
+    func `addAccount persists the account`() {
+        let (repo, dir) = makeRepository()
+        defer { cleanup(dir) }
+
+        repo.addAccount(account("personal", label: "Personal"), forProvider: "claude")
+
+        let accounts = repo.accounts(forProvider: "claude")
+        #expect(accounts.count == 1)
+        #expect(accounts.first?.accountId == "personal")
+        #expect(accounts.first?.label == "Personal")
+    }
+
+    @Test
+    func `addAccount preserves insertion order`() {
+        let (repo, dir) = makeRepository()
+        defer { cleanup(dir) }
+
+        repo.addAccount(account("personal"), forProvider: "claude")
+        repo.addAccount(account("work"), forProvider: "claude")
+
+        #expect(repo.accounts(forProvider: "claude").map(\.accountId) == ["personal", "work"])
+    }
+
+    @Test
+    func `addAccount round-trips every field`() {
+        let (repo, dir) = makeRepository()
+        defer { cleanup(dir) }
+
+        let original = account(
+            "work",
+            label: "Work - Acme",
+            email: "dev@acme.example",
+            organization: "Acme",
+            probeConfig: ["profile": "acme", "tokenEnvVar": "ACME_TOKEN"]
+        )
+        repo.addAccount(original, forProvider: "claude")
+
+        #expect(repo.accounts(forProvider: "claude").first == original)
+    }
+
+    @Test
+    func `addAccount with an existing id replaces rather than duplicates`() {
+        let (repo, dir) = makeRepository()
+        defer { cleanup(dir) }
+
+        repo.addAccount(account("personal", label: "Old"), forProvider: "claude")
+        repo.addAccount(account("personal", label: "New"), forProvider: "claude")
+
+        let accounts = repo.accounts(forProvider: "claude")
+        #expect(accounts.count == 1)
+        #expect(accounts.first?.label == "New")
+    }
+
+    @Test
+    func `accounts are namespaced per provider`() {
+        let (repo, dir) = makeRepository()
+        defer { cleanup(dir) }
+
+        repo.addAccount(account("personal"), forProvider: "claude")
+        repo.addAccount(account("work"), forProvider: "codex")
+
+        #expect(repo.accounts(forProvider: "claude").map(\.accountId) == ["personal"])
+        #expect(repo.accounts(forProvider: "codex").map(\.accountId) == ["work"])
+    }
+
+    // MARK: - Updating
+
+    @Test
+    func `updateAccount replaces the matching account in place`() {
+        let (repo, dir) = makeRepository()
+        defer { cleanup(dir) }
+
+        repo.addAccount(account("personal", label: "Personal"), forProvider: "claude")
+        repo.addAccount(account("work", label: "Work"), forProvider: "claude")
+
+        repo.updateAccount(account("personal", label: "Home"), forProvider: "claude")
+
+        let accounts = repo.accounts(forProvider: "claude")
+        #expect(accounts.map(\.accountId) == ["personal", "work"])
+        #expect(accounts.first?.label == "Home")
+    }
+
+    @Test
+    func `updateAccount for an unknown id leaves accounts unchanged`() {
+        let (repo, dir) = makeRepository()
+        defer { cleanup(dir) }
+
+        repo.addAccount(account("personal"), forProvider: "claude")
+        repo.updateAccount(account("ghost", label: "Ghost"), forProvider: "claude")
+
+        #expect(repo.accounts(forProvider: "claude").map(\.accountId) == ["personal"])
+    }
+
+    // MARK: - Removing
+
+    @Test
+    func `removeAccount deletes only the named account`() {
+        let (repo, dir) = makeRepository()
+        defer { cleanup(dir) }
+
+        repo.addAccount(account("personal"), forProvider: "claude")
+        repo.addAccount(account("work"), forProvider: "claude")
+
+        repo.removeAccount(accountId: "personal", forProvider: "claude")
+
+        #expect(repo.accounts(forProvider: "claude").map(\.accountId) == ["work"])
+    }
+
+    @Test
+    func `removeAccount for an unknown id leaves accounts unchanged`() {
+        let (repo, dir) = makeRepository()
+        defer { cleanup(dir) }
+
+        repo.addAccount(account("personal"), forProvider: "claude")
+        repo.removeAccount(accountId: "ghost", forProvider: "claude")
+
+        #expect(repo.accounts(forProvider: "claude").map(\.accountId) == ["personal"])
+    }
+
+    @Test
+    func `removing the last account returns the provider to single-account state`() {
+        let (repo, dir) = makeRepository()
+        defer { cleanup(dir) }
+
+        repo.addAccount(account("personal"), forProvider: "claude")
+        repo.removeAccount(accountId: "personal", forProvider: "claude")
+
+        #expect(repo.accounts(forProvider: "claude").isEmpty)
+    }
+
+    @Test
+    func `removing the active account clears the active pointer`() {
+        let (repo, dir) = makeRepository()
+        defer { cleanup(dir) }
+
+        repo.addAccount(account("personal"), forProvider: "claude")
+        repo.addAccount(account("work"), forProvider: "claude")
+        repo.setActiveAccountId("personal", forProvider: "claude")
+
+        repo.removeAccount(accountId: "personal", forProvider: "claude")
+
+        #expect(repo.activeAccountId(forProvider: "claude") == nil)
+    }
+
+    @Test
+    func `removing a non-active account keeps the active pointer`() {
+        let (repo, dir) = makeRepository()
+        defer { cleanup(dir) }
+
+        repo.addAccount(account("personal"), forProvider: "claude")
+        repo.addAccount(account("work"), forProvider: "claude")
+        repo.setActiveAccountId("work", forProvider: "claude")
+
+        repo.removeAccount(accountId: "personal", forProvider: "claude")
+
+        #expect(repo.activeAccountId(forProvider: "claude") == "work")
+    }
+
+    // MARK: - Active Account
+
+    @Test
+    func `setActiveAccountId persists the value`() {
+        let (repo, dir) = makeRepository()
+        defer { cleanup(dir) }
+
+        repo.setActiveAccountId("work", forProvider: "claude")
+
+        #expect(repo.activeAccountId(forProvider: "claude") == "work")
+    }
+
+    @Test
+    func `setActiveAccountId to nil clears the value`() {
+        let (repo, dir) = makeRepository()
+        defer { cleanup(dir) }
+
+        repo.setActiveAccountId("work", forProvider: "claude")
+        repo.setActiveAccountId(nil, forProvider: "claude")
+
+        #expect(repo.activeAccountId(forProvider: "claude") == nil)
+    }
+
+    @Test
+    func `active account is namespaced per provider`() {
+        let (repo, dir) = makeRepository()
+        defer { cleanup(dir) }
+
+        repo.setActiveAccountId("personal", forProvider: "claude")
+        repo.setActiveAccountId("work", forProvider: "codex")
+
+        #expect(repo.activeAccountId(forProvider: "claude") == "personal")
+        #expect(repo.activeAccountId(forProvider: "codex") == "work")
+    }
+
+    // MARK: - Key Pattern (JSONSettingsStore)
+
+    @Test
+    func `accounts are stored under providers dot id dot accounts`() {
+        let (store, repo, dir) = makeStore()
+        defer { cleanup(dir) }
+
+        repo.addAccount(account("personal", label: "Personal"), forProvider: "claude")
+
+        let raw: [Any]? = store.read(key: "providers.claude.accounts")
+        #expect(raw?.count == 1)
+        #expect((raw?.first as? [String: Any])?["accountId"] as? String == "personal")
+    }
+
+    @Test
+    func `active account is stored under providers dot id dot activeAccountId`() {
+        let (store, repo, dir) = makeStore()
+        defer { cleanup(dir) }
+
+        repo.setActiveAccountId("work", forProvider: "claude")
+
+        #expect(store.read(key: "providers.claude.activeAccountId") == "work")
+    }
+
+    @Test
+    func `an empty accounts array in the file reads as single-account`() {
+        let (store, repo, dir) = makeStore()
+        defer { cleanup(dir) }
+
+        store.write(value: [Any](), key: "providers.claude.accounts")
+
+        #expect(repo.accounts(forProvider: "claude").isEmpty)
+    }
+
+    @Test
+    func `malformed account entries are skipped rather than failing the read`() {
+        let (store, repo, dir) = makeStore()
+        defer { cleanup(dir) }
+
+        store.write(
+            value: [["not": "an account"], ["accountId": "personal", "label": "Personal", "probeConfig": [:]]],
+            key: "providers.claude.accounts"
+        )
+
+        #expect(repo.accounts(forProvider: "claude").map(\.accountId) == ["personal"])
+    }
+
+    // MARK: - Persistence Across Instances
+
+    @Test
+    func `accounts survive a new repository over the same file`() {
+        let (store, repo, dir) = makeStore()
+        defer { cleanup(dir) }
+
+        repo.addAccount(account("personal", label: "Personal"), forProvider: "claude")
+        repo.setActiveAccountId("personal", forProvider: "claude")
+
+        let reopened = JSONSettingsRepository(store: JSONSettingsStore(fileURL: store.fileURL))
+
+        #expect(reopened.accounts(forProvider: "claude").map(\.accountId) == ["personal"])
+        #expect(reopened.activeAccountId(forProvider: "claude") == "personal")
+    }
+}


### PR DESCRIPTION
Closes #164

Phase 3 PR A from #160 — `JSONSettingsRepository` now conforms to `MultiAccountSettingsRepository`. Repository layer and tests only; no UI (#166) and no `QuotaMonitor` (#165) changes.

## What this does

Adds the six protocol methods against `JSONSettingsStore`:

| Key | Holds |
|---|---|
| `providers.{id}.accounts` | array of `ProviderAccountConfig` |
| `providers.{id}.activeAccountId` | string |

`JSONSettingsStore` persists through `JSONSerialization`, so configs are encoded to plain dictionaries via `JSONEncoder` rather than stored as `Codable` values directly. Malformed entries are skipped instead of failing the whole read, so one bad entry cannot make a provider's accounts disappear.

Two behaviours worth calling out, since neither is spelled out in the issue:

- **Writing an empty list removes the key** rather than leaving `[]` behind. That keeps the provider on the single-account path after its last account is removed, instead of leaving it in a distinguishable "explicitly empty" state.
- **Removing the active account clears the active pointer.** Otherwise `activeAccountId` would keep naming an account that no longer exists. Removing a non-active account leaves the pointer alone.

`addAccount` with an id that already exists replaces that entry rather than appending a duplicate, so the array stays keyed by `accountId`.

## Backward compatibility

No migration. A provider with no `accounts` key reads back an empty list, which is the existing single-account behaviour — same for a provider whose accounts were all removed, because of the empty-list-removes-the-key rule above. `activeAccountId` is `nil` until something sets it. Existing per-provider settings are untouched; there's a test asserting `isEnabled` survives an account write.

## Tests

23 tests in `Tests/InfrastructureTests/Settings/JSONSettingsRepositoryMultiAccountTests.swift`, following the existing `JSONSettingsRepositoryProviderTests` shape — a real `JSONSettingsStore` over a temp file, no mocks, asserting state through the public API (Chicago School, as in CLAUDE.md).

Covered: defaults for an unconfigured provider · add/update/remove · insertion order · full field round-trip · replace-on-duplicate-id · per-provider namespacing · unknown-id update and remove are no-ops · active pointer cleared on removing the active account and kept otherwise · the two key paths as written in the file · an explicitly empty array reading as single-account · malformed entries skipped · state surviving a fresh repository over the same file.

`tuist test Infrastructure` passes.

## Note on CHANGELOG

I added an `### Added` entry under `[Unreleased]` since recent merges here update it. Happy to drop it if internal repository-layer changes are not meant to appear there — this one has no user-visible effect until the UI lands in #166.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for managing multiple accounts per provider.
  - Account details and the selected active account are now preserved across app sessions.
  - Added the ability to add, update, remove, and switch between provider accounts.
  - Removing an account automatically clears it as the active selection when applicable.

- **Compatibility**
  - Existing single-account configurations continue to work without migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->