### PR TITLE
fix(kimi): support kimi CLI 0.36+ /usage output format

### DIFF
--- a/Sources/Infrastructure/Kimi/KimiCLIUsageProbe.swift
+++ b/Sources/Infrastructure/Kimi/KimiCLIUsageProbe.swift
@@ -204,6 +204,14 @@ public struct KimiCLIUsageProbe: UsageProbe {
             }
         }
 
+        // Extract seconds
+        if let secMatch = text.range(of: #"(\d+)\s*s"#, options: .regularExpression) {
+            let secStr = String(text[secMatch])
+            if let seconds = Int(secStr.filter { $0.isNumber }) {
+                totalSeconds += Double(seconds)
+            }
+        }
+
         guard totalSeconds > 0 else { return nil }
         return Date().addingTimeInterval(totalSeconds)
     }

--- a/Sources/Infrastructure/Kimi/KimiCLIUsageProbe.swift
+++ b/Sources/Infrastructure/Kimi/KimiCLIUsageProbe.swift
@@ -4,12 +4,20 @@ import Domain
 /// Infrastructure adapter that probes the Kimi CLI to fetch usage quotas.
 /// Starts the interactive `kimi` CLI, sends `/usage`, and parses the output.
 ///
-/// Sample CLI output:
+/// Sample CLI output (kimi CLI < 0.36):
 /// ```
 /// ╭─────────────────────────────── API Usage ───────────────────────────────╮
 /// │  Weekly limit  ━━━━━━━━━━━━━━━━━━━━  100% left  (resets in 6d 23h 22m)  │
 /// │  5h limit      ━━━━━━━━━━━━━━━━━━━━  100% left  (resets in 4h 22m)      │
 /// ╰─────────────────────────────────────────────────────────────────────────╯
