### PR TITLE
fix(grok): show full remaining when billing omits usage percentages

### DIFF
--- a/Sources/Infrastructure/Grok/GrokUsageProbe.swift
+++ b/Sources/Infrastructure/Grok/GrokUsageProbe.swift
@@ -257,6 +257,22 @@ public struct GrokUsageProbe: UsageProbe, @unchecked Sendable {
             ))
         }
 
+        // Fallback: billing returns 200 with a valid period but no usage
+        // percentages (fresh period with zero usage, or an unmetered plan).
+        // Without this the card renders an empty grid. Treat "no usage
+        // reported" as 100% remaining for the current window.
+        if quotas.isEmpty, periodStart != nil || periodEnd != nil {
+            AppLog.probes.info("Grok: No usage percentages in billing response, showing full remaining for current period")
+            quotas.append(UsageQuota(
+                percentRemaining: 100,
+                quotaType: periodQuotaType,
+                providerId: providerId,
+                resetsAt: periodEnd,
+                resetText: resetText,
+                windowDuration: windowDuration
+            ))
+        }
+
         AppLog.probes.info("Grok: Parsed \(quotas.count) quotas")
 
         return UsageSnapshot(

--- a/Tests/InfrastructureTests/Grok/GrokUsageProbeParsingTests.swift
+++ b/Tests/InfrastructureTests/Grok/GrokUsageProbeParsingTests.swift
@@ -152,6 +152,32 @@ struct GrokUsageProbeParsingTests {
     }
 
     @Test
+    func `shows full remaining when billing has a period but no usage percentages`() throws {
+        let json = """
+        {
+          "config": {
+            "currentPeriod": {
+              "type": "USAGE_PERIOD_TYPE_WEEKLY",
+              "start": "2026-09-03T10:51:20.845630+00:00",
+              "end": "2026-09-10T10:51:20.845630+00:00"
+            },
+            "onDemandCap": {"val": 0},
+            "onDemandUsed": {"val": 0},
+            "isUnifiedBillingUser": true,
+            "prepaidBalance": {"val": 0}
+          }
+        }
+        """
+
+        let snapshot = try GrokUsageProbe.parseResponse(Data(json.utf8), providerId: "grok")
+
+        let weekly = try #require(snapshot.quota(for: .weekly))
+        #expect(weekly.percentRemaining == 100)
+        let expectedEnd = try #require(GrokCredentialLoader.parseDate("2026-09-10T10:51:20.845630+00:00"))
+        #expect(weekly.resetsAt == expectedEnd)
+    }
+
+    @Test
     func `throws parseFailed on invalid JSON`() {
         #expect(throws: ProbeError.parseFailed("Failed to parse billing response as JSON")) {
             try GrokUsageProbe.parseResponse(Data("not json".utf8), providerId: "grok")

--- a/Tests/InfrastructureTests/Grok/GrokUsageProbeParsingTests.swift
+++ b/Tests/InfrastructureTests/Grok/GrokUsageProbeParsingTests.swift
@@ -175,6 +175,7 @@ struct GrokUsageProbeParsingTests {
         #expect(weekly.percentRemaining == 100)
         let expectedEnd = try #require(GrokCredentialLoader.parseDate("2026-09-10T10:51:20.845630+00:00"))
         #expect(weekly.resetsAt == expectedEnd)
+        #expect(weekly.windowDuration == 604_800)
     }
 
     @Test


### PR DESCRIPTION
## Problem

With Grok enabled, the Grok card in the menu bar renders an empty grid (header only, no quota cards), even though credentials exist and the billing endpoint returns HTTP 200.

## Root cause

Verified against the live endpoint for the affected account:

`GET https://cli-chat-proxy.grok.com/v1/billing?format=credits` returns 200 with a valid `currentPeriod` but **no** `creditUsagePercent` and **no** `productUsage`:

```json
{"config":{"currentPeriod":{"type":"USAGE_PERIOD_TYPE_WEEKLY","start":"2026-09-03T10:51:20.845630+00:00","end":"2026-09-10T10:51:20.845630+00:00"},"onDemandCap":{"val":0},"onDemandUsed":{"val":0},"isUnifiedBillingUser":true,"prepaidBalance":{"val":0}}}
```

`GrokUsageProbe.parseResponse` only builds quotas from `creditUsagePercent` / `productUsage` / capped on-demand, so it yields **zero quotas** for this shape and the card shows nothing.

## Fix

When quotas are empty but the response carries a valid billing period, synthesize one quota at 100% remaining for the current window (period type, reset time, and window duration preserved). Truly empty responses (`{}`, no period) still yield zero quotas.

- `Sources/Infrastructure/Grok/GrokUsageProbe.swift`
- Regression test: `shows full remaining when billing has a period but no usage percentages`

## Verification

```
tuist test Infrastructure -- -only-testing:InfrastructureTests/GrokUsageProbeParsingTests -only-testing:InfrastructureTests/GrokUsageProbeTests -only-testing:InfrastructureTests/GrokCredentialLoaderTests
```

All Grok suites pass (parsing incl. the new test, probe behavior, credential loader); pre-existing `handles empty response with no quotas` still passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Usage information now reports 100% remaining when a valid billing period has no recorded usage, such as for fresh or unmetered periods.
  * Quota reset times continue to be displayed based on the billing period’s end date.

* **Tests**
  * Added coverage for weekly billing periods without usage data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->