### PR TITLE
feat(notify): publish the quota tile to a Home Screen widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- The Notify! quota tile can now live on the iPhone Home Screen as well as the Lock Screen. Notify! added Home Screen widgets in its September 2026 update, and a screen widget carries exactly the content a Live Activity does, so the same tile ClaudeBar already builds (up to six quota windows, a progress bar and the reset countdown) can sit there permanently instead of appearing and vanishing with a job. It has its own switch in Settings then Notify!, is on once you link a device, and is placed through iOS's own widget picker after adding it under Settings then Home Screen Widgets in Notify!. If your copy of Notify! is not serving Home Screen widgets yet, ClaudeBar treats that as "not yet" rather than an error and quietly tries again later.
+
 ---
 
 ## [0.4.90] - 2026-09-05

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Some companies support ClaudeBar's open source development through [GitHub Spons
 - **Visual Status Indicators** - Color-coded progress bars (green/yellow/red) show quota health
 - **System Notifications** - Get alerted when quota status changes to warning or critical
 - **Touch Bar Integration** - Persistent MacBook Touch Bar widget with real-time multi-provider gauges, progress bars, and an interactive pixel mascot ([learn more](#claudebar-with-touch-bar))
-- **Notify! Lock Screen Publishing** - Push quota state to your iPhone Lock Screen via [Notify!](https://getnotifyapp.com) as a Live Activity showing up to six quota windows plus a widget gauge for one chosen quota (off by default, see below)
+- **Notify! iPhone Publishing** - Push quota state to your iPhone via [Notify!](https://getnotifyapp.com) on three surfaces: a Lock Screen Live Activity showing up to six quota windows, a Home Screen widget carrying that same content but staying put, and a Lock Screen widget gauge for one chosen quota (off by default, see below)
 - **Auto-Refresh** - Automatically updates quotas at configurable intervals
 - **Keyboard Shortcuts** - Quick access with `⌘D` (Dashboard) and `⌘R` (Refresh)
 
@@ -144,16 +144,18 @@ Kiro monitors AWS Kiro (formerly CodeWhisperer) usage through the `kiro-cli` com
 
 ### Notify! Setup
 
-Publishing quota state to your iPhone Lock Screen is optional and off by default. It is configured in **Settings > Notify!**.
+Publishing quota state to your iPhone is optional and off by default. It is configured in **Settings > Notify!**.
 
 1. Get [Notify!](https://getnotifyapp.com). It runs on Mac, on iOS, and on any device through web push.
-2. **Open it once on the iPhone or iPad you want to publish to.** A Live Activity cannot be started until that device has registered with the push service, and only opening the app does that.
+2. **For the Live Activity, open Notify! once on the iPhone or iPad you are publishing to.** One cannot be started until that device has registered a push-to-start credential, and only opening the app produces one. Skip this step if you only want the widgets, which are polled rather than pushed, and skip it for a Mac or browser ID, which cannot show a Live Activity at all.
 3. In Notify!, copy your device ID and device token.
 4. Put them in the **Device ID** and **Token** fields in ClaudeBar's Notify! settings pane and press **Save Link**. Pasting a whole notification URL into the Device ID field works too, ClaudeBar splits it across both. **Verify Device** confirms the pair against Notify! and names the phone it belongs to. Then turn **Publish to Notify!** on.
 
-The Live Activity needs an iPhone or iPad ID. Notify! also issues IDs for Macs and browsers, and those keep the widget gauge perfectly well, but Notify! cannot start a Live Activity on one, so ClaudeBar disables just that switch and says why. A group ID receives notifications but owns no Lock Screen of its own, so it gets neither.
+The Live Activity needs an iPhone or iPad ID. Notify! also issues IDs for Macs and browsers, and those keep both widgets perfectly well, but Notify! cannot start a Live Activity on one, so ClaudeBar disables just that switch and says why. A group ID receives notifications but owns no Lock Screen or Home Screen of its own, so it gets none of the three.
 
-The Live Activity and the widget gauge can each be turned off separately, and you can choose which quota the gauge shows. Note that this sends provider names, quota window labels and remaining percentages to a third-party service. The device token is stored in the Keychain, not in `~/.claudebar/settings.json`. A build you compile yourself is ad-hoc signed and the Keychain refuses it, so on those the token falls back to ClaudeBar's app credentials and the pane says so.
+All three surfaces can be turned off separately, and you can choose which quota the gauge shows. The Home Screen widget shows the same thing as the Live Activity, and the difference is that it stays: a Live Activity appears while something is happening and then goes away, while the Home Screen widget sits where you put it and always shows the latest state. It needs a recent Notify! app, where you turn it on under **Settings > Home Screen Widgets**, and you place it yourself through iOS's own widget picker. Notify! can also switch the surface off at its own end while it is still rolling out; ClaudeBar treats that as "not yet", pauses just that widget, and carries on publishing the other two.
+
+Note that this sends provider names, quota window labels and remaining percentages to a third-party service. The device token is stored in the Keychain, not in `~/.claudebar/settings.json`. A build you compile yourself is ad-hoc signed and the Keychain refuses it, so on those the token falls back to ClaudeBar's app credentials and the pane says so.
 
 Full details: [docs/features/notify.md](docs/features/notify.md).
 

--- a/Sources/App/Notify/NotifyPublishDriver.swift
+++ b/Sources/App/Notify/NotifyPublishDriver.swift
@@ -51,10 +51,23 @@ final class NotifyPublishDriver {
     /// backoff and every attempt inside the wait lengthens it.
     private var tileSuppressedUntil: Date?
 
+    /// While set, Home Screen tile writes are skipped: the gateway has that
+    /// surface switched off server side. Separate from the tile's wait because
+    /// the two mean opposite things. Backoff is the gateway asking ClaudeBar to
+    /// stop doing something; the kill switch is a feature Notify! has not
+    /// started serving yet, and nothing on this Mac shortens it.
+    private var screenTileSuppressedUntil: Date?
+
     /// How often the payload is re-offered to the gate. A minute is the
     /// tile's own minimum interval, so this is the finest cadence that can
     /// ever change an answer.
     private static let tickInterval: TimeInterval = 60
+
+    /// How long the Home Screen tile goes quiet after the gateway says it is
+    /// not serving that surface. Deliberately hours: the switch is thrown by
+    /// Notify! on Notify!'s own schedule, so asking again on the next tick is a
+    /// poll against a decision that will not have moved, once a minute forever.
+    private static let switchedOffSuppression: TimeInterval = 6 * 60 * 60
 
     init(
         monitor: QuotaMonitor,
@@ -151,12 +164,14 @@ final class NotifyPublishDriver {
         }
 
         // Said before the payload is built, because an empty payload cannot
-        // tell these two apart afterwards: both surfaces switched off and no
+        // tell these two apart afterwards: every surface switched off and no
         // quota reported yet produce exactly the same nothing, and blaming the
         // providers for a switch the user turned off themselves is the more
         // annoying of the two wrong answers.
-        guard settings.notifyLiveActivityEnabled || settings.notifyWidgetEnabled else {
-            return "Both the Live Activity and the Lock Screen widget are switched off, so there is nothing to send."
+        guard settings.notifyLiveActivityEnabled
+            || settings.notifyWidgetEnabled
+            || settings.notifyScreenWidgetEnabled else {
+            return "The Live Activity, the Lock Screen widget and the Home Screen widget are all switched off, so there is nothing to send."
         }
 
         // Let any publish already running finish first, rather than cancelling
@@ -187,9 +202,19 @@ final class NotifyPublishDriver {
         }
 
         let now = Date()
-        let decision = withoutSuppressedTile(gate.decide(payload: payload, since: nil, now: now), at: now)
+        let decision = withoutSuppressedSurfaces(gate.decide(payload: payload, since: nil, now: now), at: now)
         guard !decision.publishesNothing else {
-            return "Notify! is still holding off Live Activity starts. ClaudeBar will retry on its own."
+            // Every surface the payload carried is inside a wait the gateway
+            // asked for, and the two waits are different news. A backoff is
+            // ClaudeBar being told to slow down, which the user can sometimes
+            // clear from their phone; the kill switch is a surface Notify! has
+            // not started serving, where waiting is the only move either of us
+            // has. The backoff is named first because it is the one with a
+            // remedy.
+            if tileSuppressedUntil != nil {
+                return "Notify! is still holding off Live Activity starts. ClaudeBar will retry on its own."
+            }
+            return "Notify! is not serving Home Screen widgets yet. ClaudeBar will try again later."
         }
 
         return await startPublish(payload: payload, decision: decision, at: now).value
@@ -227,6 +252,7 @@ final class NotifyPublishDriver {
         let readings = monitor.notifyReadings()
         let includesTile = settings.notifyLiveActivityEnabled
         let includesGauge = settings.notifyWidgetEnabled
+        let includesScreenTile = settings.notifyScreenWidgetEnabled
         let selection = NotifyGaugeSelection(
             providerId: settings.notifyGaugeProviderId,
             quotaKey: settings.notifyGaugeQuotaKey
@@ -236,7 +262,8 @@ final class NotifyPublishDriver {
             readings: readings,
             gaugeSelection: selection,
             includesTile: includesTile,
-            includesGauge: includesGauge
+            includesGauge: includesGauge,
+            includesScreenTile: includesScreenTile
         )
     }
 
@@ -249,7 +276,7 @@ final class NotifyPublishDriver {
         guard !payload.isEmpty else { return }
 
         let now = Date()
-        let decision = withoutSuppressedTile(gate.decide(payload: payload, since: record, now: now), at: now)
+        let decision = withoutSuppressedSurfaces(gate.decide(payload: payload, since: record, now: now), at: now)
         guard !decision.publishesNothing else { return }
 
         guard publishTask == nil else { return }
@@ -302,27 +329,40 @@ final class NotifyPublishDriver {
         tickTimer = nil
     }
 
-    /// Drops the tile from a decision while the gateway's push to start backoff
-    /// is still running, and forgets the wait once it has passed.
-    private func withoutSuppressedTile(
+    /// Drops the surfaces sitting inside a wait the gateway asked for, and
+    /// forgets each wait once it has passed.
+    ///
+    /// The two waits are held apart on purpose. The tile's is push to start
+    /// backoff, where every attempt inside it lengthens the wait; the Home
+    /// Screen tile's is a server side kill switch, where nothing is wrong and
+    /// there is simply nothing serving that route yet. Neither is evidence about
+    /// the other, so neither may silence the other, and the gauge is a poll the
+    /// gateway rations not at all.
+    private func withoutSuppressedSurfaces(
         _ decision: NotifyPublishDecision,
         at now: Date
     ) -> NotifyPublishDecision {
-        guard let tileSuppressedUntil else { return decision }
-        if now >= tileSuppressedUntil {
+        if let tileSuppressedUntil, now >= tileSuppressedUntil {
             self.tileSuppressedUntil = nil
-            return decision
         }
-        return NotifyPublishDecision(publishesTile: false, publishesGauge: decision.publishesGauge)
+        if let screenTileSuppressedUntil, now >= screenTileSuppressedUntil {
+            self.screenTileSuppressedUntil = nil
+        }
+
+        return NotifyPublishDecision(
+            publishesTile: decision.publishesTile && tileSuppressedUntil == nil,
+            publishesGauge: decision.publishesGauge,
+            publishesScreenTile: decision.publishesScreenTile && screenTileSuppressedUntil == nil
+        )
     }
 
     /// Drops whichever surfaces the linked device could never show.
     ///
-    /// A Notify! id says what it is, and the two surfaces answer to it
+    /// A Notify! id says what it is, and the three surfaces answer to it
     /// separately. A `GRP`, `MC` or `WB` id cannot show a Live Activity, so a
-    /// tile aimed at one is a 400 waiting to happen. Only a group cannot keep a
-    /// widget, being a fan-out target rather than a device. Neither request is
-    /// worth making.
+    /// tile aimed at one is a 400 waiting to happen. Only a group can keep
+    /// neither widget, being a fan-out target rather than a device with a widget
+    /// list of its own. None of those requests is worth making.
     ///
     /// This is the one narrowing the gate cannot do for itself. The gate is
     /// pure and the payload knows nothing about where it is going; the link is
@@ -334,23 +374,26 @@ final class NotifyPublishDriver {
     ) -> NotifyPublishDecision {
         NotifyPublishDecision(
             publishesTile: decision.publishesTile && link.supportsLiveActivity,
-            publishesGauge: decision.publishesGauge && link.supportsWidget
+            publishesGauge: decision.publishesGauge && link.supportsWidget,
+            publishesScreenTile: decision.publishesScreenTile && link.supportsScreenWidget
         )
     }
 
     // MARK: - Publishing
 
-    /// Which surface a write was for. The two are addressed by separate handles
-    /// and fail for separate reasons, so every reaction to a failure has to know
+    /// Which surface a write was for. Each is addressed by its own handle and
+    /// fails for its own reasons, so every reaction to a failure has to know
     /// which one it is reacting to.
     private enum Surface {
         case tile
         case gauge
+        case screenTile
 
         var label: String {
             switch self {
             case .tile: "tile"
             case .gauge: "widget"
+            case .screenTile: "Home Screen widget"
             }
         }
     }
@@ -382,7 +425,7 @@ final class NotifyPublishDriver {
             // failure to show. The place to explain a device's limits is where
             // the user pastes the link, not once a minute forever.
             AppLog.notifications.debug(
-                "Notify! publish skipped: the linked \(link.kind.displayName) shows neither surface"
+                "Notify! publish skipped: the linked \(link.kind.displayName) shows none of these surfaces"
             )
             return nil
         }
@@ -392,6 +435,7 @@ final class NotifyPublishDriver {
         // device that cannot do Live Activities at all.
         var sentTile = false
         var sentGauge = false
+        var sentScreenTile = false
         var failures: [String] = []
 
         if supported.publishesTile, let tile = payload.tile {
@@ -408,8 +452,24 @@ final class NotifyPublishDriver {
                 sentGauge = true
             }
         }
+        // Last, and with the same content the Live Activity just carried. The
+        // Home Screen route takes the tile body unchanged, which is why the
+        // builder hands out one value for both rather than two that agree.
+        if supported.publishesScreenTile, let screenTile = payload.screenTile {
+            if let failure = await sendScreenTile(screenTile, link: link) {
+                failures.append(failure)
+            } else {
+                sentScreenTile = true
+            }
+        }
 
-        remember(payload: payload, sentTile: sentTile, sentGauge: sentGauge, at: now)
+        remember(
+            payload: payload,
+            sentTile: sentTile,
+            sentGauge: sentGauge,
+            sentScreenTile: sentScreenTile,
+            at: now
+        )
         return failures.first
     }
 
@@ -421,7 +481,7 @@ final class NotifyPublishDriver {
                 link: link,
                 activityId: settings.notify.notifyActivityId()
             )
-            settings.notify.setNotifyActivityId(activityId)
+            store(activityId: activityId, for: link)
             return nil
         } catch NotifyPublishError.tileGone {
             // The handle names a tile the user dismissed, which can never be
@@ -439,7 +499,7 @@ final class NotifyPublishDriver {
     private func restartTile(_ tile: NotifyTile, link: NotifyDeviceLink) async -> String? {
         do {
             let activityId = try await publisher.publishTile(tile, link: link, activityId: nil)
-            settings.notify.setNotifyActivityId(activityId)
+            store(activityId: activityId, for: link)
             return nil
         } catch {
             report(error, surface: .tile)
@@ -455,12 +515,63 @@ final class NotifyPublishDriver {
                 link: link,
                 widgetId: settings.notify.notifyWidgetId()
             )
-            settings.notify.setNotifyWidgetId(widgetId)
+            store(widgetId: widgetId, for: link)
             return nil
         } catch {
             report(error, surface: .gauge)
             return message(for: error)
         }
+    }
+
+    /// - Returns: nil when the Home Screen widget was written, or the failure as
+    ///   a message.
+    private func sendScreenTile(_ tile: NotifyTile, link: NotifyDeviceLink) async -> String? {
+        do {
+            let screenWidgetId = try await publisher.publishScreenTile(
+                tile,
+                link: link,
+                screenWidgetId: settings.notify.notifyScreenWidgetId()
+            )
+            store(screenWidgetId: screenWidgetId, for: link)
+            return nil
+        } catch {
+            report(error, surface: .screenTile)
+            return message(for: error)
+        }
+    }
+
+    /// Stores a handle only while it still belongs to the saved link.
+    ///
+    /// A publish holds the link it started with, and a request can be in flight
+    /// for as long as the timeout allows. The user can remove or replace the
+    /// link in that window, and the reply, when it lands, carries a handle for
+    /// a device that is no longer the one on file. Writing it would leave the
+    /// next link inheriting a stranger's tile id, which costs a wasted request
+    /// and a 403 before it heals. Comparing first is cheaper than healing.
+    private func store(activityId: String, for link: NotifyDeviceLink) {
+        guard settings.notify.notifyDeviceLink() == link else {
+            AppLog.notifications.info("Notify! link changed while publishing, discarding the tile handle it returned")
+            return
+        }
+        settings.notify.setNotifyActivityId(activityId)
+    }
+
+    private func store(widgetId: String, for link: NotifyDeviceLink) {
+        guard settings.notify.notifyDeviceLink() == link else {
+            AppLog.notifications.info("Notify! link changed while publishing, discarding the widget handle it returned")
+            return
+        }
+        settings.notify.setNotifyWidgetId(widgetId)
+    }
+
+    private func store(screenWidgetId: String, for link: NotifyDeviceLink) {
+        guard settings.notify.notifyDeviceLink() == link else {
+            AppLog.notifications.info(
+                "Notify! link changed while publishing, discarding the Home Screen widget handle it returned"
+            )
+            return
+        }
+        settings.notify.setNotifyScreenWidgetId(screenWidgetId)
     }
 
     /// Every `NotifyPublishError` already carries a sentence written for a
@@ -471,20 +582,26 @@ final class NotifyPublishDriver {
 
     /// Records what the phone now shows, per surface.
     ///
-    /// The payload is merged rather than stored wholesale: a surface that was
-    /// held back or that failed still shows its previous content, and recording
-    /// the new content for it would tell the gate a change had already been
-    /// sent and lose it until the keep alive came round.
-    private func remember(payload: NotifyPayload, sentTile: Bool, sentGauge: Bool, at now: Date) {
-        guard sentTile || sentGauge else { return }
+    /// What was actually sent, not what was decided: a surface that failed must
+    /// not be filed as delivered. `NotifyPublishRecord.updated` does the per
+    /// surface merge itself, so a surface that was held back or that failed
+    /// keeps the content it is really showing.
+    private func remember(
+        payload: NotifyPayload,
+        sentTile: Bool,
+        sentGauge: Bool,
+        sentScreenTile: Bool,
+        at now: Date
+    ) {
+        guard sentTile || sentGauge || sentScreenTile else { return }
 
-        let standing = NotifyPayload(
-            tile: sentTile ? payload.tile : record?.payload.tile,
-            gauge: sentGauge ? payload.gauge : record?.payload.gauge
+        let sent = NotifyPublishDecision(
+            publishesTile: sentTile,
+            publishesGauge: sentGauge,
+            publishesScreenTile: sentScreenTile
         )
-        let sent = NotifyPublishDecision(publishesTile: sentTile, publishesGauge: sentGauge)
         record = (record ?? NotifyPublishRecord(payload: .empty))
-            .updated(with: standing, decision: sent, at: now)
+            .updated(with: payload, decision: sent, at: now)
     }
 
     /// Turns a failed write into whatever state change it implies, and one log
@@ -500,7 +617,11 @@ final class NotifyPublishDriver {
     /// names something that is gone.
     private func report(_ error: any Error, surface: Surface) {
         guard let error = error as? NotifyPublishError else {
-            AppLog.notifications.error("Notify! \(surface.label) publish failed: \(error.localizedDescription)")
+            // An error from outside this feature's own vocabulary, so its text is
+            // not known to be free of a URL, and every URL here carries the
+            // device token. The type is enough to find the cause and cannot
+            // quote anything.
+            AppLog.notifications.error("Notify! \(surface.label) publish failed: \(type(of: error))")
             return
         }
 
@@ -517,11 +638,13 @@ final class NotifyPublishDriver {
             )
 
         case .backoff(let retryAfter, let openingTheAppMayHelp):
-            // Push to start backoff is a Live Activity rule. A widget write is
-            // a poll the gateway does not ration, so a tile's wait must never
-            // silence one.
+            // Push to start backoff is a Live Activity rule. Both widgets are
+            // polls the gateway does not ration, so a tile's wait must never
+            // silence either of them.
             guard surface == .tile else {
-                AppLog.notifications.warning("Notify! widget publish was rate limited, retrying on a later tick")
+                AppLog.notifications.warning(
+                    "Notify! \(surface.label) publish was rate limited, retrying on a later tick"
+                )
                 return
             }
             tileSuppressedUntil = Date().addingTimeInterval(retryAfter)
@@ -530,6 +653,29 @@ final class NotifyPublishDriver {
                 : ""
             AppLog.notifications.warning(
                 "Notify! is holding off Live Activity starts for \(Int(retryAfter.rounded()))s\(hint)"
+            )
+
+        case .surfaceSwitchedOff:
+            // Not a failure, which is why it is the only branch here that logs
+            // at info. Home Screen widgets ship behind a server side kill
+            // switch, so a ClaudeBar that can write them meets a gateway that is
+            // not serving them yet, and the remedy is entirely Notify!'s.
+            // Backing off for hours rather than retrying every tick, because
+            // nothing this app does moves that switch and asking once a minute
+            // forever would fill the log with a fact that has not changed.
+            guard surface == .screenTile else {
+                // The 503 belongs to the Home Screen route. Reaching here means
+                // the gateway switched off a surface this code did not expect to
+                // be switchable, so that write is skipped and offered again on a
+                // later tick, and the Home Screen tile's own pause is left alone.
+                AppLog.notifications.info(
+                    "Notify! has the \(surface.label) switched off at the moment, retrying on a later tick"
+                )
+                return
+            }
+            screenTileSuppressedUntil = Date().addingTimeInterval(Self.switchedOffSuppression)
+            AppLog.notifications.info(
+                "Notify! is not serving Home Screen widgets yet, pausing that surface for six hours"
             )
 
         case .deliveryUnconfirmed(let activityId):
@@ -543,6 +689,16 @@ final class NotifyPublishDriver {
                 "Notify! could not confirm the tile started, updating it on the next tick"
             )
 
+        case .transportFailed:
+            // The one error whose text is not ClaudeBar's own. It carries a
+            // URLError's localized description, which is free to quote the URL
+            // it failed on, and every URL in this feature has the device token
+            // in its query string. The client already refuses to write that
+            // down; logging it here through the error's description would put it
+            // in the same file by the back door. The pane still shows it, which
+            // is not written down.
+            AppLog.notifications.error("Notify! \(surface.label) publish could not reach the gateway")
+
         default:
             AppLog.notifications.error("Notify! \(surface.label) publish failed: \(error.localizedDescription)")
         }
@@ -554,6 +710,7 @@ final class NotifyPublishDriver {
         switch surface {
         case .tile: settings.notify.setNotifyActivityId(nil)
         case .gauge: settings.notify.setNotifyWidgetId(nil)
+        case .screenTile: settings.notify.setNotifyScreenWidgetId(nil)
         }
     }
 }

--- a/Sources/App/Settings/AppSettings.swift
+++ b/Sources/App/Settings/AppSettings.swift
@@ -151,6 +151,14 @@ public final class AppSettings {
         }
     }
 
+    /// Whether the Home Screen widget is one of the surfaces published. It
+    /// carries the same content as the Live Activity, and unlike it, it stays.
+    public var notifyScreenWidgetEnabled: Bool {
+        didSet {
+            repository.setNotifyScreenWidgetEnabled(notifyScreenWidgetEnabled)
+        }
+    }
+
     /// Provider whose quota the widget gauge shows. Empty means "whichever
     /// quota needs attention most", which is what a glance wants before the
     /// user has picked anything.
@@ -297,6 +305,7 @@ public final class AppSettings {
         self.notifyEnabled = repository.isNotifyEnabled()
         self.notifyLiveActivityEnabled = repository.isNotifyLiveActivityEnabled()
         self.notifyWidgetEnabled = repository.isNotifyWidgetEnabled()
+        self.notifyScreenWidgetEnabled = repository.isNotifyScreenWidgetEnabled()
         self.notifyGaugeProviderId = repository.notifyGaugeProviderId()
         self.notifyGaugeQuotaKey = repository.notifyGaugeQuotaKey()
         self.overviewModeEnabled = repository.overviewModeEnabled()

--- a/Sources/App/Views/SettingsWindow/NotifyPane.swift
+++ b/Sources/App/Views/SettingsWindow/NotifyPane.swift
@@ -11,14 +11,14 @@ import Infrastructure
 /// it yet.
 ///
 /// A saved ID narrows the second card, one control at a time. Notify! hands out
-/// ids for groups, Macs and browsers as well as for phones, and the two surfaces
-/// answer to that separately: a Mac or a browser keeps a widget perfectly well
-/// and cannot show a Live Activity, while a group is a fan-out target with no
-/// Lock Screen of its own and gets neither. So each switch is disabled by its
-/// own rule and carries its own sentence, and a Mac user reads that half the
-/// feature works for them rather than none of it. Saving such an ID is still
-/// allowed. It is a real ID, the user may be about to replace it, and refusing a
-/// save the gateway itself would accept reads as a bug.
+/// ids for groups, Macs and browsers as well as for phones, and the three
+/// surfaces answer to that separately: a Mac or a browser keeps a widget
+/// perfectly well and cannot show a Live Activity, while a group is a fan-out
+/// target with no screen of its own and gets none of them. So each switch is
+/// disabled by its own rule and carries its own sentence, and a Mac user reads
+/// that most of the feature works for them rather than none of it. Saving such
+/// an ID is still allowed. It is a real ID, the user may be about to replace it,
+/// and refusing a save the gateway itself would accept reads as a bug.
 /// Verify Device stays live for every kind, because it checks the credentials
 /// rather than the surfaces and is the one useful thing to press here.
 struct NotifyPane: View {
@@ -56,7 +56,7 @@ struct NotifyPane: View {
     var body: some View {
         SettingsPane(
             title: "Notify!",
-            subtitle: "Push your quota to an iPhone Lock Screen as a Live Activity and a widget, using the Notify! app."
+            subtitle: "Push your quota to an iPhone as a Lock Screen Live Activity, a Lock Screen widget and a Home Screen widget, using the Notify! app."
         ) {
             linkCard
             publishCard
@@ -370,7 +370,7 @@ struct NotifyPane: View {
                 .disabled(!linkSupportsLiveActivity)
                 .opacity(linkSupportsLiveActivity ? 1 : 0.6)
 
-                // Back beside the control now that the two surfaces are gated
+                // Back beside the control now that the surfaces are gated
                 // separately. A Mac closes off this one switch and nothing else,
                 // so there is exactly one sentence on screen rather than four.
                 if let savedLiveActivityReason {
@@ -384,7 +384,7 @@ struct NotifyPane: View {
             VStack(alignment: .leading, spacing: 8) {
                 SettingsRow(
                     title: "Lock Screen widget",
-                    subtitle: "A gauge you can add to the Lock Screen or Home Screen. iOS decides when a widget redraws, roughly every fifteen minutes."
+                    subtitle: "A gauge showing one quota, small enough for the Lock Screen. iOS decides when a widget redraws, roughly every fifteen minutes."
                 ) {
                     SettingsSwitch(isOn: $settings.notifyWidgetEnabled)
                 }
@@ -393,6 +393,24 @@ struct NotifyPane: View {
 
                 if let savedWidgetReason {
                     unsupportedReasonLine(savedWidgetReason)
+                }
+
+            }
+
+            SettingsRowDivider()
+
+            VStack(alignment: .leading, spacing: 8) {
+                SettingsRow(
+                    title: "Home Screen widget",
+                    subtitle: "The same content as the Live Activity, except that it stays put instead of appearing when something happens and vanishing after. Needs a recent Notify! app: turn it on under Settings then Home Screen Widgets in Notify!, then place it with iOS's own widget picker."
+                ) {
+                    SettingsSwitch(isOn: $settings.notifyScreenWidgetEnabled)
+                }
+                .disabled(!linkSupportsScreenWidget)
+                .opacity(linkSupportsScreenWidget ? 1 : 0.6)
+
+                if let savedScreenWidgetReason {
+                    unsupportedReasonLine(savedScreenWidgetReason)
                 }
 
             }
@@ -540,7 +558,7 @@ struct NotifyPane: View {
     /// decides the surfaces anyway.
     ///
     /// With nothing saved the empty id lands on `.unrecognized`, which claims
-    /// both surfaces. That is the right answer for this pane rather than a
+    /// every surface. That is the right answer for this pane rather than a
     /// quirk to guard against: the publish card is already disabled wholesale
     /// on `isLinked`, and dimming its rows a second time would blame the user's
     /// phone for a link they have not pasted yet.
@@ -550,10 +568,11 @@ struct NotifyPane: View {
 
     /// Whether the saved link can hold a tile.
     ///
-    /// The two surfaces are asked about separately even though the same three
-    /// prefixes fail both today, because they fail for different reasons: the
-    /// gateway refuses a Live Activity outright, while a widget is accepted and
-    /// then drawn by nothing. Those are two rules, and they could stop agreeing.
+    /// The surfaces are asked about separately even though the same three
+    /// prefixes fail all of them today, because they fail for different reasons:
+    /// the gateway refuses a Live Activity outright, while a widget is accepted
+    /// and then drawn by nothing. Those are separate rules, and they could stop
+    /// agreeing.
     private var linkSupportsLiveActivity: Bool {
         linkedKind.supportsLiveActivity
     }
@@ -563,9 +582,16 @@ struct NotifyPane: View {
         linkedKind.supportsWidget
     }
 
-    /// Whether a publish has anywhere to land. It writes a tile and a gauge and
-    /// nothing else, so a link that can hold neither leaves the button nothing
-    /// to send.
+    /// Whether a Home Screen tile written to the saved link would ever be drawn.
+    /// The same answer as the Lock Screen widget today, asked separately because
+    /// it is a separate route with its own rules.
+    private var linkSupportsScreenWidget: Bool {
+        linkedKind.supportsScreenWidget
+    }
+
+    /// Whether a publish has anywhere to land. It writes a tile, a gauge and a
+    /// Home Screen tile and nothing else, so a link that can hold none of them
+    /// leaves the button nothing to send.
     private var linkSupportsAnySurface: Bool {
         linkedKind.supportsAnySurface
     }
@@ -583,6 +609,11 @@ struct NotifyPane: View {
     /// Only a group has one of these. Every real device can keep a widget.
     private var savedWidgetReason: String? {
         isLinked ? linkedKind.widgetUnsupportedReason : nil
+    }
+
+    /// The same, for the Home Screen widget, which a group cannot keep either.
+    private var savedScreenWidgetReason: String? {
+        isLinked ? linkedKind.screenWidgetUnsupportedReason : nil
     }
 
     /// The publish card's own short form: what is closed off, not the full
@@ -616,8 +647,11 @@ struct NotifyPane: View {
     private func saveLink() {
         guard let link = pendingLink else { return }
 
-        settings.notify.setNotifyDeviceId(link.deviceId)
-        settings.notify.saveNotifyDeviceToken(link.token)
+        // The repository decides whether the previous device's handles survive
+        // this, because it is the only part of that rule that can be tested: a
+        // link naming the same phone keeps them, a different phone does not.
+        settings.notify.saveNotifyDeviceLink(link)
+
         refreshLinkState()
 
         // Saving a secret can fail, and it fails silently: the credential store
@@ -653,12 +687,13 @@ struct NotifyPane: View {
         settings.notify.setNotifyDeviceId("")
         settings.notify.deleteNotifyDeviceToken()
 
-        // The two handles name a tile and a widget belonging to credentials
-        // that are now gone. Keeping them would risk writing to a stranger's
-        // surface if the gateway ever reuses an id, so a later link starts by
-        // creating its own.
+        // The handles name a tile and two widgets belonging to credentials that
+        // are now gone. Keeping them would risk writing to a stranger's surface
+        // if the gateway ever reuses an id, so a later link starts by creating
+        // its own.
         settings.notify.setNotifyActivityId(nil)
         settings.notify.setNotifyWidgetId(nil)
+        settings.notify.setNotifyScreenWidgetId(nil)
 
         deviceIdField = ""
         tokenField = ""

--- a/Sources/Domain/Notify/NotifyDeviceLink.swift
+++ b/Sources/Domain/Notify/NotifyDeviceLink.swift
@@ -36,6 +36,11 @@ public struct NotifyDeviceLink: Sendable, Equatable, Hashable {
         kind.supportsWidget
     }
 
+    /// Whether a Home Screen widget can be kept on this link.
+    public var supportsScreenWidget: Bool {
+        kind.supportsScreenWidget
+    }
+
     public init?(deviceId: String, token: String) {
         let id = deviceId.trimmingCharacters(in: .whitespacesAndNewlines)
         let secret = token.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -246,9 +251,19 @@ public enum NotifyDeviceKind: Sendable, Equatable, Hashable, CaseIterable {
         }
     }
 
-    /// Whether either Lock Screen surface is available here.
+    /// Whether a Home Screen widget can be kept here.
+    ///
+    /// The same answer as the Lock Screen widget and for the same reason: the
+    /// gateway states that screen widgets carry no device-type gate and that
+    /// legacy, `IO`, `WB` and `MC` ids can all own one. Only a group is
+    /// excluded, having no widget list of its own to write to.
+    public var supportsScreenWidget: Bool {
+        supportsWidget
+    }
+
+    /// Whether any surface at all is available here.
     public var supportsAnySurface: Bool {
-        supportsLiveActivity || supportsWidget
+        supportsLiveActivity || supportsWidget || supportsScreenWidget
     }
 
     /// What to call this in the settings pane.
@@ -276,6 +291,11 @@ public enum NotifyDeviceKind: Sendable, Equatable, Hashable, CaseIterable {
         case .group:
             Self.groupReason
         }
+    }
+
+    /// The Home Screen widget shares the Lock Screen widget's answer.
+    public var screenWidgetUnsupportedReason: String? {
+        widgetUnsupportedReason
     }
 
     /// The same for the widget, which only a group cannot keep.

--- a/Sources/Domain/Notify/NotifyPayload.swift
+++ b/Sources/Domain/Notify/NotifyPayload.swift
@@ -49,14 +49,28 @@ public struct NotifyPayload: Sendable, Equatable {
     public let tile: NotifyTile?
     public let gauge: NotifyGauge?
 
-    public init(tile: NotifyTile? = nil, gauge: NotifyGauge? = nil) {
+    /// The Home Screen tile. Deliberately the same `NotifyTile` the Live
+    /// Activity carries, because the gateway derives both content sets from one
+    /// module: any body that starts a Live Activity is a valid screen widget
+    /// body. It is a separate property rather than a reuse of `tile` because the
+    /// two surfaces are switched on and off independently and published on
+    /// different clocks, so a payload has to be able to carry one without the
+    /// other.
+    public let screenTile: NotifyTile?
+
+    public init(
+        tile: NotifyTile? = nil,
+        gauge: NotifyGauge? = nil,
+        screenTile: NotifyTile? = nil
+    ) {
         self.tile = tile
         self.gauge = gauge
+        self.screenTile = screenTile
     }
 
     /// Nothing to say, so nothing to send.
     public var isEmpty: Bool {
-        tile == nil && gauge == nil
+        tile == nil && gauge == nil && screenTile == nil
     }
 
     public static let empty = NotifyPayload()

--- a/Sources/Domain/Notify/NotifyPayloadBuilder.swift
+++ b/Sources/Domain/Notify/NotifyPayloadBuilder.swift
@@ -36,14 +36,24 @@ public struct NotifyPayloadBuilder: Sendable {
         readings: [NotifyQuotaReading],
         gaugeSelection: NotifyGaugeSelection = .automatic,
         includesTile: Bool = true,
-        includesGauge: Bool = true
+        includesGauge: Bool = true,
+        includesScreenTile: Bool = true
     ) -> NotifyPayload {
         let ordered = Self.ordered(readings)
         guard let headline = ordered.first else { return .empty }
 
+        // The Live Activity and the Home Screen tile are built once and shared.
+        // The gateway takes the same body on both routes, so building them twice
+        // could only produce two things that were supposed to be identical and
+        // one day were not.
+        let tile = (includesTile || includesScreenTile)
+            ? self.tile(ordered: ordered, headline: headline)
+            : nil
+
         return NotifyPayload(
-            tile: includesTile ? tile(ordered: ordered, headline: headline) : nil,
-            gauge: includesGauge ? gauge(ordered: ordered, headline: headline, selection: gaugeSelection) : nil
+            tile: includesTile ? tile : nil,
+            gauge: includesGauge ? gauge(ordered: ordered, headline: headline, selection: gaugeSelection) : nil,
+            screenTile: includesScreenTile ? tile : nil
         )
     }
 
@@ -60,7 +70,16 @@ public struct NotifyPayloadBuilder: Sendable {
                 return left.quota.percentRemaining < right.quota.percentRemaining
             }
             if left.providerName != right.providerName { return left.providerName < right.providerName }
-            return left.quota.quotaType.quotaKey < right.quota.quotaType.quotaKey
+            if left.quota.quotaType.quotaKey != right.quota.quotaType.quotaKey {
+                return left.quota.quotaType.quotaKey < right.quota.quotaType.quotaKey
+            }
+            // The last tie break, and the one that makes the comparator total.
+            // Display names are not unique: an aggregating provider can report
+            // two accounts under one name, and Swift's sort is not stable, so
+            // without this two readings that tie on everything else could come
+            // back in either order. The payload would then differ between builds
+            // of the same state and the driver would republish for nothing.
+            return left.providerId < right.providerId
         }
     }
 

--- a/Sources/Domain/Notify/NotifyPublishError.swift
+++ b/Sources/Domain/Notify/NotifyPublishError.swift
@@ -42,6 +42,13 @@ public enum NotifyPublishError: Error, Sendable, Equatable, LocalizedError {
     /// The request never completed.
     case transportFailed(String)
 
+    /// The gateway has this surface switched off server side. Home Screen
+    /// widgets ship behind a kill switch, so a build that supports them can meet
+    /// a service that is not serving them yet. Reads and deletes stay open, only
+    /// creates and updates are refused, and the remedy is to wait rather than to
+    /// change anything.
+    case surfaceSwitchedOff(String)
+
     case unexpectedStatus(Int)
 
     case malformedResponse
@@ -68,6 +75,10 @@ public enum NotifyPublishError: Error, Sendable, Equatable, LocalizedError {
             "Notify! could not confirm the Live Activity started. ClaudeBar will check again on the next update."
         case .transportFailed(let message):
             "Could not reach Notify!: \(message)"
+        case .surfaceSwitchedOff(let message):
+            message.isEmpty
+                ? "Notify! has this widget switched off at the moment. ClaudeBar will try again later."
+                : message
         case .unexpectedStatus(let code):
             "Notify! answered with HTTP \(code)."
         case .malformedResponse:
@@ -87,7 +98,7 @@ public enum NotifyPublishError: Error, Sendable, Equatable, LocalizedError {
     /// decide between backing off and giving up until something changes.
     public var isRetryable: Bool {
         switch self {
-        case .transportFailed, .backoff, .deliveryUnconfirmed, .unexpectedStatus:
+        case .transportFailed, .backoff, .deliveryUnconfirmed, .unexpectedStatus, .surfaceSwitchedOff:
             true
         case .notLinked, .rejectedCredentials, .liveActivityUnavailable, .tileGone,
              .invalidPayload, .malformedResponse:

--- a/Sources/Domain/Notify/NotifyPublishGate.swift
+++ b/Sources/Domain/Notify/NotifyPublishGate.swift
@@ -5,20 +5,40 @@ public struct NotifyPublishRecord: Sendable, Equatable {
     public let payload: NotifyPayload
     public let tileAt: Date?
     public let gaugeAt: Date?
+    public let screenTileAt: Date?
 
-    public init(payload: NotifyPayload, tileAt: Date? = nil, gaugeAt: Date? = nil) {
+    public init(
+        payload: NotifyPayload,
+        tileAt: Date? = nil,
+        gaugeAt: Date? = nil,
+        screenTileAt: Date? = nil
+    ) {
         self.payload = payload
         self.tileAt = tileAt
         self.gaugeAt = gaugeAt
+        self.screenTileAt = screenTileAt
     }
 
-    /// The record after a publish, carrying forward the timestamp of whichever
-    /// surface was not written this time.
+    /// The record after a publish, carrying forward both the timestamp and the
+    /// content of whichever surface was not written this time.
+    ///
+    /// Merging per surface rather than storing the payload wholesale is what
+    /// keeps a held back change from being lost. A tile-only publish that
+    /// recorded the whole payload would file the new gauge as already sent, and
+    /// the gate would then see no change when the gauge's own interval finally
+    /// came round, leaving a stale value on the phone until something else
+    /// happened to move it. The record has to remember what each surface is
+    /// actually showing, which is not the same as the last payload built.
     public func updated(with payload: NotifyPayload, decision: NotifyPublishDecision, at now: Date) -> NotifyPublishRecord {
         NotifyPublishRecord(
-            payload: payload,
+            payload: NotifyPayload(
+                tile: decision.publishesTile ? payload.tile : self.payload.tile,
+                gauge: decision.publishesGauge ? payload.gauge : self.payload.gauge,
+                screenTile: decision.publishesScreenTile ? payload.screenTile : self.payload.screenTile
+            ),
             tileAt: decision.publishesTile ? now : tileAt,
-            gaugeAt: decision.publishesGauge ? now : gaugeAt
+            gaugeAt: decision.publishesGauge ? now : gaugeAt,
+            screenTileAt: decision.publishesScreenTile ? now : screenTileAt
         )
     }
 }
@@ -27,17 +47,27 @@ public struct NotifyPublishRecord: Sendable, Equatable {
 public struct NotifyPublishDecision: Sendable, Equatable {
     public let publishesTile: Bool
     public let publishesGauge: Bool
+    public let publishesScreenTile: Bool
 
-    public init(publishesTile: Bool, publishesGauge: Bool) {
+    public init(
+        publishesTile: Bool,
+        publishesGauge: Bool,
+        publishesScreenTile: Bool = false
+    ) {
         self.publishesTile = publishesTile
         self.publishesGauge = publishesGauge
+        self.publishesScreenTile = publishesScreenTile
     }
 
     public var publishesNothing: Bool {
-        !publishesTile && !publishesGauge
+        !publishesTile && !publishesGauge && !publishesScreenTile
     }
 
-    public static let nothing = NotifyPublishDecision(publishesTile: false, publishesGauge: false)
+    public static let nothing = NotifyPublishDecision(
+        publishesTile: false,
+        publishesGauge: false,
+        publishesScreenTile: false
+    )
 }
 
 /// Decides when a payload is worth a request.
@@ -64,20 +94,29 @@ public struct NotifyPublishGate: Sendable {
     /// hour, so there is nothing to gain from writing it more often.
     public static let defaultGaugeInterval: TimeInterval = 15 * 60
 
-    /// Comfortably inside the gateway's two hour abandonment reaper.
+    /// The Home Screen tile is a poll like the gauge, on the same quarter hour.
+    public static let defaultScreenTileInterval: TimeInterval = 15 * 60
+
+    /// Comfortably inside both deadlines it has to beat: the gateway ends a
+    /// progress-only Live Activity after two hours without an update, and a
+    /// screen widget's `staleAt` falls two hours after its last write, past
+    /// which the phone dims the tile and says how long ago it was current.
     public static let defaultKeepAliveInterval: TimeInterval = 90 * 60
 
     private let tileInterval: TimeInterval
     private let gaugeInterval: TimeInterval
+    private let screenTileInterval: TimeInterval
     private let keepAliveInterval: TimeInterval
 
     public init(
         tileInterval: TimeInterval = NotifyPublishGate.defaultTileInterval,
         gaugeInterval: TimeInterval = NotifyPublishGate.defaultGaugeInterval,
+        screenTileInterval: TimeInterval = NotifyPublishGate.defaultScreenTileInterval,
         keepAliveInterval: TimeInterval = NotifyPublishGate.defaultKeepAliveInterval
     ) {
         self.tileInterval = tileInterval
         self.gaugeInterval = gaugeInterval
+        self.screenTileInterval = screenTileInterval
         self.keepAliveInterval = keepAliveInterval
     }
 
@@ -88,7 +127,8 @@ public struct NotifyPublishGate: Sendable {
     ) -> NotifyPublishDecision {
         NotifyPublishDecision(
             publishesTile: publishesTile(payload: payload, record: record, now: now),
-            publishesGauge: publishesGauge(payload: payload, record: record, now: now)
+            publishesGauge: publishesGauge(payload: payload, record: record, now: now),
+            publishesScreenTile: publishesScreenTile(payload: payload, record: record, now: now)
         )
     }
 
@@ -99,6 +139,18 @@ public struct NotifyPublishGate: Sendable {
         let elapsed = now.timeIntervalSince(lastAt)
         if elapsed >= keepAliveInterval { return true }
         return tile != record.payload.tile && elapsed >= tileInterval
+    }
+
+    /// The Home Screen tile takes the keep alive as well as its interval,
+    /// because its freshness deadline is a real one: two hours after the last
+    /// write the phone stops presenting the content as current and dims it.
+    private func publishesScreenTile(payload: NotifyPayload, record: NotifyPublishRecord?, now: Date) -> Bool {
+        guard let screenTile = payload.screenTile else { return false }
+        guard let record, let lastAt = record.screenTileAt else { return true }
+
+        let elapsed = now.timeIntervalSince(lastAt)
+        if elapsed >= keepAliveInterval { return true }
+        return screenTile != record.payload.screenTile && elapsed >= screenTileInterval
     }
 
     private func publishesGauge(payload: NotifyPayload, record: NotifyPublishRecord?, now: Date) -> Bool {

--- a/Sources/Domain/Notify/NotifyPublishing.swift
+++ b/Sources/Domain/Notify/NotifyPublishing.swift
@@ -29,6 +29,19 @@ public protocol NotifyPublishing: Sendable {
         widgetId: String?
     ) async throws -> String
 
+    /// Creates the Home Screen widget, or updates the one `screenWidgetId`
+    /// names.
+    ///
+    /// Takes a `NotifyTile` rather than a shape of its own: the gateway derives
+    /// this route's content contract from the Live Activity module, so the two
+    /// surfaces genuinely accept one body.
+    /// - Returns: the screen widget id to store for the next update.
+    func publishScreenTile(
+        _ tile: NotifyTile,
+        link: NotifyDeviceLink,
+        screenWidgetId: String?
+    ) async throws -> String
+
     /// Ends the Live Activity, optionally leaving it on the Lock Screen for a
     /// while so the final state can be read.
     func endTile(link: NotifyDeviceLink, activityId: String, keepFor: TimeInterval) async throws

--- a/Sources/Domain/Notify/NotifySettingsRepository.swift
+++ b/Sources/Domain/Notify/NotifySettingsRepository.swift
@@ -10,6 +10,13 @@ public enum NotifyConstants {
     /// device wants to see their quota, and each can be switched off separately.
     public static let defaultLiveActivityEnabled = true
     public static let defaultWidgetEnabled = true
+
+    /// The Home Screen widget ships behind a server side kill switch, so a
+    /// ClaudeBar that supports it can meet a gateway that is not serving it yet.
+    /// On by default anyway: a 503 is handled as "not yet" rather than as an
+    /// error, and leaving it off would mean nobody sees the surface on the day
+    /// it is switched on.
+    public static let defaultScreenWidgetEnabled = true
 }
 
 /// Settings for publishing quota state to a Notify! device.
@@ -57,6 +64,11 @@ public protocol NotifySettingsRepository: Sendable {
     func isNotifyWidgetEnabled() -> Bool
     func setNotifyWidgetEnabled(_ enabled: Bool)
 
+    /// Whether the Home Screen widget is published. It carries the same content
+    /// as the Live Activity, and unlike it, it stays.
+    func isNotifyScreenWidgetEnabled() -> Bool
+    func setNotifyScreenWidgetEnabled(_ enabled: Bool)
+
     /// Which provider the widget gauge shows. Empty means "whichever quota
     /// needs attention most".
     func notifyGaugeProviderId() -> String
@@ -74,6 +86,10 @@ public protocol NotifySettingsRepository: Sendable {
     /// The handle of the widget ClaudeBar created, for the same reason.
     func notifyWidgetId() -> String?
     func setNotifyWidgetId(_ widgetId: String?)
+
+    /// The handle of the Home Screen widget ClaudeBar created.
+    func notifyScreenWidgetId() -> String?
+    func setNotifyScreenWidgetId(_ screenWidgetId: String?)
 }
 
 public extension NotifySettingsRepository {
@@ -82,6 +98,30 @@ public extension NotifySettingsRepository {
     func notifyDeviceLink() -> NotifyDeviceLink? {
         guard let token = notifyDeviceToken() else { return nil }
         return NotifyDeviceLink(deviceId: notifyDeviceId(), token: token)
+    }
+
+    /// Stores a link, keeping the surface handles when it names the same device.
+    ///
+    /// The handles are owned by a device, not by a credential. Pressing Save
+    /// twice, or re-saving after rotating a token, names the same phone, and the
+    /// tile and the two widgets already standing on it are still ours: clearing
+    /// their handles would orphan them and make the next publish create a second
+    /// set beside them, which on a Home Screen is a duplicate the user has to go
+    /// and remove by hand. Only a different device id invalidates them, and then
+    /// they must go, because they name surfaces on a phone this link can no
+    /// longer write to.
+    ///
+    /// The device id is the comparison rather than the whole link for that same
+    /// reason: a rotated token is the same phone.
+    func saveNotifyDeviceLink(_ link: NotifyDeviceLink) {
+        if notifyDeviceId() != link.deviceId {
+            setNotifyActivityId(nil)
+            setNotifyWidgetId(nil)
+            setNotifyScreenWidgetId(nil)
+        }
+
+        setNotifyDeviceId(link.deviceId)
+        saveNotifyDeviceToken(link.token)
     }
 
     /// Which quota window the gauge should show.

--- a/Sources/Infrastructure/Notify/NotifyGatewayClient.swift
+++ b/Sources/Infrastructure/Notify/NotifyGatewayClient.swift
@@ -11,6 +11,7 @@ import Domain
 /// Routes used:
 /// - `POST /live-activity/{deviceId|activityId}?token=` for the Lock Screen tile
 /// - `POST /widgets/{deviceId|widgetId}?token=` for the gauge widget
+/// - `POST /screenwidgets/{deviceId|screenWidgetId}?token=` for the Home Screen widget
 /// - `DELETE /live-activity/{activityId}?token=&keepFor=` to end the tile
 /// - `GET /link?id=&token=` to check a pasted device link
 ///
@@ -24,6 +25,7 @@ public struct NotifyGatewayClient: NotifyPublishing, Sendable {
 
     private static let liveActivityRoute = "/live-activity"
     private static let widgetsRoute = "/widgets"
+    private static let screenWidgetsRoute = "/screenwidgets"
     private static let linkRoute = "/link"
 
     /// The first rung of the gateway's push to start backoff ladder, used when a 429 names no
@@ -188,6 +190,99 @@ public struct NotifyGatewayClient: NotifyPublishing, Sendable {
         return identifier
     }
 
+    /// Creates the Home Screen widget when `screenWidgetId` is nil, otherwise updates that exact
+    /// one.
+    ///
+    /// The body is the tile's, built by the same `tileBody` the Live Activity uses. That is not a
+    /// convenience: the gateway derives this route's content contract from its Live Activity
+    /// module, so the two surfaces take the same fields, the same caps and the same merge rules,
+    /// and one tile value driving both is the entire point of the feature. A second builder here
+    /// could only drift from the first and put two different pictures of one quota on one phone.
+    ///
+    /// A create carries `"new": true` for the same "never hijack" reason as the other two
+    /// surfaces: the device dialect would otherwise write over whichever screen widget is already
+    /// there. A create answers 201, and 200 is accepted alongside it exactly as for the gauge,
+    /// since the gateway answers 200 when the call it received turned out to be an update.
+    public func publishScreenTile(
+        _ tile: NotifyTile,
+        link: NotifyDeviceLink,
+        screenWidgetId: String?
+    ) async throws -> String {
+        // Only a group is refused, and for the reason the gauge refuses one: a group is not a
+        // device and owns no widget list to write into. Every real device can keep a screen
+        // widget, the gateway being explicit that this route carries no device type gate at all
+        // and that legacy, `IO`, `WB` and `MC` ids can each own one.
+        guard link.supportsScreenWidget else {
+            throw NotifyPublishError.invalidPayload(
+                link.kind.screenWidgetUnsupportedReason
+                    ?? "A group owns no Home Screen of its own, so use the device ID and token for a single device instead."
+            )
+        }
+
+        var body = Self.tileBody(tile)
+        let target: String
+        let route: String
+        let accepting: Set<Int>
+
+        if let screenWidgetId {
+            target = screenWidgetId
+            route = "POST \(Self.screenWidgetsRoute) (update)"
+            accepting = [200]
+        } else {
+            target = link.deviceId
+            body["new"] = true
+            route = "POST \(Self.screenWidgetsRoute) (create)"
+            accepting = [200, 201]
+            AppLog.network.debug("Notify!: creating a Home Screen widget on device \(link.deviceId)")
+        }
+
+        let url = try Self.endpoint(
+            host: host,
+            path: "\(Self.screenWidgetsRoute)/\(target)",
+            queryItems: [URLQueryItem(name: "token", value: link.token)]
+        )
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.httpBody = try Self.encode(body)
+        Self.applyWriteHeaders(&request, timeout: timeout)
+
+        // Two statuses mean something here that they do not mean anywhere else in this client, so
+        // they are translated where that difference is known rather than inside the shared
+        // `failure` mapping, which every other route would then have to reason about.
+        let data: Data
+        do {
+            data = try await send(request, route: route, accepting: accepting, expected: [503])
+        } catch NotifyPublishError.unexpectedStatus(503) {
+            // The server side kill switch for Home Screen widgets. While it is off, creates and
+            // updates are refused and reads and deletes are deliberately left open so an already
+            // placed tile keeps rendering. Nothing is wrong with ClaudeBar, the credentials or
+            // the content, so this must not reach the user reading like a failure, and the remedy
+            // is to wait for the day the surface is switched on.
+            //
+            // The gateway's own sentence does not survive `unexpectedStatus`, which carries a
+            // status code and nothing else, and that costs nothing: an empty message picks the
+            // error's own "switched off at the moment, ClaudeBar will try again later" wording,
+            // which is the sentence to put in front of a user however the server phrased it.
+            throw NotifyPublishError.surfaceSwitchedOff("")
+        } catch NotifyPublishError.liveActivityUnavailable(let message) {
+            // A 409, which the shared mapping reads as a Live Activity problem because that is
+            // what it means on the route it was written for. Here it means the device dialect
+            // found several screen widgets and cannot tell which one was meant. ClaudeBar creates
+            // its own with `new` and addresses it by `SW…` id afterwards, so it should never see
+            // this, but telling somebody to open the Notify! app about their Live Activities
+            // would be a wrong answer to a question about a Home Screen widget.
+            throw NotifyPublishError.invalidPayload(message)
+        }
+
+        guard let decoded = try? JSONDecoder().decode(ScreenWidgetWriteResponse.self, from: data),
+              let identifier = decoded.screenWidgetId ?? screenWidgetId else {
+            AppLog.network.error("Notify!: \(route) answered a body ClaudeBar could not read")
+            throw NotifyPublishError.malformedResponse
+        }
+        return identifier
+    }
+
     /// Ends the tile, leaving it on the Lock Screen for `keepFor` seconds so the final state can
     /// be read.
     ///
@@ -282,13 +377,30 @@ public struct NotifyGatewayClient: NotifyPublishing, Sendable {
     /// device token and the device id, and neither belongs in a log the user is asked to attach to
     /// a bug report, so only the route and the status code are logged. The device id appears at
     /// debug level only, which never reaches the log file on disk.
-    private func send(_ request: URLRequest, route: String, accepting: Set<Int>) async throws -> Data {
+    /// `expected` names statuses that are a refusal rather than a fault: they
+    /// still throw, but they are logged at info, because writing "error" into
+    /// the file a user attaches to a bug report for something ClaudeBar then
+    /// tells them is perfectly normal is how a log stops being trusted. The
+    /// Home Screen widget's 503 kill switch is the only one so far.
+    private func send(
+        _ request: URLRequest,
+        route: String,
+        accepting: Set<Int>,
+        expected: Set<Int> = []
+    ) async throws -> Data {
         let data: Data
         let response: URLResponse
         do {
             (data, response) = try await networkClient.request(request)
         } catch {
-            AppLog.network.error("Notify!: \(route) could not be reached: \(error.localizedDescription)")
+            // The code and domain, never the description. Every URL in this
+            // client carries the device token in its query string, and a
+            // transport error's localized description is free to quote the URL
+            // it failed on. `AppLog.error` is written to a plaintext file users
+            // are asked to attach to bug reports, so the description goes to the
+            // thrown error, which is shown in the pane and never written down.
+            let failure = error as NSError
+            AppLog.network.error("Notify!: \(route) could not be reached (\(failure.domain) \(failure.code))")
             throw NotifyPublishError.transportFailed(error.localizedDescription)
         }
 
@@ -305,7 +417,11 @@ public struct NotifyGatewayClient: NotifyPublishing, Sendable {
                 data: data,
                 retryAfterHeader: http.value(forHTTPHeaderField: "Retry-After")
             )
-            AppLog.network.error("Notify!: \(route) failed with HTTP \(http.statusCode)")
+            if expected.contains(http.statusCode) {
+                AppLog.network.info("Notify!: \(route) answered HTTP \(http.statusCode), which is expected here")
+            } else {
+                AppLog.network.error("Notify!: \(route) failed with HTTP \(http.statusCode)")
+            }
             throw mapped
         }
 
@@ -351,6 +467,10 @@ public struct NotifyGatewayClient: NotifyPublishing, Sendable {
     }
 
     /// The tile's content fields, stating a null for anything the Domain type left nil.
+    ///
+    /// Both the Live Activity and the Home Screen widget are written with this, because the
+    /// gateway builds both routes' content contracts from one module and accepts either body on
+    /// either route unchanged.
     ///
     /// `status`, `endsIn`, `steps`, `step` and `button` are deliberately never mentioned. Those
     /// are the fields the "leave it alone" rule is actually for: an absent field is left alone by
@@ -507,6 +627,13 @@ private struct LiveActivityWriteResponse: Decodable {
 /// the echoed content is what ClaudeBar just sent.
 private struct WidgetWriteResponse: Decodable {
     let widgetId: String?
+}
+
+/// The `ScreenWidget` object, answered by a create (201) and an update (200) alike. Only the id is
+/// read, for the reason the widget's is: the rest of the object is the content ClaudeBar just sent
+/// back again, plus a `staleAt` the phone owns and ClaudeBar has no decision to make about.
+private struct ScreenWidgetWriteResponse: Decodable {
+    let screenWidgetId: String?
 }
 
 /// `GET /link`, which answers flat snake_case. Only the four fields ClaudeBar needs are read, and

--- a/Sources/Infrastructure/Storage/JSONSettingsRepository.swift
+++ b/Sources/Infrastructure/Storage/JSONSettingsRepository.swift
@@ -616,6 +616,14 @@ public final class JSONSettingsRepository:
         store.write(value: enabled, key: "notify.widgetEnabled")
     }
 
+    public func isNotifyScreenWidgetEnabled() -> Bool {
+        store.read(key: "notify.screenWidgetEnabled") ?? NotifyConstants.defaultScreenWidgetEnabled
+    }
+
+    public func setNotifyScreenWidgetEnabled(_ enabled: Bool) {
+        store.write(value: enabled, key: "notify.screenWidgetEnabled")
+    }
+
     public func notifyGaugeProviderId() -> String {
         store.read(key: "notify.gauge.providerId") ?? ""
     }
@@ -651,6 +659,15 @@ public final class JSONSettingsRepository:
     /// Passed through for the same reason as the activity handle above.
     public func setNotifyWidgetId(_ widgetId: String?) {
         store.write(value: widgetId, key: "notify.widgetId")
+    }
+
+    public func notifyScreenWidgetId() -> String? {
+        store.read(key: "notify.screenWidgetId")
+    }
+
+    /// Passed through for the same reason as the two handles above.
+    public func setNotifyScreenWidgetId(_ screenWidgetId: String?) {
+        store.write(value: screenWidgetId, key: "notify.screenWidgetId")
     }
 
     // MARK: - MiniMaxSettingsRepository

--- a/Tests/DomainTests/Notify/NotifyDeviceLinkTests.swift
+++ b/Tests/DomainTests/Notify/NotifyDeviceLinkTests.swift
@@ -278,6 +278,27 @@ struct NotifyDeviceLinkTests {
     }
 
     @Test
+    func `an app device, a Mac and a browser can all keep a Home Screen widget`() {
+        // The gateway is explicit that screen widgets carry no device type gate
+        // at all and that legacy, IO, WB and MC ids can each own one. Only the
+        // iOS app draws them, but which device draws what is Notify!'s business
+        // rather than a rule for ClaudeBar to invent on the user's behalf.
+        for kind in [NotifyDeviceKind.appDevice, .mac, .web, .unrecognized] {
+            #expect(kind.supportsScreenWidget)
+            #expect(kind.screenWidgetUnsupportedReason == nil)
+        }
+    }
+
+    @Test
+    func `a group can keep no Home Screen widget either`() {
+        // The one exception, and for the reason it keeps no Lock Screen widget:
+        // a group is a fan-out target with no screen of its own for a tile to
+        // stay on.
+        #expect(NotifyDeviceKind.group.supportsScreenWidget == false)
+        #expect(NotifyDeviceKind.group.screenWidgetUnsupportedReason != nil)
+    }
+
+    @Test
     func `an id from a namespace nobody knows yet is allowed through`() {
         // Refusing an unknown shape would break the day Notify! mints a new
         // namespace, and ClaudeBar would be wrong about a device it has never

--- a/Tests/DomainTests/Notify/NotifyPayloadBuilderTests.swift
+++ b/Tests/DomainTests/Notify/NotifyPayloadBuilderTests.swift
@@ -311,6 +311,40 @@ struct NotifyPayloadBuilderTests {
         #expect(payload.tile?.metrics.first?.value == "42")
     }
 
+    @Test
+    func `turning the Home Screen tile off yields a payload with no screen tile`() {
+        let payload = builder.payload(readings: [reading(42)], includesScreenTile: false)
+
+        #expect(payload.screenTile == nil)
+        #expect(payload.tile?.metrics.first?.value == "42")
+    }
+
+    @Test
+    func `the Home Screen tile survives the Live Activity being turned off`() {
+        // The two surfaces switch on and off separately, which is the whole
+        // reason the payload carries them as two fields. A user who wants a tile
+        // that stays and nothing on their Lock Screen must still get one.
+        let payload = builder.payload(readings: [reading(42)], includesTile: false)
+
+        #expect(payload.tile == nil)
+        #expect(payload.screenTile?.metrics.first?.value == "42")
+    }
+
+    @Test
+    func `the Home Screen tile is the Live Activity tile, one value on two surfaces`() {
+        // The gateway derives both routes' content contracts from one module and
+        // takes the same body on either, so the client sends one body to both.
+        // Building the two separately here could only produce two pictures of
+        // one quota that were meant to be identical and one day were not.
+        let payload = builder.payload(readings: [
+            reading(8, provider: "claude", name: "Claude"),
+            reading(70, provider: "codex", name: "Codex", quotaType: .weekly),
+        ])
+
+        #expect(payload.screenTile != nil)
+        #expect(payload.screenTile == payload.tile)
+    }
+
     // MARK: - The summary line
 
     @Test
@@ -327,4 +361,31 @@ struct NotifyPayloadBuilderTests {
         #expect(payload.tile?.body?.contains("resets in") == true)
         #expect(payload.tile?.trailing != nil)
     }
+
+    @Test
+    func `two readings that tie on everything visible still order deterministically`() {
+        // An aggregating provider can report two accounts under one display
+        // name, so the name is not a unique key and neither is the pair of name
+        // and window. Swift's sort is not stable, so without a total comparator
+        // these two could come back in either order, the payload would differ
+        // between builds of identical state, and the driver would republish for
+        // nothing on every refresh.
+        let left = NotifyQuotaReading(
+            providerId: "omp-work",
+            providerName: "Oh My Pi",
+            quota: UsageQuota(percentRemaining: 40, quotaType: .session, providerId: "omp-work")
+        )
+        let right = NotifyQuotaReading(
+            providerId: "omp-home",
+            providerName: "Oh My Pi",
+            quota: UsageQuota(percentRemaining: 40, quotaType: .session, providerId: "omp-home")
+        )
+
+        let oneWay = NotifyPayloadBuilder.ordered([left, right]).map(\.providerId)
+        let theOther = NotifyPayloadBuilder.ordered([right, left]).map(\.providerId)
+
+        #expect(oneWay == theOther)
+        #expect(oneWay == ["omp-home", "omp-work"])
+    }
+
 }

--- a/Tests/DomainTests/Notify/NotifyPublishGateTests.swift
+++ b/Tests/DomainTests/Notify/NotifyPublishGateTests.swift
@@ -21,6 +21,16 @@ struct NotifyPublishGateTests {
         )
     }
 
+    /// The same, carrying the Home Screen tile as well. A real payload holds one
+    /// tile value on both surfaces, so this builds them from one body too.
+    private func payload(tile body: String?, gauge value: String?, screenTile screenBody: String?) -> NotifyPayload {
+        NotifyPayload(
+            tile: body.flatMap { NotifyTile(title: "ClaudeBar", body: $0, progress: 42) },
+            gauge: value.flatMap { NotifyGauge(title: "ClaudeBar", value: $0, progress: 42) },
+            screenTile: screenBody.flatMap { NotifyTile(title: "ClaudeBar", body: $0, progress: 42) }
+        )
+    }
+
     // MARK: - The first publish
 
     @Test
@@ -127,6 +137,109 @@ struct NotifyPublishGateTests {
         #expect(!decision.publishesGauge)
     }
 
+    // MARK: - The Home Screen tile
+
+    @Test
+    func `a payload with no screen tile never publishes one`() {
+        let decision = gate.decide(
+            payload: payload(tile: "42% left", gauge: "42", screenTile: nil),
+            since: nil,
+            now: now
+        )
+
+        #expect(!decision.publishesScreenTile)
+        #expect(decision.publishesTile)
+    }
+
+    @Test
+    func `a changed screen tile waits for its own interval`() {
+        let standing = payload(tile: "42% left", gauge: "42", screenTile: "42% left")
+        let record = NotifyPublishRecord(payload: standing, tileAt: now, gaugeAt: now, screenTileAt: now)
+
+        let decision = gate.decide(
+            payload: payload(tile: "41% left", gauge: "42", screenTile: "41% left"),
+            since: record,
+            now: now.addingTimeInterval(300)
+        )
+
+        // Nothing is pushed to a screen widget. The phone polls its list when
+        // iOS redraws the tile, roughly every quarter hour, so a write five
+        // minutes in is a request nobody reads.
+        #expect(!decision.publishesScreenTile)
+    }
+
+    @Test
+    func `a changed screen tile publishes once its own interval has passed`() {
+        let standing = payload(tile: "42% left", gauge: "42", screenTile: "42% left")
+        let record = NotifyPublishRecord(payload: standing, tileAt: now, gaugeAt: now, screenTileAt: now)
+
+        let decision = gate.decide(
+            payload: payload(tile: "41% left", gauge: "42", screenTile: "41% left"),
+            since: record,
+            now: now.addingTimeInterval(900)
+        )
+
+        #expect(decision.publishesScreenTile)
+    }
+
+    @Test
+    func `an unchanged screen tile publishes again once the keep alive interval has passed`() {
+        // The screen tile carries a freshness deadline the Lock Screen widget
+        // does not: two hours after the last write its staleAt passes, and the
+        // phone then dims the tile and says how long ago it was current rather
+        // than presenting the old number as live. So a quota that simply is not
+        // moving still has to be rewritten, or a correct reading goes grey.
+        let standing = payload(tile: "42% left", gauge: "42", screenTile: "42% left")
+        let record = NotifyPublishRecord(payload: standing, tileAt: now, gaugeAt: now, screenTileAt: now)
+
+        let decision = gate.decide(payload: standing, since: record, now: now.addingTimeInterval(5400))
+
+        #expect(decision.publishesScreenTile)
+    }
+
+    @Test
+    func `a screen tile only publish leaves the other two surfaces showing what they are showing`() {
+        // Given all three surfaces last written at the same moment
+        let first = payload(tile: "42% left", gauge: "42", screenTile: "42% left")
+        let second = payload(tile: "41% left", gauge: "41", screenTile: "41% left")
+        let record = NotifyPublishRecord(payload: first, tileAt: now, gaugeAt: now, screenTileAt: now)
+
+        // When only the Home Screen tile goes out, a quarter of an hour later
+        let updated = record.updated(
+            with: second,
+            decision: NotifyPublishDecision(
+                publishesTile: false,
+                publishesGauge: false,
+                publishesScreenTile: true
+            ),
+            at: now.addingTimeInterval(900)
+        )
+
+        // Then the tile and the gauge keep both their timestamps and their
+        // content, because that is what the phone is still showing on them.
+        // Recording the whole payload would file their unsent changes as
+        // delivered and the gate would see nothing to send when their own
+        // intervals came round.
+        #expect(updated.payload.screenTile == second.screenTile)
+        #expect(updated.screenTileAt == now.addingTimeInterval(900))
+        #expect(updated.payload.tile == first.tile)
+        #expect(updated.payload.gauge == first.gauge)
+        #expect(updated.tileAt == now)
+        #expect(updated.gaugeAt == now)
+    }
+
+    @Test
+    func `a decision that writes only the screen tile does not report publishing nothing`() {
+        #expect(
+            !NotifyPublishDecision(
+                publishesTile: false,
+                publishesGauge: false,
+                publishesScreenTile: true
+            ).publishesNothing
+        )
+        #expect(!NotifyPublishDecision.nothing.publishesScreenTile)
+    }
+
     // MARK: - Surfaces the user turned off
 
     @Test
@@ -160,8 +273,11 @@ struct NotifyPublishGateTests {
             at: now.addingTimeInterval(120)
         )
 
-        // Then the gauge keeps its old timestamp, so its own interval still applies
-        #expect(updated.payload == next)
+        // Then the gauge keeps its old timestamp, so its own interval still
+        // applies, and its old content, because that is what the phone is still
+        // showing. Recording the unsent gauge as delivered would lose the change.
+        #expect(updated.payload.tile == next.tile)
+        #expect(updated.payload.gauge == record.payload.gauge)
         #expect(updated.tileAt == now.addingTimeInterval(120))
         #expect(updated.gaugeAt == now)
     }
@@ -181,4 +297,62 @@ struct NotifyPublishGateTests {
         #expect(!NotifyPublishDecision(publishesTile: true, publishesGauge: false).publishesNothing)
         #expect(!NotifyPublishDecision(publishesTile: false, publishesGauge: true).publishesNothing)
     }
+
+    // MARK: - What each surface is actually showing
+
+    @Test
+    func `a gauge held back by its interval is still sent once the interval passes`() {
+        // The sequence a real publish takes: the tile moves first, on its own
+        // shorter interval, while the gauge waits for its quarter hour.
+        let gate = NotifyPublishGate(tileInterval: 60, gaugeInterval: 900, keepAliveInterval: 5400)
+        let first = payload(tileTrailing: "2:14", gaugeValue: "42")
+        let second = payload(tileTrailing: "2:13", gaugeValue: "41")
+
+        // Given both surfaces published together
+        var record = NotifyPublishRecord(payload: .empty)
+            .updated(with: first, decision: NotifyPublishDecision(publishesTile: true, publishesGauge: true), at: now)
+
+        // When a minute later both have changed, but only the tile is due
+        let atOneMinute = now.addingTimeInterval(60)
+        let tileOnly = gate.decide(payload: second, since: record, now: atOneMinute)
+        #expect(tileOnly.publishesTile)
+        #expect(tileOnly.publishesGauge == false)
+        record = record.updated(with: second, decision: tileOnly, at: atOneMinute)
+
+        // Then once the gauge's own interval has passed, its change is still
+        // there to be sent. Recording the whole payload on a tile-only publish
+        // would have filed the new gauge as already delivered, and the phone
+        // would sit on the old value until something else happened to move it.
+        let atFifteenMinutes = now.addingTimeInterval(900)
+        let later = gate.decide(payload: second, since: record, now: atFifteenMinutes)
+
+        #expect(later.publishesGauge)
+    }
+
+    @Test
+    func `a surface that was not published keeps the content it is showing`() {
+        let first = payload(tileTrailing: "2:14", gaugeValue: "42")
+        let second = payload(tileTrailing: "2:13", gaugeValue: "41")
+
+        let record = NotifyPublishRecord(payload: first, tileAt: now, gaugeAt: now)
+            .updated(
+                with: second,
+                decision: NotifyPublishDecision(publishesTile: true, publishesGauge: false),
+                at: now.addingTimeInterval(60)
+            )
+
+        // The record is what the phone shows, which is not the last payload built
+        #expect(record.payload.tile == second.tile)
+        #expect(record.payload.gauge == first.gauge)
+    }
+
+    // MARK: - Helpers
+
+    private func payload(tileTrailing: String, gaugeValue: String) -> NotifyPayload {
+        NotifyPayload(
+            tile: NotifyTile(title: "ClaudeBar", progress: 42, trailing: tileTrailing),
+            gauge: NotifyGauge(title: "ClaudeBar", value: gaugeValue, unit: "%", progress: 42)
+        )
+    }
+
 }

--- a/Tests/InfrastructureTests/Notify/NotifyGatewayClientTests.swift
+++ b/Tests/InfrastructureTests/Notify/NotifyGatewayClientTests.swift
@@ -14,6 +14,7 @@ struct NotifyGatewayClientTests {
     static let token = "sekret-token-42"
     static let activityId = "LA7Q2ZKM"
     static let widgetId = "WG4H2QZ1"
+    static let screenWidgetId = "SW8N3PQ2"
 
     // The three ids that name something with no Lock Screen of its own: a push
     // capable Mac listener, a web push browser, and a notification group.
@@ -36,6 +37,19 @@ struct NotifyGatewayClientTests {
       "createdAt": "2026-09-03T09:00:00Z",
       "updatedAt": "2026-09-03T09:00:00Z",
       "updateUrl": "https://push.getnotifyapp.com/widgets/WG4H2QZ1"
+    }
+    """
+
+    /// The `ScreenWidget` object. `staleAt` is the phone's freshness deadline and rides along on
+    /// every write, but ClaudeBar has no decision to make about it, so only the id is read.
+    static let screenWidgetResponse = """
+    {
+      "screenWidgetId": "SW8N3PQ2",
+      "content": { "title": "ClaudeBar" },
+      "staleAt": 1772539200,
+      "createdAt": "2026-09-03T09:00:00Z",
+      "updatedAt": "2026-09-03T09:00:00Z",
+      "updateUrl": "https://push.getnotifyapp.com/screenwidgets/SW8N3PQ2"
     }
     """
 
@@ -458,6 +472,133 @@ struct NotifyGatewayClientTests {
         #expect(body["button"] == nil)
     }
 
+    // MARK: - The Home Screen Tile
+
+    @Test
+    func `a Home Screen tile create addresses the device with new and returns the screen widget id`() async throws {
+        // Given
+        let link = try makeLink()
+        let tile = try makeTile()
+        var capturedRequest: URLRequest?
+        let network = MockNetworkClient()
+        given(network)
+            .request(.any)
+            .willProduce { request in
+                capturedRequest = request
+                return (Data(Self.screenWidgetResponse.utf8), Self.response(201))
+            }
+        let client = NotifyGatewayClient(networkClient: network, host: Self.host, timeout: 1)
+
+        // When
+        let identifier = try await client.publishScreenTile(tile, link: link, screenWidgetId: nil)
+
+        // Then: the device dialect, and `new` for the same reason the other two surfaces send it.
+        // A screen widget stays until the user removes it, so taking over one they already placed
+        // would replace something of theirs permanently.
+        #expect(
+            capturedRequest?.url?.absoluteString
+                == "https://push.getnotifyapp.com/screenwidgets/ABC12345?token=sekret-token-42"
+        )
+        #expect(capturedRequest?.httpMethod == "POST")
+        #expect(capturedRequest?.value(forHTTPHeaderField: "Content-Type") == "application/json")
+        let body = try jsonBody(of: capturedRequest)
+        #expect(body["new"] as? Bool == true)
+        #expect(body["title"] as? String == "ClaudeBar")
+        #expect(identifier == Self.screenWidgetId)
+    }
+
+    @Test
+    func `a Home Screen tile create accepts a 200 answer as well as a 201`() async throws {
+        // Given: the gateway answers 200 when the create it received turned out to be an update
+        let link = try makeLink()
+        let tile = try makeTile()
+        let client = makeClient(status: 200, body: Self.screenWidgetResponse)
+
+        // When
+        let identifier = try await client.publishScreenTile(tile, link: link, screenWidgetId: nil)
+
+        // Then
+        #expect(identifier == Self.screenWidgetId)
+    }
+
+    @Test
+    func `a Home Screen tile update addresses that exact widget and never sends new`() async throws {
+        // Given
+        let link = try makeLink()
+        let tile = try makeTile()
+        var capturedRequest: URLRequest?
+        let network = MockNetworkClient()
+        given(network)
+            .request(.any)
+            .willProduce { request in
+                capturedRequest = request
+                return (Data(Self.screenWidgetResponse.utf8), Self.response(200))
+            }
+        let client = NotifyGatewayClient(networkClient: network, host: Self.host, timeout: 1)
+
+        // When
+        let identifier = try await client.publishScreenTile(
+            tile,
+            link: link,
+            screenWidgetId: Self.screenWidgetId
+        )
+
+        // Then: `new` on an update would leave a second tile on the Home Screen for the user to
+        // find and delete by hand
+        #expect(
+            capturedRequest?.url?.absoluteString
+                == "https://push.getnotifyapp.com/screenwidgets/SW8N3PQ2?token=sekret-token-42"
+        )
+        let body = try jsonBody(of: capturedRequest)
+        #expect(body.keys.contains("new") == false)
+        #expect(body["title"] as? String == "ClaudeBar")
+        #expect(identifier == Self.screenWidgetId)
+    }
+
+    @Test
+    func `the Home Screen tile and the Live Activity are sent one identical body`() async throws {
+        // Given one tile value, and a stub that answers whichever of the two routes it is handed
+        let link = try makeLink()
+        let tile = try makeTile()
+        var capturedRequests: [URLRequest] = []
+        let network = MockNetworkClient()
+        given(network)
+            .request(.any)
+            .willProduce { request in
+                capturedRequests.append(request)
+                let isScreenWidget = request.url?.absoluteString.contains("/screenwidgets/") == true
+                return (
+                    Data((isScreenWidget ? Self.screenWidgetResponse : Self.startResponse).utf8),
+                    Self.response(isScreenWidget ? 201 : 200)
+                )
+            }
+        let client = NotifyGatewayClient(networkClient: network, host: Self.host, timeout: 1)
+
+        // When: the same tile goes to both surfaces
+        _ = try await client.publishTile(tile, link: link, activityId: nil)
+        _ = try await client.publishScreenTile(tile, link: link, screenWidgetId: nil)
+
+        // Then: the two bodies differ in nothing at all. That is the premise of the whole feature:
+        // the gateway derives the screen widget's content contract from its Live Activity module,
+        // so one tile value drives both surfaces and the client keeps one builder for them. A
+        // second builder here could only drift and put two different pictures of one quota on one
+        // phone, which is the thing this test exists to catch.
+        #expect(capturedRequests.count == 2)
+        var liveActivityBody = try jsonBody(of: capturedRequests.first)
+        var screenBody = try jsonBody(of: capturedRequests.last)
+        liveActivityBody.removeValue(forKey: "new")
+        screenBody.removeValue(forKey: "new")
+
+        // Compared through NSDictionary rather than key by key, because the claim being made is
+        // about the whole body, nested metrics row and explicit nulls included.
+        #expect(NSDictionary(dictionary: liveActivityBody) == NSDictionary(dictionary: screenBody))
+
+        // And the thing being compared is a real body rather than two empty dictionaries, which
+        // would satisfy the equality above and prove nothing.
+        #expect(screenBody["title"] as? String == "ClaudeBar")
+        #expect((screenBody["metrics"] as? [[String: Any]])?.count == 2)
+    }
+
     // MARK: - Device Kind Guards
 
     @Test
@@ -581,6 +722,80 @@ struct NotifyGatewayClientTests {
             _ = try await client.publishGauge(gauge, link: link, widgetId: nil)
         }
         #expect(capturedRequest == nil)
+    }
+
+    @Test
+    func `a Home Screen tile aimed at a group is refused without spending a request`() async throws {
+        // Given a group link, which owns no widget list for a Home Screen tile to sit in
+        let link = try makeLink(deviceId: Self.groupDeviceId)
+        let tile = try makeTile()
+        let reason = try #require(NotifyDeviceKind.group.screenWidgetUnsupportedReason)
+        var capturedRequest: URLRequest?
+        let network = MockNetworkClient()
+        given(network)
+            .request(.any)
+            .willProduce { request in
+                capturedRequest = request
+                return (Data(Self.screenWidgetResponse.utf8), Self.response(201))
+            }
+        let client = NotifyGatewayClient(networkClient: network, host: Self.host, timeout: 1)
+
+        // When & Then: `invalidPayload` rather than `liveActivityUnavailable`, because no Live
+        // Activity is involved and that error's remedies would send the user somewhere useless
+        await #expect(throws: NotifyPublishError.invalidPayload(reason)) {
+            _ = try await client.publishScreenTile(tile, link: link, screenWidgetId: nil)
+        }
+        #expect(capturedRequest == nil)
+    }
+
+    @Test
+    func `a Home Screen tile aimed at a Mac is sent, because screen widgets carry no device gate`() async throws {
+        // Given a Mac link. A Live Activity would be refused for one, and a screen widget is not:
+        // the gateway is explicit that this route has no device-type gate and that legacy, IO, WB
+        // and MC ids can each own one. Refusing it here would be ClaudeBar inventing a rule the
+        // service does not have.
+        let link = try makeLink(deviceId: Self.macDeviceId)
+        let tile = try makeTile()
+        var capturedRequest: URLRequest?
+        let network = MockNetworkClient()
+        given(network)
+            .request(.any)
+            .willProduce { request in
+                capturedRequest = request
+                return (Data(Self.screenWidgetResponse.utf8), Self.response(201))
+            }
+        let client = NotifyGatewayClient(networkClient: network, host: Self.host, timeout: 1)
+
+        // When
+        let identifier = try await client.publishScreenTile(tile, link: link, screenWidgetId: nil)
+
+        // Then: the write went out and its id came back
+        #expect(identifier == Self.screenWidgetId)
+        #expect(
+            capturedRequest?.url?.absoluteString.contains("/screenwidgets/\(Self.macDeviceId)") == true
+        )
+    }
+
+    @Test
+    func `a Home Screen tile aimed at a browser is sent too`() async throws {
+        let link = try makeLink(deviceId: Self.webDeviceId)
+        let tile = try makeTile()
+        var capturedRequest: URLRequest?
+        let network = MockNetworkClient()
+        given(network)
+            .request(.any)
+            .willProduce { request in
+                capturedRequest = request
+                return (Data(Self.screenWidgetResponse.utf8), Self.response(201))
+            }
+        let client = NotifyGatewayClient(networkClient: network, host: Self.host, timeout: 1)
+
+        let identifier = try await client.publishScreenTile(tile, link: link, screenWidgetId: nil)
+
+        #expect(identifier == Self.screenWidgetId)
+        #expect(
+            capturedRequest?.url?.absoluteString.contains("/screenwidgets/\(Self.webDeviceId)") == true
+        )
     }
 
     @Test
@@ -828,6 +1043,56 @@ struct NotifyGatewayClientTests {
             throws: NotifyPublishError.liveActivityUnavailable("Open the Notify! app once on the device.")
         ) {
             try await client.publishTile(tile, link: link, activityId: nil)
+        }
+    }
+
+    @Test
+    func `409 on the Home Screen route becomes invalidPayload, not liveActivityUnavailable`() async throws {
+        // Given the one thing a 409 can mean here: the device dialect found several screen widgets
+        // and cannot tell which was meant. ClaudeBar creates its own and addresses it by SW id
+        // afterwards, so it should never see this.
+        let link = try makeLink()
+        let tile = try makeTile()
+        let client = makeClient(status: 409, body: """
+        { "error": "ScreenWidgetAmbiguous", "message": "Several screen widgets exist on this device." }
+        """)
+
+        // When & Then: the shared mapping reads a 409 as a Live Activity problem, because that is
+        // what it means on the route it was written for. Left alone it would tell somebody to open
+        // the Notify! app about their Live Activities, which is a wrong answer to a question about
+        // a Home Screen widget.
+        await #expect(
+            throws: NotifyPublishError.invalidPayload("Several screen widgets exist on this device.")
+        ) {
+            _ = try await client.publishScreenTile(tile, link: link, screenWidgetId: nil)
+        }
+    }
+
+    @Test
+    func `503 is the Home Screen surface being switched off, and worth trying again later`() async throws {
+        // Given the server side kill switch this surface shipped behind, so a ClaudeBar that
+        // supports it can meet a gateway that is not serving it yet
+        let link = try makeLink()
+        let tile = try makeTile()
+        let client = makeClient(status: 503, body: """
+        { "error": "ScreenWidgetsDisabled", "message": "Screen widgets are not enabled." }
+        """)
+
+        // When
+        do {
+            _ = try await client.publishScreenTile(tile, link: link, screenWidgetId: nil)
+            Issue.record("Expected the kill switch to surface")
+        } catch let error as NotifyPublishError {
+            // Then: nothing is wrong with ClaudeBar, the credentials or the content, and the only
+            // remedy is the day the surface is switched on. The gateway's own sentence is not
+            // carried, and that costs nothing: an empty message picks the error's own wording,
+            // which is the sentence to put in front of a user however the server phrased it.
+            #expect(error == .surfaceSwitchedOff(""))
+            #expect(error.errorDescription?.contains("try again later") == true)
+
+            // And it is retryable, which is what keeps the driver backing off rather than giving
+            // up on the surface until something else changes.
+            #expect(error.isRetryable)
         }
     }
 

--- a/Tests/InfrastructureTests/Settings/NotifySettingsRepositoryTests.swift
+++ b/Tests/InfrastructureTests/Settings/NotifySettingsRepositoryTests.swift
@@ -112,6 +112,18 @@ struct NotifySettingsRepositoryTests {
     }
 
     @Test
+    func `the Home Screen widget defaults to on`() {
+        let fixture = makeFixture()
+        defer { cleanup(fixture) }
+
+        // On even though the gateway ships this surface behind a kill switch, because a 503 is
+        // handled as "not yet" rather than as an error. Defaulting it off would mean nobody saw
+        // the surface on the day it was switched on.
+        #expect(fixture.repository.isNotifyScreenWidgetEnabled() == NotifyConstants.defaultScreenWidgetEnabled)
+        #expect(fixture.repository.isNotifyScreenWidgetEnabled() == true)
+    }
+
+    @Test
     func `the device id defaults to empty`() {
         let fixture = makeFixture()
         defer { cleanup(fixture) }
@@ -186,6 +198,15 @@ struct NotifySettingsRepositoryTests {
     }
 
     @Test
+    func `setNotifyScreenWidgetEnabled persists value`() {
+        let fixture = makeFixture()
+        defer { cleanup(fixture) }
+
+        fixture.repository.setNotifyScreenWidgetEnabled(false)
+        #expect(fixture.repository.isNotifyScreenWidgetEnabled() == false)
+    }
+
+    @Test
     func `setNotifyGaugeProviderId persists value`() {
         let fixture = makeFixture()
         defer { cleanup(fixture) }
@@ -221,6 +242,15 @@ struct NotifySettingsRepositoryTests {
         #expect(fixture.repository.notifyWidgetId() == "WG4H2QZ1")
     }
 
+    @Test
+    func `setNotifyScreenWidgetId persists value`() {
+        let fixture = makeFixture()
+        defer { cleanup(fixture) }
+
+        fixture.repository.setNotifyScreenWidgetId("SW8N3PQ2")
+        #expect(fixture.repository.notifyScreenWidgetId() == "SW8N3PQ2")
+    }
+
     // MARK: - Forgetting a Handle
 
     @Test
@@ -245,6 +275,20 @@ struct NotifySettingsRepositoryTests {
         fixture.repository.setNotifyWidgetId(nil)
 
         #expect(fixture.repository.notifyWidgetId() == nil)
+    }
+
+    @Test
+    func `setNotifyScreenWidgetId nil removes the handle`() {
+        let fixture = makeFixture()
+        defer { cleanup(fixture) }
+
+        fixture.repository.setNotifyScreenWidgetId("SW8N3PQ2")
+        fixture.repository.setNotifyScreenWidgetId(nil)
+
+        // A screen widget stays on the Home Screen until the user removes it, so a stored "" that
+        // read back as a handle would aim every later update at a tile that is not there while the
+        // one that is sits frozen on their phone.
+        #expect(fixture.repository.notifyScreenWidgetId() == nil)
     }
 
     // MARK: - Device Token
@@ -472,6 +516,53 @@ struct NotifySettingsRepositoryTests {
         // Then: removing a link has to remove it, wherever it ended up
         #expect(fixture.repository.notifyDeviceToken() == nil)
         #expect(fixture.repository.hasNotifyDeviceToken() == false)
+    }
+
+
+    // MARK: - Saving a link
+
+    @Test
+    func `saving the same device again keeps the surfaces already standing on it`() throws {
+        // Given a linked device with all three surfaces published
+        let fixture = makeFixture()
+        defer { cleanup(fixture) }
+        fixture.repository.saveNotifyDeviceLink(try #require(NotifyDeviceLink(deviceId: Self.deviceId, token: Self.token)))
+        fixture.repository.setNotifyActivityId("LA7Q2ZKM")
+        fixture.repository.setNotifyWidgetId("WG4H2QZ1")
+        fixture.repository.setNotifyScreenWidgetId("SW3K9QZ2")
+
+        // When the user presses Save again, which the pane allows, with a
+        // rotated token but the same phone
+        fixture.repository.saveNotifyDeviceLink(try #require(NotifyDeviceLink(deviceId: Self.deviceId, token: "a-rotated-token")))
+
+        // Then the handles survive. Clearing them would orphan a tile and two
+        // widgets that are still ours and make the next publish build a second
+        // set beside them, which on a Home Screen is a duplicate the user has to
+        // go and remove by hand.
+        #expect(fixture.repository.notifyActivityId() == "LA7Q2ZKM")
+        #expect(fixture.repository.notifyWidgetId() == "WG4H2QZ1")
+        #expect(fixture.repository.notifyScreenWidgetId() == "SW3K9QZ2")
+        #expect(fixture.repository.notifyDeviceToken() == "a-rotated-token")
+    }
+
+    @Test
+    func `linking a different device forgets the previous one's surfaces`() throws {
+        let fixture = makeFixture()
+        defer { cleanup(fixture) }
+        fixture.repository.saveNotifyDeviceLink(try #require(NotifyDeviceLink(deviceId: Self.deviceId, token: Self.token)))
+        fixture.repository.setNotifyActivityId("LA7Q2ZKM")
+        fixture.repository.setNotifyWidgetId("WG4H2QZ1")
+        fixture.repository.setNotifyScreenWidgetId("SW3K9QZ2")
+
+        // When a different phone is linked
+        fixture.repository.saveNotifyDeviceLink(try #require(NotifyDeviceLink(deviceId: "ZZZ99999", token: Self.token)))
+
+        // Then the handles go, because they name surfaces on a phone this link
+        // can no longer write to, and keeping them would spend a 403 finding out
+        #expect(fixture.repository.notifyActivityId() == nil)
+        #expect(fixture.repository.notifyWidgetId() == nil)
+        #expect(fixture.repository.notifyScreenWidgetId() == nil)
+        #expect(fixture.repository.notifyDeviceId() == "ZZZ99999")
     }
 
 }

--- a/docs/features/notify.md
+++ b/docs/features/notify.md
@@ -1,6 +1,6 @@
 # Notify!
 
-ClaudeBar already knows every quota worth knowing, and the phone is where the user actually looks. [Notify!](https://getnotifyapp.com) already exists, runs on Mac and iOS and reaches anything else through web push, and has a documented gateway API, so ClaudeBar can put a quota on a Lock Screen without shipping an iOS app of its own.
+ClaudeBar already knows every quota worth knowing, and the phone is where the user actually looks. [Notify!](https://getnotifyapp.com) already exists, runs on Mac and iOS and reaches anything else through web push, and has a documented gateway API, so ClaudeBar can put a quota on a Lock Screen and a Home Screen without shipping an iOS app of its own.
 
 ---
 
@@ -19,19 +19,25 @@ The question the app exists to answer is *"can I start another long run?"*, and 
 
 The obvious fix is an iPhone app, and it is enormous out of proportion to the payload. It means an App Store presence and review queue, an APNs push service to run, an account system to pair a Mac with a phone, a widget extension, a Live Activity extension, and a second release train alongside the Sparkle one. All of that to render one percentage.
 
-Notify! has already built exactly that. It is a published app covering Mac, iOS and web push, whose entire premise is that a script somewhere else pushes content to a device you carry: it owns the push certificates, the device pairing, and on iOS the Live Activity and widget extensions that draw a Lock Screen. What it exposes to the outside world is a plain HTTP gateway with no SDK and no bearer token, addressed by a device id and a per device secret the user copies out of the app.
+Notify! has already built exactly that. It is a published app covering Mac, iOS and web push, whose entire premise is that a script somewhere else pushes content to a device you carry: it owns the push certificates, the device pairing, and on iOS the Live Activity and widget extensions that draw a Lock Screen and a Home Screen. What it exposes to the outside world is a plain HTTP gateway with no SDK and no bearer token, addressed by a device id and a per device secret the user copies out of the app.
 
-So the whole feature on ClaudeBar's side is: turn the quotas it already holds into two small JSON bodies, and POST them.
+So the whole feature on ClaudeBar's side is: turn the quotas it already holds into two small JSON bodies, and POST them to three routes.
 
 ## Behavior
 
-Two surfaces, both on the Lock Screen, both switchable independently once the feature itself is on.
+Three surfaces, each switchable independently once the feature itself is on, and two of them carry the identical thing.
+
+That last part is the premise rather than a coincidence, and it is what makes the third surface nearly free. The gateway derives the Home Screen widget's content contract from the same module its Live Activity uses: same fields, same caps, same merge rules, same validation messages, so any body that would start a Live Activity is already a valid Home Screen widget body. ClaudeBar builds the tile once, as one `NotifyTile` that `NotifyPayloadBuilder` hands to both surfaces, and `NotifyGatewayClient` encodes it through the same `tileBody` for both routes. Building it twice would only produce two things that were meant to be identical and one day were not, which on a phone reads as two different pictures of one quota.
 
 **The metrics Live Activity** is the dense one. It carries the title `ClaudeBar`, a progress bar, a compact reset countdown where a timer would sit, and a row of up to six quota windows, each with its own label, value, unit and color. Six is the gateway's ceiling and also about the point at which a Lock Screen row stops being readable, so the two limits agree.
 
-**The Lock Screen widget** is the glanceable one. Its gauge is a single chosen quota: a headline value, a unit, a quieter second line naming the provider and the window, and a `progress` the gateway draws as a bar on the rectangular widget and as a ring on the circular one. The gauge shows whichever quota needs attention most until the user picks a specific one.
+**The Home Screen widget** carries that same tile, and differs in when the user meets it. A Live Activity appears while something is happening and goes away when it stops; a Home Screen widget stays where it was placed and always shows the latest thing stored for it. So the tile answers "what is my quota right now" to somebody whose phone is already lit, and the Home Screen widget answers "what was my quota when I last looked", to somebody who went looking. Neither is a substitute for the other, which is why both are on by default and either can be switched off alone.
 
-Four rules shape what those two actually say, and all four live in `NotifyPayloadBuilder`:
+The Home Screen widget is also the newest surface on Notify!'s side, and that shows in two places. It needs a recent Notify!, where it is turned on under Settings then Home Screen Widgets. And creating one over the gateway puts nothing on a screen by itself: it fills a slot the user still has to place through iOS's own widget picker, the same as any other widget.
+
+**The Lock Screen widget** is the glanceable one, and the only surface with a shape of its own. Its gauge is a single chosen quota: a headline value, a unit, a quieter second line naming the provider and the window, and a `progress` the gateway draws as a bar on the rectangular widget and as a ring on the circular one. The gauge shows whichever quota needs attention most until the user picks a specific one.
+
+Four rules shape what all of that actually says, and all four live in `NotifyPayloadBuilder`:
 
 - **Percentages are remaining, not used.** A 42% quota publishes `progress: 42`. Every other ClaudeBar surface reads that way, and a full ring meaning a full quota is the only intuitive mapping a gauge has.
 - **The worst quota leads.** Readings sort by status severity, then by how little is left. The headline is the first one, and the tile takes its tint, its bar and its countdown from it.
@@ -42,13 +48,16 @@ Money based quotas have no percentage to draw. Their value is the formatted bala
 
 ### Publish cadence
 
-Quota numbers move on every refresh and the reset countdown moves every minute, so "publish whenever the payload differs" is a request per refresh, forever. `NotifyPublishGate` adds three rules on top of the difference:
+Quota numbers move on every refresh and the reset countdown moves every minute, so "publish whenever the payload differs" is a request per refresh, forever. `NotifyPublishGate` adds four rules on top of the difference:
 
 | Rule | Value | Why |
 |---|---|---|
 | Minimum gap, tile | 60 s | The tile is a push, so it can afford to be prompt. |
 | Minimum gap, gauge | 15 min | iOS decides when a widget redraws, roughly every quarter hour. Pushing faster buys nothing. |
-| Keep alive, tile | 90 min | The gateway ends a progress-only tile that goes **two hours** without an update, on the grounds that a frozen percentage is worse than no tile. Ninety minutes clears that with room to spare. |
+| Minimum gap, Home Screen tile | 15 min | Also a poll, on the same quarter hour and for the same reason. Nothing is ever pushed to it: the phone fetches the device's screen widget list when iOS decides to redraw the tile. |
+| Keep alive, tile and Home Screen tile | 90 min | Two deadlines, both at **two hours**, both measured from the last write. The gateway ends a progress-only Live Activity that has gone that long without an update, on the grounds that a frozen percentage is worse than no tile; and a Home Screen widget's `staleAt` lands there too, after which the phone dims the tile rather than presenting old numbers as current. Ninety minutes clears both with room to spare. |
+
+The gauge is the one surface with no keep alive. The gateway documents neither a reaper nor a freshness deadline for `/widgets`, so there is nothing a heartbeat there would prevent.
 
 The keep alive is the reason `NotifyPublishDriver` runs a one minute timer at all. Both time based rules are unreachable from `@Observable` state alone: a change the gate suppressed for arriving too soon has to be offered again once its interval has passed, and nothing in observable state fires on the mere passage of time.
 
@@ -56,20 +65,21 @@ Saving credentials or pressing publish in the settings pane bypasses the gate en
 
 ### Recovery
 
-Five failure modes have a remedy, and each one is a distinct case on `NotifyPublishError` for exactly that reason.
+Each failure mode below has a remedy of its own, and each one is a distinct case on `NotifyPublishError` for exactly that reason.
 
 | What happened | HTTP | What ClaudeBar does |
 |---|---|---|
 | The user swiped the tile away | 410 | Forget the stored activity id and start a fresh tile, once. A retry loop here is a retry loop against the gateway. |
-| A stored handle is refused | 403 | Forget that one handle, so the next publish creates a replacement for it. The gateway answers a missing token, a wrong token, an unknown id and somebody else's id identically, so a 403 is not evidence the credentials are bad: far more often the user deleted that one tile or widget in the Notify! app. The other surface's handle is left alone, because clearing it would abandon something alive and put a duplicate beside it. |
-| Push to start backoff | 429 | Suppress tile writes until the gateway's own wait has passed. Every attempt inside the wait lengthens it. The widget keeps publishing. |
+| A stored handle is refused | 403 | Forget that one handle, so the next publish creates a replacement for it. The gateway answers a missing token, a wrong token, an unknown id and somebody else's id identically, so a 403 is not evidence the credentials are bad: far more often the user deleted that one tile or widget in the Notify! app. The other surfaces' handles are left alone, because clearing one would abandon something alive and put a duplicate beside it. |
+| Push to start backoff | 429 | Suppress tile writes until the gateway's own wait has passed. Every attempt inside the wait lengthens it. Both widgets keep publishing. |
 | The phone has never opened Notify! | 409 | Report it and stop. No Live Activity can start until the device has a push-to-start credential, which only opening the app once produces. |
 | Apple never answered a start | 502 `unknown` | Keep the activity id the gateway returned and update it on the next tick. Starting again could leave two tiles. |
 | Apple refused a start | 502 `not-delivered` | Wait. No tile exists, so starting again is safe, but every unanswered start counts toward the same ladder as a 429, so the gateway's own `retryAfterSeconds` is honored and 30 minutes assumed when it names none. |
+| Home Screen widgets are not being served | 503 | Pause that one surface for six hours and say so at info level, not as an error. This is the gateway's own kill switch rather than anything wrong here, and nothing on this Mac moves it, so asking again every minute would be a poll against a decision that has not changed. The other two surfaces are untouched. |
 
-Some failures are not worth discovering over the wire. A tile or a gauge aimed at a `GRP`, `MC` or `WB` id is refused locally, before a request exists, because the outcome is already known: the tile would come back 400 and the gauge would come back 201 for a row nothing draws. What the user reads is the id's own reason, which names the kind of device they linked and tells them to use the device ID and token from their phone, rather than a status code that reads as ClaudeBar failing at something it should have managed.
+Some failures are not worth discovering over the wire. A Live Activity aimed at a `GRP`, `MC` or `WB` id is refused locally, before a request exists, because the outcome is already known: the gateway answers that start with a 400 saying the device cannot show one. Either widget aimed at a `GRP` id is refused for a different reason, that a group is not a device and owns no widget list to write into. What the user reads in both cases is the id's own reason, which names the kind of device they linked and tells them to use the device ID and token from their phone, rather than a status code that reads as ClaudeBar failing at something it should have managed.
 
-The two surfaces are written independently. A tile the device refuses to start must not cost the user their widget, which polls happily on a phone that cannot start a Live Activity at all.
+The three surfaces are written independently, each addressed by its own stored handle and each failing for its own reasons. A tile the device refuses to start must not cost the user their widgets, which poll happily on a phone that cannot start a Live Activity at all, and a Home Screen route the gateway has not switched on yet must not silence the two surfaces it is already serving.
 
 ### Privacy
 
@@ -89,20 +99,20 @@ The gateway is the prior art, and it was read end to end from its own OpenAPI do
 
 Host `https://push.getnotifyapp.com`. `NotifyGatewayClient`'s initializer takes another only so tests can point it at a stub. These routes declare `security: []`: there is no bearer token, and the per device secret travels in `?token=`.
 
-### The id namespaces, and which of them have a Lock Screen
+### The id namespaces, and which of them have a screen
 
 The id half of those credentials is not one thing. Notify! mints several formats, in namespaces fenced against each other, and they are not interchangeable destinations.
 
-| Id | What it names | Notification | Live Activity | Lock Screen widget |
-|---|---|---|---|---|
-| `GRP` + 5 | A notification group, which fans out to its members | yes | no | no |
-| `MC` + 14 | A push capable Mac listener | yes | no | yes |
-| `WB` + 14 | A web push browser | yes | no | yes |
-| `IO` + 14 | An iPhone or iPad | yes | yes | yes |
-| 8 characters | The legacy app device format: an iPhone or iPad, or an older poll only Mac listener | yes | yes | yes |
-| anything else | A device format newer than this document | yes | yes | yes |
+| Id | What it names | Notification | Live Activity | Lock Screen widget | Home Screen widget |
+|---|---|---|---|---|---|
+| `GRP` + 5 | A notification group, which fans out to its members | yes | no | no | no |
+| `MC` + 14 | A push capable Mac listener | yes | no | yes | yes |
+| `WB` + 14 | A web push browser | yes | no | yes | yes |
+| `IO` + 14 | An iPhone or iPad | yes | yes | yes | yes |
+| 8 characters | The legacy app device format: an iPhone or iPad, or an older poll only Mac listener | yes | yes | yes | yes |
+| anything else | A device format newer than this document | yes | yes | yes | yes |
 
-**The two surfaces are gated differently, and only one of them is gated by the namespace at all.** A Live Activity is refused for a Mac or a browser. A widget is not.
+**The three surfaces are gated differently.** A Live Activity is refused for a Mac and for a browser. Neither widget is, and both still refuse a group, because a group is not a device: it fans a notification out to its members and owns no surface of its own for anything to sit on. So the namespace decides two different things, and only the Live Activity rule turns on which device it is.
 
 Note which way round the Live Activity rule is written. The namespaces that cannot show one are named and everything else is allowed, rather than the reverse, because app device ids are not one fixed shape: the legacy format is 8 characters, `IO` is 16, and more will follow. A list of what may pass would refuse a real phone on the day Notify! mints a format ClaudeBar has never heard of, and a refused phone reads as ClaudeBar being broken rather than as a new namespace.
 
@@ -110,9 +120,9 @@ ClaudeBar drives no notification route, so that column is not something it uses;
 
 The Live Activity restriction is the gateway's own rule. It refuses a start with a **400** on the grounds that the target device cannot show Live Activities at all, naming a Mac of either generation and a web push browser. A group owns no Lock Screen to start anything on either.
 
-The widget is the opposite. The gateway is explicit that widgets carry no device type gate and that legacy, `WB` and `MC` ids can all own one, so which of them actually draws a widget is Notify!'s business rather than a rule for ClaudeBar to invent. Only a group is refused, and only because a group is not a device: it has members, and no widget list of its own for a gauge to sit in.
+Both widgets are the opposite, and identically so. The gateway is explicit that neither route carries a device type gate: legacy, `IO`, `WB` and `MC` ids can all own a Lock Screen widget, and it says the same of Home Screen widgets in so many words. Which of them actually draws one is Notify!'s business rather than a rule for ClaudeBar to invent. Only a group is refused, and only because a group is not a device: it has members, and no widget list of its own for a gauge or a tile to sit in. `NotifyDeviceKind.supportsScreenWidget` is therefore written as `supportsWidget` rather than as a second copy of the same switch, so the two can never drift into disagreeing about one id.
 
-`NotifyDeviceKind` holds the whole rule and everything above it reads the same answer, through `liveActivityUnsupportedReason` and `widgetUnsupportedReason` rather than one shared verdict. `NotifyGatewayClient` refuses a tile for a Mac, a browser or a group, and a gauge only for a group, before a request exists. `NotifyPublishDriver` drops an unavailable surface from a decision rather than writing it once a minute forever. `NotifyPane` disables just the control that cannot work, with the sentence that explains that one, so a Mac user reads that their Live Activity is unavailable and their widget is not.
+`NotifyDeviceKind` holds the whole rule and everything above it reads the same answer, through `liveActivityUnsupportedReason`, `widgetUnsupportedReason` and `screenWidgetUnsupportedReason` rather than one shared verdict. `NotifyGatewayClient` refuses a tile for a Mac, a browser or a group, and either widget only for a group, before a request exists. `NotifyPublishDriver` drops an unavailable surface from a decision rather than writing it once a minute forever. `NotifyPane` disables just the control that cannot work, with the sentence that explains that one, so a Mac user reads that their Live Activity is unavailable and that both their widgets are not.
 
 One thing cannot be decided locally at all. The legacy 8 character format is shared by iPhones and by those older poll only Mac listeners, and nothing in the id separates them, so such an id is allowed through and the gateway has the last word: it answers the old Mac case with that same 400. An `IO` id carries no such ambiguity. A well formed id belonging to none of the namespaces above is allowed through for the same reason, so a format added after this was written still links; it differs from a known app device only in what the pane calls it, since claiming an unknown id is an iPhone would be a guess. Note too that `GRP` plus 5 is itself eight characters, so the two grammars genuinely overlap and the prefix is tested first, which is the gateway's own tie break: anything beginning with `GRP` goes to the group fan out and everything else is treated as a device.
 
@@ -122,7 +132,7 @@ One thing cannot be decided locally at all. The legacy 8 character format is sha
 
 Saying nothing is load bearing in a second way, and it cuts both ways. Updates are JSON merge-patch: an absent field is left alone, a value replaces, an explicit `null` deletes. So `NotifyGatewayClient` deliberately never mentions `status`, `endsIn`, `steps`, `step` or `button`, and a ClaudeBar update can share a tile with whatever else the user configured.
 
-The same rule makes silence dangerous for the fields ClaudeBar does drive. Omitting one it previously set does not clear it, it freezes it. A reset countdown would keep ticking beside a quota that no longer reports one, and a gauge would keep the last percentage after the shown reading became a credit balance with no percentage at all. Those two are not hypothetical: `trailing` is nil whenever the headline quota has no `resetsAt`, and `unit` and `progress` are both nil for a dollar based quota. So every field ClaudeBar owns is stated on every write, as an explicit `null` when it has no value. The widget is where this matters most, since it lives under its `WG…` id until the user removes it, while a tile is short lived and gets restarted anyway. `title` is the one exception: the gateway treats it as an identity and refuses to clear it.
+The same rule makes silence dangerous for the fields ClaudeBar does drive. Omitting one it previously set does not clear it, it freezes it. A reset countdown would keep ticking beside a quota that no longer reports one, and a gauge would keep the last percentage after the shown reading became a credit balance with no percentage at all. Those two are not hypothetical: `trailing` is nil whenever the headline quota has no `resetsAt`, and `unit` and `progress` are both nil for a dollar based quota. So every field ClaudeBar owns is stated on every write, as an explicit `null` when it has no value. The widgets are where this matters most, since each lives under its `WG…` or `SW…` id until the user removes it, while a Live Activity is short lived and gets restarted anyway. `title` is the one exception: the gateway treats it as an identity and refuses to clear it.
 
 `POST /live-activity/{id}?token=`
 
@@ -150,32 +160,43 @@ The same rule makes silence dangerous for the fields ClaudeBar does drive. Omitt
 | `tint` | string | hex | Accent color. |
 | `progress` | number | 0 to 100 | The gauge: a bar on the rectangular widget, a ring on the circular one. |
 
-Combined tile content must serialize under 2048 bytes and widget content under 1024. `NotifyLimits` enforces every length above at construction, shortening rather than failing, because a quota label that happens to be long should shorten, never fail to reach the phone.
+`POST /screenwidgets/{id}?token=`
+
+No third table, because there is nothing new to put in one. This route's content contract is derived from the Live Activity's, field for field, cap for cap and merge rule for merge rule, down to the wording of its 400s, so the tile table above describes it exactly and `NotifyGatewayClient` sends it through the same `tileBody`. What differs on the wire is the path and the id namespace: `SW` plus six characters, alongside `LA` and `WG`. A create addresses the device id, carries `"new": true` for the same never-hijack reason as the other two, and answers **201**; an update addresses the `SW…` handle and answers **200**. Both come back with the stored content, the handle, and `staleAt`.
+
+Combined tile content must serialize under 2048 bytes, Lock Screen widget content under 1024, and Home Screen widget content under 2048: it inherits the tile's cap along with the tile's contract. `NotifyLimits` enforces every length above at construction, shortening rather than failing, because a quota label that happens to be long should shorten, never fail to reach the phone.
+
+Two statuses mean something on `/screenwidgets` that they mean nowhere else in this client, so `publishScreenTile` translates them where that difference is known rather than inside the shared mapping every other route would then have to reason about.
+
+- **503** is the server side kill switch, and no other route has one. Home Screen widgets ship behind it, so creates and updates can be refused while reads and deletes stay deliberately open and an already placed tile keeps rendering. It means the feature is not being served yet, not that anything is wrong with ClaudeBar, the credentials or the content, so it becomes `surfaceSwitchedOff`, which is retryable and whose sentence says ClaudeBar will try again later.
+- **409** here means the device dialect found several screen widgets and cannot say which was meant. The shared mapping reads a 409 as `liveActivityUnavailable`, because that is what it means on the route it was written for, and sending somebody to open the Notify! app about their Live Activities would be a wrong answer to a question about a Home Screen widget. ClaudeBar creates its own with `new` and addresses it by `SW…` id afterwards, so it should never meet this at all.
 
 ### Two dialects, and why ClaudeBar only uses one of them
 
-Both write routes take either a **device id** or a **handle**, and the handler decides by looking the id up rather than by its shape.
+All three write routes take either a **device id** or a **handle**, and the handler decides by looking the id up rather than by its shape. That last part is not pedantry: a legacy device id is eight arbitrary alphanumerics, so one can perfectly well begin with `SW`, and a gateway that read the prefix would send that device's write to somebody's widget.
 
 - Device id, the *upsert* dialect: the first call starts the device's single live tile and later calls update it in place.
-- `LA######` / `WG######`, the *precise* dialect: always that exact tile or widget.
+- `LA######` / `WG######` / `SW######`, the *precise* dialect: always that exact tile or widget.
 
-The upsert dialect is the shorter code and it is wrong here. A user who has a Notify! tile running from some other script of their own would find ClaudeBar had taken it over, silently, with a quota. So ClaudeBar always creates its own: the first write carries `"new": true` against the device id, the returned `LA…` or `WG…` handle is persisted to `notify.activityId` / `notify.widgetId`, and every write after that addresses the handle. `new` never appears on an update, where it would leave the device with two tiles.
+The upsert dialect is the shorter code and it is wrong here. A user who has a Notify! tile running from some other script of their own would find ClaudeBar had taken it over, silently, with a quota. So ClaudeBar always creates its own: the first write carries `"new": true` against the device id, the returned `LA…`, `WG…` or `SW…` handle is persisted to `notify.activityId` / `notify.widgetId` / `notify.screenWidgetId`, and every write after that addresses the handle. `new` never appears on an update, where it would leave the device with two tiles.
 
 `new=1` earns its keep twice over: it is also the gateway's documented override for the sticky-dismissal 410, which is what lets a tile the user swiped away be replaced.
 
-### The reapers
+### The reapers, and the freshness deadline
 
-Three server side rules end a tile without being asked, and only the first one matters to a quota display:
+Three server side rules end a Live Activity without being asked, and only the first one matters to a quota display:
 
 - a progress-only tile with no update for **2 hours** is ended as `abandoned`
 - a countdown that passes its finish by 30 minutes with no end call is ended as `overdue`
 - a tile still live 9 hours after starting is `expired` (Apple's own ceiling is 8)
 
-The first is the entire reason `NotifyPublishGate` has a keep alive.
+A Home Screen widget is never ended, because there is nothing there to end: `end` and `keepFor` are accepted on that route and silently ignored rather than refused. What it has instead is `staleAt`, epoch seconds returned with every write and computed from that write, never from a read. It falls **two hours** after the write, or five minutes past a countdown's promised finish when the body carried one, which ClaudeBar's never does. Past it the phone dims the tile and says how long ago it was current rather than presenting old numbers as live. That is the honest failure for a surface that stays put: a publisher that stops writing leaves a tile that visibly stops being current instead of one that lies. So a Home Screen tile has to be rewritten inside two hours.
+
+Two deadlines, both two hours, both measured from the last write, and one heartbeat clears both. That is the entire reason `NotifyPublishGate` has a keep alive, and the reason the Home Screen tile takes it as well as its own fifteen minute interval while the gauge takes only its interval.
 
 ### The one call that is rate limited
 
-`GET /link?id=&token=` validates a pair and describes the device it names, and the gateway allows **five calls a minute per IP**. It belongs behind an explicit "Verify Device" button and nothing else. Nothing on a timer may call it. It also has an error envelope of its own and answers **404**, not the 403 every other route uses, for a pair it does not recognise, giving that same 404 for a wrong token and for an id that does not exist so it cannot be used to enumerate ids. `NotifyGatewayClient` translates it to rejected credentials, because to the person who has just pasted their link it is the same problem. It also answers for groups, and a group carries neither surface, so `NotifyGatewayClient` rejects `type: "group"` there rather than letting it fail later with a puzzling 400.
+`GET /link?id=&token=` validates a pair and describes the device it names, and the gateway allows **five calls a minute per IP**. It belongs behind an explicit "Verify Device" button and nothing else. Nothing on a timer may call it. It also has an error envelope of its own and answers **404**, not the 403 every other route uses, for a pair it does not recognise, giving that same 404 for a wrong token and for an id that does not exist so it cannot be used to enumerate ids. `NotifyGatewayClient` translates it to rejected credentials, because to the person who has just pasted their link it is the same problem. It also answers for groups, and a group carries none of the three surfaces, so `NotifyGatewayClient` rejects `type: "group"` there rather than letting it fail later with a puzzling 400.
 
 ### In-repo precedent
 
@@ -191,10 +212,10 @@ Notify! is a **destination**, not a provider. `QuotaMonitor` remains the single 
 Sources/Domain/Notify/
 ├── NotifyLimits.swift              # the gateway's field limits, enforced at construction
 ├── NotifyDeviceLink.swift          # device id + token; NotifyDeviceKind; NotifyDeviceInfo
-├── NotifyTile.swift                # NotifyMetric, NotifyTile: the Live Activity's content
-├── NotifyGauge.swift               # the widget's content; progress is the gauge
+├── NotifyTile.swift                # NotifyMetric, NotifyTile: the content both tiles carry
+├── NotifyGauge.swift               # the Lock Screen widget's content; progress is the gauge
 ├── NotifyPayload.swift             # NotifyQuotaReading, NotifyGaugeSelection, NotifyPayload
-├── NotifyPayloadBuilder.swift      # readings to tile + gauge; pure, the whole decision layer
+├── NotifyPayloadBuilder.swift      # readings to one tile + a gauge; pure, the whole decision layer
 ├── NotifyPublishGate.swift         # whether a payload is worth a request; pure, clock free
 ├── NotifyPublishError.swift        # every way a publish fails, and the remedy each implies
 ├── NotifyPublishing.swift          # @Mockable protocol; the App layer's only view of the API
@@ -227,14 +248,15 @@ Settings keys, all under `notify.*` in `~/.claudebar/settings.json`:
 | `notify.deviceId` | The linked device id. |
 | `notify.liveActivityEnabled` | Whether the tile is published. Default `true`. |
 | `notify.widgetEnabled` | Whether the gauge is published. Default `true`. |
+| `notify.screenWidgetEnabled` | Whether the Home Screen tile is published. Default `true`, because a 503 is handled as "not yet" rather than as an error, and shipping it off would mean nobody saw the surface on the day Notify! switched it on. |
 | `notify.gauge.providerId`, `notify.gauge.quotaKey` | Which quota the gauge shows. Both empty means automatic. |
-| `notify.activityId`, `notify.widgetId` | The handles of the tile and widget ClaudeBar created. |
+| `notify.activityId`, `notify.widgetId`, `notify.screenWidgetId` | The handles of the Live Activity, the Lock Screen widget and the Home Screen widget ClaudeBar created. |
 
 The device token is the exception and never appears here. It goes to the secure credential store under `CredentialKey.notifyDeviceToken`.
 
 ### The testable core
 
-Everything that decides anything is a pure value type in Domain, with no clock, no network and no settings lookups of its own. `NotifyPayloadBuilder` takes readings and a selection and returns a payload; `NotifyPublishGate` takes a payload, the last record and a `now` and returns two booleans; `NotifyDeviceLink` and `NotifyLimits` are parsers. `NotifyGatewayClient.failure(status:data:retryAfterHeader:)` is static and takes the raw body, so every status code can be driven through it without a network stub.
+Everything that decides anything is a pure value type in Domain, with no clock, no network and no settings lookups of its own. `NotifyPayloadBuilder` takes readings and a selection and returns a payload; `NotifyPublishGate` takes a payload, the last record and a `now` and returns one boolean per surface; `NotifyDeviceLink` and `NotifyLimits` are parsers. `NotifyGatewayClient.failure(status:data:retryAfterHeader:)` is static and takes the raw body, so every status code can be driven through it without a network stub.
 
 `NotifyPublishDriver` is deliberately free of judgement, because there is no App test target: anything decided there would be decided untested. It gathers state, asks the builder and the gate, and performs the I/O the answer implies.
 
@@ -247,20 +269,27 @@ Rules under test, no mocks required:
 - a percentage is remaining: a 42% quota publishes `progress: 42`, never 58
 - a money based quota publishes its formatted balance with no unit, and the tile's bar falls through to the worst quota that has a percentage
 - a gauge selection naming a window that has stopped reporting falls back to the worst quota rather than publishing nothing
+- the Live Activity and the Home Screen tile are one built value, so a payload with both surfaces on carries the identical tile twice and the two can never disagree about the same quota
 - the gate holds a changed tile back inside its minimum interval, and releases it once the interval has passed
 - the gate republishes an unchanged tile after the keep alive interval, and only then
+- the Home Screen tile has its own fifteen minute interval and takes the keep alive too, so an unchanged one is still rewritten before its two hour freshness deadline; the gauge has the interval and no keep alive
+- the record merges the three surfaces one at a time, so a surface the gate held back still remembers what it is actually showing rather than being filed as having sent the payload that was built
 - the gate never writes a surface the payload left nil, because nil means the user switched that surface off
 - the two fields the pane asks for, a bare `id token` pair, and a whole pasted notification URL all yield the same link
 - a token the Keychain refuses is still stored, still round trips, is reported as not secure, and still never reaches `settings.json`
 - an id outside 8 to 32 alphanumeric characters is refused locally, before any request exists
 - `GRP` plus 5 reads as a group, `WB` plus 14 as a browser, `MC` plus 14 as a Mac, `IO` plus 14 and a bare 8 characters as an app device, with the group prefix winning the overlap at eight characters
-- an id in none of those namespaces, of any length, carries both surfaces, because the rule names what cannot publish rather than what may
-- a Mac and a browser can keep a widget and cannot show a Live Activity, a group can do neither, and an app device and an id from a namespace that does not exist yet can do both
+- an id in none of those namespaces, of any length, carries all three surfaces, because the rule names what cannot publish rather than what may
+- a Mac and a browser can keep both widgets and cannot show a Live Activity, a group can keep none of the three, and an app device and an id from a namespace that does not exist yet can do everything
+- the two widgets always answer alike for the same id, because the Home Screen rule is the Lock Screen rule rather than a copy of it
 - each reason is present exactly when its own surface is unavailable, so no working control is explained away and no dead one is left unaccounted for
-- a tile and a gauge aimed at any of those three fail before a request exists, each with the sentence that names what to paste instead
+- a Live Activity aimed at a Mac, a browser or a group fails before a request exists, and so does either widget aimed at a group, each with the sentence that names what to paste instead
 - an over-long label shortens; an empty one is refused; a tint that is not 6 or 8 hex digits is dropped rather than failing the publish
 - a percentage outside 0 to 100 clamps, because a quota can legitimately report a negative remainder
 - each status maps to the one error whose remedy differs: 403 to rejected credentials, 409 to unavailable, 410 to tile gone, 429 to backoff, 502 with `deliveryState: "unknown"` to delivery unconfirmed, and 502 with `not-delivered` to a wait
+- a 503 on the Home Screen route is a switched-off surface rather than a failure: retryable, and carrying its own "ClaudeBar will try again later" sentence when the gateway named none
+- a 409 on the Home Screen route is a rejected payload rather than a Live Activity waiting on the app being opened, because the shared mapping's reading of a 409 belongs to the route it was written for
+- the Home Screen write sends the same content body as the Live Activity write, since both go through the one `tileBody`
 - every field ClaudeBar drives is present in the body on every write, as an explicit null when it has no value, while the fields it never drives stay unmentioned
 - a 429's wait comes from the body's own seconds first, the `Retry-After` header second, and 30 minutes (the ladder's first rung) when neither is present
 
@@ -274,7 +303,7 @@ Rules under test, no mocks required:
 
 **Phase 3, the cadence.** `NotifyPublishGate` and `NotifyPublishDriver`: dedupe, minimum intervals, keep alive, and every recovery path in the table above. This is where the feature stops being a demo and starts being something that can be left on for a week.
 
-Ships behind `notify.enabled`, default off, in Settings under its own Notify! pane. The pane is where the device is linked, either surface is switched off, the gauge's quota is chosen, and a publish can be forced. It posts `.notifySettingsChanged` on save, because credentials and the surface handles live outside observable state and the driver has no other way to notice them.
+Ships behind `notify.enabled`, default off, in Settings under its own Notify! pane. The pane is where the device is linked, any of the three surfaces is switched off, the gauge's quota is chosen, and a publish can be forced. It posts `.notifySettingsChanged` on save, because credentials and the surface handles live outside observable state and the driver has no other way to notice them.
 
 ## Considered and rejected
 


### PR DESCRIPTION
Adds the Home Screen widget surface that arrived in Notify!'s September 2026 update, and carries the review follow-ups from #284 that were still outstanding when it merged.

## One body, two surfaces

A screen widget is a Home Screen tile (small, medium or large) that stays. Where a Live Activity appears when something starts and disappears when it ends, a screen widget always shows the latest thing stored.

Its content set **is** the Live Activity set. The gateway derives both contracts from the same module, so the body ClaudeBar already builds for the tile is a valid screen widget body, unchanged. That is the whole reason this is a small change here:

- `NotifyPayloadBuilder` builds one `NotifyTile` and the payload carries it under both `tile` and `screenTile`. Separate properties because the two surfaces are switched on and off independently and published on different clocks, one shared value because two builders could only drift.
- `NotifyGatewayClient` posts the same `tileBody(_:)` to both routes.

A test pins that premise rather than restating it: publish one tile to each route, capture both requests, and compare the JSON bodies once the create-only `new` flag is removed.

## Cadence

The screen tile gets its own 15 minute interval, matching how often the phone polls, and it takes the keep alive.

The keep alive matters more here than anywhere else. A screen widget carries a `staleAt`, two hours after the last write, past which the phone dims the tile and reports how long ago it was current rather than presenting old data as live. The existing 90 minute keep alive already clears that and the Live Activity's two hour abandonment reaper both, so no new timer was needed.

## Two statuses that mean something new

Translated in `publishScreenTile` rather than in the shared status mapping, so no other route has to reason about them:

- **503** is the server side kill switch: Home Screen widgets are not being served yet. Nothing is wrong with ClaudeBar, the credentials or the content, and nothing this app does moves that switch. It is logged at info rather than error, reported to the user as a wait, and backed off for six hours rather than retried every tick. Reads and deletes are deliberately not gated server side, so a tile already placed keeps rendering.
- **409** is device dialect ambiguity. ClaudeBar always creates its own with `new=1`, so it should be unreachable, but it maps to `invalidPayload` rather than claiming a Live Activity problem.

## Device support

This route has no device-type gate, so only a group is refused, being a fan-out target with no widget list of its own. A Mac, a browser and a phone can all keep one. Only the iOS app renders them, and the tile is placed through iOS's own widget picker under Settings then Home Screen Widgets in Notify!.

The surface is on by default. A 503 is handled as "not yet" rather than as an error, and defaulting it off would mean nobody sees it on the day it is switched on.

## Also in here: the #284 review follow-ups

That PR merged before its review was addressed, so these are live on main today:

- A publish record merges per surface instead of storing the payload wholesale. A tile-only publish used to file an unsent gauge as delivered, so when the gauge's own interval came round the gate saw no change and the phone kept a stale value.
- Reading order is total. It tied on provider name then quota key, neither of which is unique when one provider reports two accounts under one name, and Swift's sort is not stable, so identical state could build a different payload and republish for nothing.
- A returned handle is stored only while it still belongs to the saved link, and saving a link clears the previous device's handles.
- Transport failures log an error domain and code rather than a localized description.

## Credentials

The last point above is now a rule the whole feature follows, after a pass over every path a secret could take. Every URL here carries the device token in its query string, and an error description is free to quote the URL it failed on, so nothing outside this app's own vocabulary reaches the log file on disk: an unknown error logs its type, a transport failure logs no text at all, and no URL is ever logged or put in a thrown message. Both still reach the settings pane, which is not written to disk.

The device token itself goes to the Keychain, never to `settings.json`. The device ID appears only at debug level, which is OSLog and never the log file.

## Testing

`tuist test` passes: 1308 tests, 13 of them new.

Beyond the shared-body test above: the create and update dialects, the 503 and 409 translations, the group refusal and the Mac and browser acceptance, the settings round trip, the gate's interval and keep alive for the new surface, and that a screen-tile-only publish leaves the other two surfaces' recorded content alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notify! now supports Home Screen widgets alongside Lock Screen widgets and Live Activities.
  * Home Screen widgets show the same quota details as Live Activities, including progress and reset countdowns.
  * Added independent controls for each Notify! surface, with Home Screen widgets configured through iOS’s widget picker.
  * Home Screen widgets refresh independently and can be paused and retried when temporarily unavailable.
  * Mac and browser links support widgets; group links do not support these surfaces.

* **Documentation**
  * Updated setup guidance and feature descriptions for all Notify! surfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->