+/// ```
+///
+/// Sample CLI output (kimi CLI >= 0.36):
+/// ```
+///   ╭ Usage ───────────────────────────────────────────────────────────╮
+///   │   Weekly limit  ██████████████████░░  90% used  resets in 35m    │
+///   │   5h limit      ██░░░░░░░░░░░░░░░░░░  12% used  resets in 3h 35m │
+///   ╰──────────────────────────────────────────────────────────────────╯
 /// ```
 public struct KimiCLIUsageProbe: UsageProbe {
     private let kimiBinary: String
@@ -50,7 +58,11 @@ public struct KimiCLIUsageProbe: UsageProbe {
                 timeout: timeout,
                 workingDirectory: nil,
                 autoResponses: [
+                    // kimi CLI < 0.36 shows a 💫 prompt when ready for input.
                     "💫": "/usage\r",
+                    // kimi CLI >= 0.36 dropped the 💫 prompt; its status footer
+                    // ("context: N% ...") signals the TUI is ready instead.
+                    "context:": "/usage\r",
                 ]
             )
         } catch {
@@ -74,23 +86,21 @@ public struct KimiCLIUsageProbe: UsageProbe {
 
     /// Parses the Kimi CLI `/usage` output into a UsageSnapshot.
     ///
-    /// Looks for lines containing known quota labels ("Weekly limit", "5h limit")
-    /// with `N% left` and `(resets in ...)`. Strips ANSI escape codes first
-    /// so colored progress bars in release builds don't interfere.
+    /// Looks for lines containing known quota labels ("Weekly limit", "5h limit").
+    /// Two output formats are supported:
+    /// - kimi CLI < 0.36: `N% left  (resets in ...)`
+    /// - kimi CLI >= 0.36: `N% used  resets in ...` (remaining = 100 - used)
     ///
     /// Expected format per quota line (with or without progress bars):
     /// ```
     /// Weekly limit  ━━━━━━━━━━━━━━━━━━━━  100% left  (resets in 6d 23h 22m)
-    /// 5h limit                            75% left   (resets in 4h 22m)
+    /// Weekly limit  ██████████████████░░   90% used  resets in 35m
     /// ```
     public static func parse(_ text: String) throws -> UsageSnapshot {
         var quotas: [UsageQuota] = []
 
         for line in text.components(separatedBy: .newlines) {
             let lower = line.lowercased()
-
-            // Only process lines that contain "% left"
-            guard lower.contains("% left") else { continue }
 
             // Determine quota type from known labels
             let quotaType: QuotaType
@@ -102,22 +112,46 @@ public struct KimiCLIUsageProbe: UsageProbe {
                 continue
             }
 
-            // Extract percent: look for "N% left"
-            guard let percentMatch = line.range(of: #"(\d+)%\s+left"#, options: .regularExpression),
-                  let percent = Double(line[percentMatch].prefix(while: { $0.isNumber })) else {
+            // The TUI redraws the panel on resize/refresh; keep the first occurrence.
+            if quotas.contains(where: { $0.quotaType == quotaType }) { continue }
+
+            // Extract percent and reset text from either output format.
+            let percent: Double
+            var resetRaw: String?
+            if lower.contains("% left") {
+                // kimi CLI < 0.36: "100% left  (resets in 6d 23h 22m)"
+                guard let percentMatch = line.range(of: #"(\d+)%\s+left"#, options: .regularExpression),
+                      let remaining = Double(line[percentMatch].prefix(while: { $0.isNumber })) else {
+                    continue
+                }
+                percent = remaining
+                if let resetMatch = lower.range(of: #"\(resets\s+in\s+(.+?)\)"#, options: .regularExpression) {
+                    resetRaw = String(lower[resetMatch])
+                        .replacingOccurrences(of: "(resets in ", with: "")
+                        .replacingOccurrences(of: ")", with: "")
+                        .trimmingCharacters(in: .whitespaces)
+                }
+            } else if lower.contains("% used") {
+                // kimi CLI >= 0.36: "90% used  resets in 35m"
+                guard let percentMatch = line.range(of: #"(\d+)\s*%\s*used"#, options: .regularExpression),
+                      let used = Double(line[percentMatch].prefix(while: { $0.isNumber })) else {
+                    continue
+                }
+                percent = max(0, 100 - used)
+                if let resetMatch = lower.range(of: #"resets\s+in\s+[0-9dhms ]+"#, options: .regularExpression) {
+                    resetRaw = String(lower[resetMatch])
+                        .replacingOccurrences(of: #"^resets\s+in\s+"#, with: "", options: .regularExpression)
+                        .trimmingCharacters(in: .whitespaces)
+                }
+            } else {
                 continue
             }
 
-            // Extract reset text: look for "(resets in ...)"
             var resetText: String?
             var resetsAt: Date?
-            if let resetMatch = line.range(of: #"\(resets\s+in\s+(.+?)\)"#, options: .regularExpression) {
-                let raw = String(line[resetMatch])
-                    .replacingOccurrences(of: "(resets in ", with: "")
-                    .replacingOccurrences(of: ")", with: "")
-                    .trimmingCharacters(in: .whitespaces)
-                resetText = "Resets in \(raw)"
-                resetsAt = parseResetDuration(raw)
+            if let resetRaw, !resetRaw.isEmpty {
+                resetText = "Resets in \(resetRaw)"
+                resetsAt = parseResetDuration(resetRaw)
             }
 
             quotas.append(UsageQuota(

--- a/Tests/InfrastructureTests/Kimi/KimiCLIUsageProbeParsingTests.swift
+++ b/Tests/InfrastructureTests/Kimi/KimiCLIUsageProbeParsingTests.swift
@@ -36,6 +36,22 @@ struct KimiCLIUsageProbeParsingTests {
     ╰─────────────────────────────────────────────────────────────────────────╯
     """
 
+    /// kimi CLI >= 0.36 reports "% used" without parentheses around the reset text
+    private static let usedFormatOutput = """
+      ╭ Usage ───────────────────────────────────────────────────────────╮
+      │   Weekly limit  ██████████████████░░  90% used  resets in 35m    │
+      │   5h limit      ██░░░░░░░░░░░░░░░░░░  12% used  resets in 3h 35m │
+      ╰──────────────────────────────────────────────────────────────────╯
+    """
+
+    /// The TUI redraws the usage panel, emitting each quota line more than once
+    private static let redrawnOutput = """
+    │   Weekly limit  ██████████████████░░  90% used  resets in 35m    │
+    │   5h limit      ██░░░░░░░░░░░░░░░░░░  12% used  resets in 3h 35m │
+    │   Weekly limit  ██████████████████░░  90% used  resets in 35m    │
+    │   5h limit      ██░░░░░░░░░░░░░░░░░░  12% used  resets in 3h 35m │
+    """
+
     // MARK: - Full Output Parsing
 
     @Test
@@ -104,6 +120,61 @@ struct KimiCLIUsageProbeParsingTests {
         #expect(snapshot.quotas.count == 2)
         #expect(snapshot.quota(for: .weekly)?.percentRemaining == 100.0)
         #expect(snapshot.quota(for: .session)?.percentRemaining == 100.0)
+    }
+
+    // MARK: - Used Format (kimi CLI >= 0.36)
+
+    @Test
+    func `parse used format converts used percent to remaining`() throws {
+        let snapshot = try KimiCLIUsageProbe.parse(Self.usedFormatOutput)
+
+        #expect(snapshot.quotas.count == 2)
+        #expect(snapshot.quota(for: .weekly)?.percentRemaining == 10.0)
+        #expect(snapshot.quota(for: .session)?.percentRemaining == 88.0)
+    }
+
+    @Test
+    func `parse used format extracts reset text without parentheses`() throws {
+        let snapshot = try KimiCLIUsageProbe.parse(Self.usedFormatOutput)
+
+        #expect(snapshot.quota(for: .weekly)?.resetText == "Resets in 35m")
+        #expect(snapshot.quota(for: .session)?.resetText == "Resets in 3h 35m")
+    }
+
+    @Test
+    func `parse used format extracts session reset date`() throws {
+        let now = Date()
+        let snapshot = try KimiCLIUsageProbe.parse(Self.usedFormatOutput)
+        let session = snapshot.quota(for: .session)
+
+        #expect(session?.resetsAt != nil)
+        if let resetsAt = session?.resetsAt {
+            let diff = resetsAt.timeIntervalSince(now)
+            // 3h 35m = 12900s — allow 60s tolerance
+            #expect(diff > 12840)
+            #expect(diff < 12960)
+        }
+    }
+
+    @Test
+    func `parse used format at 100 percent used reports zero remaining`() throws {
+        let depleted = """
+        │   Weekly limit  ████████████████████  100% used  resets in 35m    │
+        """
+        let snapshot = try KimiCLIUsageProbe.parse(depleted)
+
+        #expect(snapshot.quota(for: .weekly)?.percentRemaining == 0.0)
+    }
+
+    // MARK: - Redrawn Panels
+
+    @Test
+    func `parse redrawn output keeps first occurrence of each quota`() throws {
+        let snapshot = try KimiCLIUsageProbe.parse(Self.redrawnOutput)
+
+        #expect(snapshot.quotas.count == 2)
+        #expect(snapshot.quota(for: .weekly)?.percentRemaining == 10.0)
+        #expect(snapshot.quota(for: .session)?.percentRemaining == 88.0)
     }
 
     // MARK: - Reset Time Parsing

--- a/Tests/InfrastructureTests/Kimi/KimiCLIUsageProbeParsingTests.swift
+++ b/Tests/InfrastructureTests/Kimi/KimiCLIUsageProbeParsingTests.swift
@@ -258,6 +258,31 @@ struct KimiCLIUsageProbeParsingTests {
     }
 
     @Test
+    func `parseResetDuration handles seconds only`() {
+        let now = Date()
+        let date = KimiCLIUsageProbe.parseResetDuration("45s")
+
+        #expect(date != nil)
+        if let date {
+            let diff = date.timeIntervalSince(now)
+            #expect(abs(diff - 45) < 2)
+        }
+    }
+
+    @Test
+    func `parse used format with seconds reset sets resetsAt`() throws {
+        let secondsReset = """
+        │   5h limit      ██░░░░░░░░░░░░░░░░░░  12% used  resets in 45s │
+        """
+        let snapshot = try KimiCLIUsageProbe.parse(secondsReset)
+        let session = snapshot.quota(for: .session)
+
+        #expect(session?.percentRemaining == 88.0)
+        #expect(session?.resetText == "Resets in 45s")
+        #expect(session?.resetsAt != nil)
+    }
+
+    @Test
     func `parseResetDuration returns nil for empty string`() {
         let date = KimiCLIUsageProbe.parseResetDuration("")
         #expect(date == nil)


### PR DESCRIPTION
## Problem

kimi CLI 0.36 changed its interactive TUI, breaking the CLI probe — Kimi shows **Kimi Unavailable: Failed to parse output: No quota data found in Kimi CLI output**.

Two breaking changes in the CLI:

1. **The 💫 prompt marker is gone.** The probe waits for 💫 before typing `/usage`, so the command is never sent. kimi CLI >= 0.36 shows a status footer (`context: N% ...`) when the TUI is ready instead.
2. **The /usage panel format changed.** Quota lines used to be `100% left  (resets in 6d 23h 22m)`; they are now `90% used  resets in 35m` (used instead of left, no parentheses), so `parse` finds no `% left` lines.

Captured from kimi CLI 0.36.1 / 0.41.0:

```
  ╭ Usage ───────────────────────────────────────────────────────────╮
  │   Weekly limit  ██████████████████░░  90% used  resets in 35m    │
  │   5h limit      ██░░░░░░░░░░░░░░░░░░  12% used  resets in 3h 35m │
  ╰──────────────────────────────────────────────────────────────────╯
```

## Fix

- `autoResponses`: also send `/usage` when the new `context:` footer appears (each trigger fires at most once, so older CLIs are unaffected).
- `parse`: accept both formats. New-format lines convert `used%` → `remaining%` (clamped at 0) and read the parenthesis-free reset text.
- Dedupe quota lines by type: the TUI redraws the panel on refresh/resize, which previously produced duplicate quotas.

## Tests

Added parsing tests covering: `% used` → remaining conversion, parenthesis-free reset text + `resetsAt`, 100% used → 0% left, and redraw dedupe. Verified against real output captured from kimi CLI 0.36.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Kimi CLI usage detection across older and newer output formats.
  - Correctly reports remaining quota when the CLI provides usage percentages.
  - Handles repeated quota displays without duplicating results.
  - Improved reset information parsing, including depleted quotas, alternate reset formats, and durations with seconds.
  - More reliably identifies usage responses from newer CLI versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->