### PR TITLE
fix(antigravity): use consistent menu bar quota labels for Gemini (#278)

### DIFF
--- a/Sources/Infrastructure/Antigravity/AntigravityQuotaSummaryParser.swift
+++ b/Sources/Infrastructure/Antigravity/AntigravityQuotaSummaryParser.swift
@@ -13,11 +13,15 @@ enum AntigravityQuotaSummaryParser {
     private static let claudeGroup = "Claude & others"
 
     /// Known buckets, matched by exact `bucketId` only, in display order.
-    private static let buckets: [(id: String, quotaType: QuotaType, group: String, compactTitle: String)] = [
-        ("gemini-5h", .session, geminiGroup, "5h"),
-        ("gemini-weekly", .weekly, geminiGroup, "7d"),
-        ("3p-5h", .modelSpecific("Claude"), claudeGroup, "5h"),
-        ("3p-weekly", .modelSpecific("Claude Weekly"), claudeGroup, "7d")
+    ///
+    /// `menuBarTitle` is the prefix shown in the dual-window menu bar label
+    /// (e.g. "Gemini 80%" or "Claude Weekly 20%"). It is kept separate from
+    /// `compactTitle`, which is used inside the popover quota card header.
+    private static let buckets: [(id: String, quotaType: QuotaType, group: String, compactTitle: String, menuBarTitle: String)] = [
+        ("gemini-5h",    .session,                   geminiGroup,  "5h", "Gemini"),
+        ("gemini-weekly",.weekly,                    geminiGroup,  "7d", "Gemini Weekly"),
+        ("3p-5h",        .modelSpecific("Claude"),   claudeGroup,  "5h", "Claude"),
+        ("3p-weekly",    .modelSpecific("Claude Weekly"), claudeGroup, "7d", "Claude Weekly")
     ]
 
     /// Returns nil when the payload is not a quota summary at all (caller may fall back to
@@ -47,7 +51,8 @@ enum AntigravityQuotaSummaryParser {
                 providerId: providerId,
                 resetsAt: bucket.resetTime.flatMap(parseDate),
                 group: spec.group,
-                compactTitle: spec.compactTitle
+                compactTitle: spec.compactTitle,
+                menuBarTitle: spec.menuBarTitle
             )
         }
     }

--- a/Tests/InfrastructureTests/Antigravity/AntigravityQuotaSummaryParserTests.swift
+++ b/Tests/InfrastructureTests/Antigravity/AntigravityQuotaSummaryParserTests.swift
@@ -50,6 +50,19 @@ struct AntigravityQuotaSummaryParserTests {
     }
 
     @Test
+    func `assigns consistent menu bar titles so Gemini mirrors Claude format`() throws {
+        let quotas = try #require(AntigravityQuotaSummaryParser.parse(Data(Self.remoteSummary.utf8), providerId: "antigravity"))
+
+        // Gemini pool: should show "Gemini" / "Gemini Weekly" — not the generic "5h" / "7d"
+        #expect(quotas[0].menuBarTitle == "Gemini",        "gemini-5h should use 'Gemini' as menu bar prefix")
+        #expect(quotas[1].menuBarTitle == "Gemini Weekly", "gemini-weekly should use 'Gemini Weekly' as menu bar prefix")
+
+        // Claude pool: already correct, verified here for symmetry
+        #expect(quotas[2].menuBarTitle == "Claude",        "3p-5h should use 'Claude' as menu bar prefix")
+        #expect(quotas[3].menuBarTitle == "Claude Weekly", "3p-weekly should use 'Claude Weekly' as menu bar prefix")
+    }
+
+    @Test
     func `accepts the language server response envelope`() throws {
         let quotas = try #require(AntigravityQuotaSummaryParser.parse(Data(Self.languageServerSummary.utf8), providerId: "antigravity"))
 


### PR DESCRIPTION
Previously the Antigravity Gemini pool buckets (gemini-5h, gemini-weekly) fell back to QuotaType.shortLabel ('5h' / '7d') in the dual-window menu bar prefix, while the Claude pool already rendered as 'Claude' / 'Claude Weekly' via .modelSpecific.

Assign an explicit menuBarTitle to every known bucket so the menu bar now shows:
  Gemini X%  |  Gemini Weekly X%
  Claude X%  |  Claude Weekly X%

The compactTitle ('5h' / '7d') is preserved unchanged and continues to drive the popover quota card header inside its group section. quotaType and persisted quota keys are unaffected, so existing user settings remain valid.

Tests: new test asserts all four menuBarTitle values for symmetry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quota labels in the menu bar for dual-window usage, including clearer Gemini and Claude weekly labels.

* **Tests**
  * Added coverage to verify consistent menu bar titles across Gemini and Claude quota categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->